### PR TITLE
Add stats CLI and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,47 @@ pre-commit run --all-files
 - `GET /runs/{id}/trials`
 - `GET /runs/{id}/metrics`
 
+## Market Stats
+
+### Exemple de spécification
+
+```json
+{
+  "data": {
+    "dataset_path": "data/eurusd_m1_2025H1.csv",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01",
+    "end": "2025-06-30"
+  },
+  "events": [
+    { "name": "k_consecutive", "params": { "k": 2, "direction": "up" } }
+  ],
+  "conditions": [
+    { "name": "htf_trend", "params": { "tf_multiplier": 60, "ema_period": 50 } },
+    { "name": "vol_tertile", "params": { "window": 14 } },
+    { "name": "session", "params": { "col": "session_id" } }
+  ],
+  "targets": [
+    { "name": "up_next_bar", "params": {} },
+    { "name": "continuation_n", "params": { "n": 3, "direction": "up" } }
+  ],
+  "validation": { "scheme": "walk_forward", "train_months": 2, "test_months": 1, "folds": 3, "embargo_days": 2 },
+  "artifacts": { "out_dir": "runs/stats_eurusd_m1_2025H1", "save_equity": false, "save_trades": false },
+  "persistence": { "store_trades_in_db": false, "store_equity_in_db": false }
+}
+```
+
+### CLI
+
+```bash
+poetry run quant-engine stats run --spec path/to/stats_spec.json
+poetry run quant-engine stats show --symbol EURUSD --event k_consecutive --target up_next_bar --timeframe M1 --limit 20
+```
+
+### API
+
+- `POST /stats/run`
+- `GET /stats/result`
+- `GET /stats`
+

--- a/tests/data/stats_spec_example.json
+++ b/tests/data/stats_spec_example.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "dataset_path": "data/eurusd_m1_2025H1.csv",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01",
+    "end": "2025-06-30"
+  },
+  "events": [
+    { "name": "k_consecutive", "params": { "k": 2, "direction": "up" } }
+  ],
+  "conditions": [
+    { "name": "htf_trend", "params": { "tf_multiplier": 60, "ema_period": 50 } },
+    { "name": "vol_tertile", "params": { "window": 14 } },
+    { "name": "session", "params": { "col": "session_id" } }
+  ],
+  "targets": [
+    { "name": "up_next_bar", "params": {} },
+    { "name": "continuation_n", "params": { "n": 3, "direction": "up" } }
+  ],
+  "validation": { "scheme": "walk_forward", "train_months": 2, "test_months": 1, "folds": 3, "embargo_days": 2 },
+  "artifacts": { "out_dir": "runs/stats_eurusd_m1_2025H1", "save_equity": false, "save_trades": false },
+  "persistence": { "store_trades_in_db": false, "store_equity_in_db": false }
+}

--- a/tests/test_stats_smoke.py
+++ b/tests/test_stats_smoke.py
@@ -1,0 +1,64 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+pl = pytest.importorskip("polars")
+
+from quant_engine.api import schemas
+from quant_engine.core.spec import ArtifactsSpec, ValidationSpec
+from quant_engine.stats import runner
+
+
+def test_stats_smoke(tmp_path: Path) -> None:
+    n = 30
+    start = datetime(2020, 1, 1)
+    dates = [start + timedelta(days=i) for i in range(n)]
+    df = pl.DataFrame(
+        {
+            "timestamp": [d.strftime("%Y-%m-%dT%H:%M:%S") for d in dates],
+            "symbol": ["ABC"] * n,
+            "open": list(range(n)),
+            "high": [x + 1 for x in range(n)],
+            "low": list(range(n)),
+            "close": [x + 0.5 for x in range(n)],
+            "session_id": [d.strftime("%Y-%m-%d") for d in dates],
+        }
+    )
+    dataset_path = tmp_path / "synth.json"
+    dataset_path.write_text(json.dumps(df.to_dicts()))
+    out_dir = tmp_path / "run"
+    spec = schemas.StatsSpec(
+        data=schemas.StatsDataSpec(
+            dataset_path=str(dataset_path),
+            symbols=["ABC"],
+            timeframe="M1",
+            start="2020-01-01",
+            end="2020-01-30",
+        ),
+        events=[
+            schemas.StatsEventSpec(
+                name="k_consecutive", params={"k": 2, "direction": "up"}
+            )
+        ],
+        conditions=[
+            schemas.StatsConditionSpec(name="session", params={"col": "session_id"}),
+            schemas.StatsConditionSpec(name="vol_tertile", params={"window": 14}),
+        ],
+        targets=[schemas.StatsTargetSpec(name="up_next_bar", params={})],
+        validation=ValidationSpec(
+            min_trades=0,
+            train_months=0,
+            test_months=1,
+            folds=1,
+            embargo_days=0,
+        ),
+        artifacts=ArtifactsSpec(out_dir=str(out_dir)),
+    )
+    runner.run_stats(spec)
+    summary_path = out_dir / "stats_summary.parquet"
+    assert summary_path.exists()
+    df_read = pd.read_parquet(summary_path)
+    assert df_read["p_hat"].notna().any()


### PR DESCRIPTION
## Summary
- add `stats` CLI group with `run` and `show` commands
- document market statistics workflow in README
- provide example stats spec and smoke test

## Testing
- ⚠️ `pre-commit run --files README.md src/quant_engine/cli/main.py tests/data/stats_spec_example.json tests/test_stats_smoke.py` (pre-commit missing)
- ⚠️ `pip install pre-commit` (proxy prevented download)
- ⚠️ `pip install polars` (proxy prevented download)
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73e4044288323b5a7f32562eefae8