### PR TITLE
Implement stats aggregation with Wilson CI and WFA support

### DIFF
--- a/src/quant_engine/io/artifacts.py
+++ b/src/quant_engine/io/artifacts.py
@@ -1,9 +1,10 @@
-"""Utilities to persist backtest results."""
+"""Utilities to persist backtest and statistics results."""
 from __future__ import annotations
-
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
+import pandas as pd
 
 
 def _write_rows(path: str | Path, rows: List[Dict[str, Any]]) -> None:
@@ -25,4 +26,19 @@ def write_equity(path: str | Path, equity: List[float]) -> None:
 
 def write_summary(path: str | Path, summary: Dict[str, Any]) -> None:
     Path(path).write_text(json.dumps(summary, indent=2))
+
+
+def write_stats_summary(path: str | Path, df: pd.DataFrame) -> None:
+    """Persist aggregate statistics to a Parquet file."""
+
+    df.to_parquet(path, index=False)
+
+
+def write_stats_details(path: str | Path, df: pd.DataFrame) -> None:
+    """Persist detailed statistics to a Parquet file.
+
+    Placeholder for future extensions (e.g. time to reversal).
+    """
+
+    df.to_parquet(path, index=False)
 

--- a/src/quant_engine/stats/estimators.py
+++ b/src/quant_engine/stats/estimators.py
@@ -1,7 +1,11 @@
 """Estimator helpers for statistics runs."""
 from __future__ import annotations
 
-from typing import Tuple
+from math import sqrt
+from statistics import NormalDist
+from typing import Dict, Tuple
+
+import pandas as pd
 
 
 def phat(successes: int, trials: int) -> float:
@@ -10,14 +14,43 @@ def phat(successes: int, trials: int) -> float:
     return successes / trials if trials else 0.0
 
 
-def wilson_ci(successes: int, trials: int, z: float = 1.96) -> Tuple[float, float]:
-    """Return a Wilson score confidence interval (placeholder)."""
+def freq_with_wilson(successes: int, n: int, alpha: float = 0.05) -> Tuple[float, float, float]:
+    """Return empirical frequency and Wilson score interval."""
 
-    return (0.0, 0.0)
+    if n == 0:
+        return 0.0, 0.0, 0.0
+    z = NormalDist().inv_cdf(1 - alpha / 2)
+    p = successes / n
+    denom = 1 + z * z / n
+    center = p + z * z / (2 * n)
+    margin = z * sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    ci_low = (center - margin) / denom
+    ci_high = (center + margin) / denom
+    return p, ci_low, ci_high
 
 
-def baseline(trials: int) -> float:
-    """Return a baseline probability estimate."""
+def aggregate_binary(outcomes: pd.Series) -> Dict[str, float]:
+    """Aggregate binary outcomes with Wilson interval."""
 
-    return 0.0
+    n = int(outcomes.count())
+    successes = int(outcomes.sum()) if n else 0
+    p, ci_low, ci_high = freq_with_wilson(successes, n)
+    return {
+        "n": n,
+        "successes": successes,
+        "p_hat": p,
+        "ci_low": ci_low,
+        "ci_high": ci_high,
+    }
+
+
+def baseline(outcomes: pd.Series) -> float:
+    """Return the global empirical success probability."""
+
+    n = int(outcomes.count())
+    successes = int(outcomes.sum()) if n else 0
+    return phat(successes, n)
+
+
+__all__ = ["freq_with_wilson", "aggregate_binary", "baseline"]
 


### PR DESCRIPTION
## Summary
- add Wilson score based frequency estimator and binary outcome aggregation
- compute walk-forward aggregated statistics with baseline and lift
- persist stats summaries via new artifact writers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7376d7de48323a842212e756de67c