### PR TITLE
Implement basic stats features and runner

### DIFF
--- a/src/quant_engine/stats/conditions.py
+++ b/src/quant_engine/stats/conditions.py
@@ -1,23 +1,46 @@
 """Regime condition helpers for statistics runs."""
 from __future__ import annotations
 
-from typing import Any, Dict, List
+import numpy as np
+import pandas as pd
 
 
-def htf_trend(data: List[Dict[str, Any]], **params: Any) -> List[str]:
-    """Placeholder for higher-time-frame trend regime."""
+def htf_trend(df: pd.DataFrame, *, tf_multiplier: int, ema_period: int) -> pd.Series:
+    """Return higher time frame trend as ``"up"`` or ``"down"``.
 
-    return ["flat" for _ in data]
+    The dataset is downsampled by ``tf_multiplier`` and an EMA of ``ema_period``
+    is computed on the resulting series.  Trend labels are then forward filled
+    to the original frequency.
+    """
+
+    groups = np.arange(len(df)) // tf_multiplier
+    htf_close = df["close"].groupby(groups).last()
+    ema = htf_close.ewm(span=ema_period, adjust=False).mean()
+    trend_per_group = pd.Series(
+        np.where(ema.diff() > 0, "up", "down"), index=htf_close.index
+    )
+    return pd.Series(groups).map(trend_per_group).astype("category")
 
 
-def vol_tertile(data: List[Dict[str, Any]], **params: Any) -> List[int]:
-    """Placeholder for volatility tertile regime."""
+def vol_tertile(df: pd.DataFrame, *, window: int) -> pd.Series:
+    """Classify current ATR into tertiles across the sample."""
 
-    return [0 for _ in data]
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    atr = tr.rolling(window).mean()
+    q1, q2 = atr.quantile([1 / 3, 2 / 3])
+    if q1 == q2:
+        tertiles = pd.Series(["mid"] * len(atr), index=atr.index)
+    else:
+        tertiles = pd.cut(atr, [-np.inf, q1, q2, np.inf], labels=["low", "mid", "high"])
+    return tertiles.astype("category")
 
 
-def session(data: List[Dict[str, Any]], **params: Any) -> List[str]:
-    """Placeholder for session labels."""
+def session(df: pd.DataFrame, *, col: str = "session_id") -> pd.Series:
+    """Return the session label as a categorical series."""
 
-    return ["" for _ in data]
+    return df[col].astype("category")
 

--- a/src/quant_engine/stats/events.py
+++ b/src/quant_engine/stats/events.py
@@ -1,23 +1,58 @@
 """Event definitions for statistics runs."""
 from __future__ import annotations
 
-from typing import Any, Dict, List
+import pandas as pd
 
 
-def k_consecutive(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
-    """Placeholder for detecting ``k`` consecutive events."""
+def k_consecutive(df: pd.DataFrame, *, k: int, direction: str) -> pd.Series:
+    """Return ``True`` when ``k`` consecutive bars close in ``direction``.
 
-    return [False for _ in data]
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least ``open`` and ``close`` columns.
+    k:
+        Number of consecutive bars to check.
+    direction:
+        ``"up"`` for positive closes, ``"down"`` for negative closes.
+    """
+
+    up = df["close"] > df["open"]
+    down = df["open"] > df["close"]
+    series = up if direction == "up" else down
+    return series.rolling(k).sum().eq(k).fillna(False)
 
 
-def shock_atr(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
-    """Placeholder for ATR shock events."""
+def shock_atr(df: pd.DataFrame, *, mult: float, window: int) -> pd.Series:
+    """True if the current true range exceeds ``mult`` times the ATR."""
 
-    return [False for _ in data]
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    atr = tr.rolling(window).mean()
+    return (tr > mult * atr).fillna(False)
 
 
-def breakout_hhll(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
-    """Placeholder for breakout of higher high / lower low events."""
+def breakout_hhll(df: pd.DataFrame, *, lookback: int, type: str) -> pd.Series:
+    """Detect breakout of higher highs or lower lows.
 
-    return [False for _ in data]
+    Parameters
+    ----------
+    df:
+        OHLC DataFrame.
+    lookback:
+        Number of bars to look back when computing the reference high/low.
+    type:
+        ``"hh"`` to detect new highs, ``"ll"`` for new lows.
+    """
+
+    if type == "hh":
+        ref = df["high"].shift(1).rolling(lookback, min_periods=1).max()
+        return (df["high"] > ref).fillna(False)
+    if type == "ll":
+        ref = df["low"].shift(1).rolling(lookback, min_periods=1).min()
+        return (df["low"] < ref).fillna(False)
+    raise ValueError("type must be 'hh' or 'll'")
 

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -1,32 +1,115 @@
 """Execution utilities for :mod:`quant_engine.stats`."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Dict
+from datetime import date
+from typing import Any, Dict, List, Tuple
 
-try:  # pragma: no cover - optional dependency
-    import polars as pl
-except Exception:  # pragma: no cover
-    pl = None
+import pandas as pd
 
 from ..api.schemas import StatsSpec
+from ..core.dataset import load_dataset
+from ..core.spec import DataSpec
+from ..core.features import atr
+from . import conditions as cond_mod
+from . import events as event_mod
+from . import targets as tgt_mod
 
 
-def run_stats(spec: StatsSpec) -> Dict[str, Any]:
-    """Run a statistics specification.
+def _build_data_frame(dataset: List[Dict[str, Any]]) -> pd.DataFrame:
+    df = pd.DataFrame(dataset)
+    if df.empty:
+        return df
+    df.rename(columns={"timestamp": "ts", "session": "session_id"}, inplace=True)
+    df["ts"] = pd.to_datetime(df["ts"])
+    return df
 
-    The current implementation is a synchronous placeholder that writes an
-    empty ``stats_summary.parquet`` file and returns its path.
+
+def run_stats(spec: StatsSpec) -> pd.DataFrame:
+    """Run statistics computation according to ``spec``.
+
+    Returns a long-form :class:`pandas.DataFrame` with at least the columns
+    ``ts``, ``symbol``, ``event``, ``event_on``, ``condition_name``,
+    ``condition_value``, ``target`` and ``outcome_value``.
     """
 
-    out_dir = Path(spec.artifacts.out_dir) if spec.artifacts and spec.artifacts.out_dir else Path(".")
-    out_dir.mkdir(parents=True, exist_ok=True)
-    summary_path = out_dir / "stats_summary.parquet"
-    if pl is not None:
-        pl.DataFrame().write_parquet(summary_path)
-    else:
-        summary_path.touch()
-    return {"summary_path": str(summary_path)}
+    data_spec = DataSpec(
+        path=spec.data.dataset_path,
+        symbols=spec.data.symbols,
+        start=date.fromisoformat(spec.data.start),
+        end=date.fromisoformat(spec.data.end),
+    )
+    dataset = load_dataset(data_spec)
+    df = _build_data_frame(dataset)
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "ts",
+                "symbol",
+                "event",
+                "event_on",
+                "condition_name",
+                "condition_value",
+                "target",
+                "outcome_value",
+            ]
+        )
+
+    df["atr"] = atr.compute(dataset, {"period": 14})
+
+    event_cols: List[Tuple[str, str]] = []
+    for ev in spec.events:
+        func = getattr(event_mod, ev.name)
+        col = f"ev::{ev.name}"
+        df[col] = func(df, **ev.params)
+        event_cols.append((ev.name, col))
+
+    cond_cols: List[Tuple[str, str]] = []
+    for cond in spec.conditions:
+        func = getattr(cond_mod, cond.name)
+        col = f"cond::{cond.name}"
+        df[col] = func(df, **cond.params)
+        cond_cols.append((cond.name, col))
+
+    tgt_cols: List[Tuple[str, str]] = []
+    for tgt in spec.targets:
+        func = getattr(tgt_mod, tgt.name)
+        col = f"tgt::{tgt.name}"
+        df[col] = func(df, **tgt.params)
+        tgt_cols.append((tgt.name, col))
+
+    records: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        base = {"ts": row["ts"], "symbol": row["symbol"]}
+        for ev_name, ev_col in event_cols:
+            ev_on = bool(row[ev_col])
+            for tgt_name, tgt_col in tgt_cols:
+                outcome = row[tgt_col]
+                if cond_cols:
+                    for cond_name, cond_col in cond_cols:
+                        records.append(
+                            {
+                                **base,
+                                "event": ev_name,
+                                "event_on": ev_on,
+                                "condition_name": cond_name,
+                                "condition_value": row[cond_col],
+                                "target": tgt_name,
+                                "outcome_value": outcome,
+                            }
+                        )
+                else:
+                    records.append(
+                        {
+                            **base,
+                            "event": ev_name,
+                            "event_on": ev_on,
+                            "condition_name": None,
+                            "condition_value": None,
+                            "target": tgt_name,
+                            "outcome_value": outcome,
+                        }
+                    )
+    return pd.DataFrame.from_records(records)
 
 
 __all__ = ["run_stats"]

--- a/src/quant_engine/stats/targets.py
+++ b/src/quant_engine/stats/targets.py
@@ -1,23 +1,49 @@
 """Target metrics for statistics runs."""
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
+
+import numpy as np
+import pandas as pd
 
 
-def up_next_bar(data: List[Dict[str, Any]], **params: Any) -> List[bool]:
-    """Placeholder for next bar up move."""
+def up_next_bar(df: pd.DataFrame, **params: Any) -> pd.Series:
+    """True if the next bar closes higher than the current bar."""
 
-    return [False for _ in data]
-
-
-def continuation_n(data: List[Dict[str, Any]], **params: Any) -> List[int]:
-    """Placeholder for continuation over ``n`` bars."""
-
-    return [0 for _ in data]
+    next_close = df["close"].shift(-1)
+    res = (next_close > df["close"]).astype("boolean")
+    return res.mask(next_close.isna())
 
 
-def time_to_reversal(data: List[Dict[str, Any]], **params: Any) -> List[int]:
-    """Placeholder for time until reversal."""
+def continuation_n(df: pd.DataFrame, *, n: int, direction: str) -> pd.Series:
+    """Continuation of the move after ``n`` bars in ``direction``."""
 
-    return [0 for _ in data]
+    future = df["close"].shift(-n)
+    if direction == "up":
+        res = (future > df["close"]).astype("boolean")
+    else:
+        res = (future < df["close"]).astype("boolean")
+    return res.mask(future.isna())
+
+
+def time_to_reversal(df: pd.DataFrame, *, max_horizon: int) -> pd.Series:
+    """Number of bars until price movement reverses direction."""
+
+    close = df["close"].to_numpy()
+    n = len(close)
+    out = np.full(n, np.nan)
+    for i in range(n - 1):
+        initial = np.sign(close[i + 1] - close[i])
+        if initial == 0 or np.isnan(initial):
+            continue
+        for j in range(1, max_horizon + 1):
+            if i + j >= n:
+                break
+            step = np.sign(close[i + j] - close[i + j - 1])
+            if step == -initial and step != 0:
+                out[i] = j
+                break
+            if j == max_horizon:
+                out[i] = max_horizon
+    return pd.Series(out).astype("Int64")
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import pandas as pd
+
+from quant_engine.stats import events, conditions, targets, runner
+from quant_engine.api import schemas
+
+
+def load_df():
+    import json, pathlib
+    data = json.loads(pathlib.Path('tests/data/ohlcv.json').read_text())
+    df = pd.DataFrame(data)
+    df.rename(columns={'timestamp': 'ts', 'session': 'session_id'}, inplace=True)
+    return df
+
+def test_events():
+    df = load_df()
+    k = events.k_consecutive(df, k=3, direction='up')
+    assert k.tolist() == [False, False, True, True, True]
+    shock = events.shock_atr(df, mult=0.5, window=2)
+    assert shock.tolist() == [False, True, True, True, True]
+    br = events.breakout_hhll(df, lookback=2, type='hh')
+    assert br.tolist() == [False, True, True, True, True]
+
+
+def test_conditions():
+    df = load_df()
+    trend = conditions.htf_trend(df, tf_multiplier=2, ema_period=2)
+    assert trend.tolist() == ['down', 'down', 'up', 'up', 'up']
+    vol = conditions.vol_tertile(df, window=2)
+    assert vol.tolist() == ['mid']*5
+    sess = conditions.session(df, col='session_id')
+    assert sess.tolist() == [
+        '2020-01-01',
+        '2020-01-02',
+        '2020-01-03',
+        '2020-01-04',
+        '2020-01-05',
+    ]
+
+
+def test_targets():
+    df = load_df()
+    up = targets.up_next_bar(df)
+    assert up.tolist() == [True, True, True, True, pd.NA]
+    cont = targets.continuation_n(df, n=2, direction='up')
+    assert cont.tolist() == [True, True, True, pd.NA, pd.NA]
+    ttr = targets.time_to_reversal(df, max_horizon=3)
+    assert ttr.tolist() == [3, 3, pd.NA, pd.NA, pd.NA]
+
+
+def test_runner_long_format():
+    spec = schemas.StatsSpec(
+        data=schemas.StatsDataSpec(
+            dataset_path='tests/data/ohlcv.json',
+            symbols=['ABC'],
+            timeframe='1d',
+            start='2020-01-01',
+            end='2020-01-05',
+        ),
+        events=[schemas.StatsEventSpec(name='k_consecutive', params={'k':2,'direction':'up'})],
+        conditions=[schemas.StatsConditionSpec(name='session', params={'col':'session_id'})],
+        targets=[schemas.StatsTargetSpec(name='up_next_bar')],
+    )
+    df = runner.run_stats(spec)
+    assert list(df.columns) == [
+        'ts',
+        'symbol',
+        'event',
+        'event_on',
+        'condition_name',
+        'condition_value',
+        'target',
+        'outcome_value',
+    ]
+    assert len(df) == 5
+    first = df.iloc[0]
+    assert first['event'] == 'k_consecutive'
+    assert first['condition_name'] == 'session'
+    assert first['target'] == 'up_next_bar'


### PR DESCRIPTION
## Summary
- add k-consecutive, ATR shock and breakout events
- add HTF trend, volatility tertiles and session conditions
- support up-next-bar, continuation and time-to-reversal targets
- build stats runner to generate long-format dataset
- cover stats module with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7341b4c30832399a1681a156975a4