### PR TITLE
Add pre-commit hooks and CLI smoke test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 24.8.0
+  hooks:
+    - id: black
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.8
+  hooks:
+    - id: ruff
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+    - id: mypy
+      additional_dependencies: ["pydantic>=2.0"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ docker compose up -d
 poetry run alembic upgrade head
 ```
 
+## Qualité
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
 ## Endpoints clés
 - `POST /submit`
 - `GET /status/{id}`

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("typer")
+
+SPEC_PATH = Path(__file__).parent / "data" / "spec_example.json"
+PYTHONPATH = str(Path(__file__).resolve().parents[1] / "src")
+
+
+@pytest.mark.skipif(not SPEC_PATH.exists(), reason="spec file missing")
+def test_cli_smoke() -> None:
+    env = {**os.environ, "DB_DSN": "sqlite:///:memory:", "PYTHONPATH": PYTHONPATH}
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_engine.cli.main", "run-local", "--spec", str(SPEC_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "metrics" in result.stdout


### PR DESCRIPTION
## Summary
- configure Black, Ruff, and MyPy via pre-commit
- document local quality checks
- add smoke test for run-local CLI command

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md tests/test_cli_smoke.py` *(fails: command not found)*
- `pytest tests/test_cli_smoke.py -q` *(skipped: typer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f810335c8323954525b9e3ac8a03