### PR TITLE
Add skeleton stats module and API endpoints

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -13,9 +13,11 @@ from ..core.spec import Spec
 from ..optimize.runner import run as run_optimisation
 from ..io import ids
 from ..persistence import db
+from ..stats import runner as stats_runner
 from . import schemas
 
 _jobs: Dict[str, Dict[str, Any]] = {}
+_last_stats: Dict[str, Any] | None = None
 
 
 def submit(spec: Spec) -> schemas.SubmitResponse:
@@ -37,6 +39,24 @@ def result(job_id: str) -> schemas.ResultResponse:
     if not job:
         return schemas.ResultResponse(result=None)
     return schemas.ResultResponse(result=job.get("result"))
+
+
+# ---------------------------------------------------------------------------
+# Statistics endpoints (synchronous MVP)
+
+
+def stats_run(spec: schemas.StatsSpec) -> schemas.StatusResponse:
+    """Execute a statistics run synchronously and store the result."""
+
+    global _last_stats
+    _last_stats = stats_runner.run_stats(spec)
+    return schemas.StatusResponse(status="completed")
+
+
+def stats_result() -> schemas.ResultResponse:
+    """Return the last statistics result if available."""
+
+    return schemas.ResultResponse(result=_last_stats)
 
 
 # ---------------------------------------------------------------------------

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+from ..core.spec import ValidationSpec, ArtifactsSpec, PersistenceSpec
 
 
 @dataclass
@@ -18,4 +22,47 @@ class StatusResponse:
 @dataclass
 class ResultResponse:
     result: Dict[str, Any] | None
+
+
+class StatsDataSpec(BaseModel):
+    """Dataset location and window for statistics runs."""
+
+    dataset_path: str
+    symbols: List[str]
+    timeframe: str
+    start: str
+    end: str
+
+
+class StatsEventSpec(BaseModel):
+    """Specification for an event to detect in the dataset."""
+
+    name: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatsConditionSpec(BaseModel):
+    """Specification for conditioning regime."""
+
+    name: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatsTargetSpec(BaseModel):
+    """Specification for a target metric."""
+
+    name: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StatsSpec(BaseModel):
+    """Top-level specification for a statistics run."""
+
+    data: StatsDataSpec
+    events: List[StatsEventSpec] = Field(default_factory=list)
+    conditions: List[StatsConditionSpec] = Field(default_factory=list)
+    targets: List[StatsTargetSpec] = Field(default_factory=list)
+    validation: ValidationSpec | None = None
+    artifacts: ArtifactsSpec | None = None
+    persistence: PersistenceSpec | None = None
 

--- a/src/quant_engine/core/spec.py
+++ b/src/quant_engine/core/spec.py
@@ -50,6 +50,20 @@ class ValidationSpec:
 
 
 @dataclass
+class ArtifactsSpec:
+    """Persistence configuration for locally written artifacts."""
+
+    out_dir: str | None = None
+
+
+@dataclass
+class PersistenceSpec:
+    """Configuration for optional database persistence."""
+
+    enabled: bool = False
+
+
+@dataclass
 class StrategySpec:
     filters: FiltersSpec
     tpsl: TPSLSpec

--- a/src/quant_engine/stats/__init__.py
+++ b/src/quant_engine/stats/__init__.py
@@ -1,0 +1,6 @@
+"""Statistics module skeleton."""
+
+from .runner import run_stats
+
+__all__ = ["run_stats"]
+

--- a/src/quant_engine/stats/conditions.py
+++ b/src/quant_engine/stats/conditions.py
@@ -1,0 +1,23 @@
+"""Regime condition helpers for statistics runs."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def htf_trend(data: List[Dict[str, Any]], **params: Any) -> List[str]:
+    """Placeholder for higher-time-frame trend regime."""
+
+    return ["flat" for _ in data]
+
+
+def vol_tertile(data: List[Dict[str, Any]], **params: Any) -> List[int]:
+    """Placeholder for volatility tertile regime."""
+
+    return [0 for _ in data]
+
+
+def session(data: List[Dict[str, Any]], **params: Any) -> List[str]:
+    """Placeholder for session labels."""
+
+    return ["" for _ in data]
+

--- a/src/quant_engine/stats/estimators.py
+++ b/src/quant_engine/stats/estimators.py
@@ -1,0 +1,23 @@
+"""Estimator helpers for statistics runs."""
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def phat(successes: int, trials: int) -> float:
+    """Return the empirical success probability."""
+
+    return successes / trials if trials else 0.0
+
+
+def wilson_ci(successes: int, trials: int, z: float = 1.96) -> Tuple[float, float]:
+    """Return a Wilson score confidence interval (placeholder)."""
+
+    return (0.0, 0.0)
+
+
+def baseline(trials: int) -> float:
+    """Return a baseline probability estimate."""
+
+    return 0.0
+

--- a/src/quant_engine/stats/events.py
+++ b/src/quant_engine/stats/events.py
@@ -1,0 +1,23 @@
+"""Event definitions for statistics runs."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def k_consecutive(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
+    """Placeholder for detecting ``k`` consecutive events."""
+
+    return [False for _ in data]
+
+
+def shock_atr(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
+    """Placeholder for ATR shock events."""
+
+    return [False for _ in data]
+
+
+def breakout_hhll(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
+    """Placeholder for breakout of higher high / lower low events."""
+
+    return [False for _ in data]
+

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -1,0 +1,33 @@
+"""Execution utilities for :mod:`quant_engine.stats`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except Exception:  # pragma: no cover
+    pl = None
+
+from ..api.schemas import StatsSpec
+
+
+def run_stats(spec: StatsSpec) -> Dict[str, Any]:
+    """Run a statistics specification.
+
+    The current implementation is a synchronous placeholder that writes an
+    empty ``stats_summary.parquet`` file and returns its path.
+    """
+
+    out_dir = Path(spec.artifacts.out_dir) if spec.artifacts and spec.artifacts.out_dir else Path(".")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / "stats_summary.parquet"
+    if pl is not None:
+        pl.DataFrame().write_parquet(summary_path)
+    else:
+        summary_path.touch()
+    return {"summary_path": str(summary_path)}
+
+
+__all__ = ["run_stats"]
+

--- a/src/quant_engine/stats/targets.py
+++ b/src/quant_engine/stats/targets.py
@@ -1,0 +1,23 @@
+"""Target metrics for statistics runs."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def up_next_bar(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
+    """Placeholder for next bar up move."""
+
+    return [False for _ in data]
+
+
+def continuation_n(data: List[Dict[str, Any]], **params: Any) -> List[int]:
+    """Placeholder for continuation over ``n`` bars."""
+
+    return [0 for _ in data]
+
+
+def time_to_reversal(data: List[Dict[str, Any]], **params: Any) -> List[int]:
+    """Placeholder for time until reversal."""
+
+    return [0 for _ in data]
+


### PR DESCRIPTION
## Summary
- define pydantic StatsSpec and related models
- add skeleton stats package with runner and stubs
- expose synchronous stats_run and stats_result endpoints

## Testing
- `pytest`
- `pre-commit run --files src/quant_engine/api/app.py src/quant_engine/api/schemas.py src/quant_engine/core/spec.py src/quant_engine/stats/__init__.py src/quant_engine/stats/events.py src/quant_engine/stats/conditions.py src/quant_engine/stats/targets.py src/quant_engine/stats/estimators.py src/quant_engine/stats/runner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72f0810788323ab32a07705ea67cd