### PR TITLE
Add Bayesian proportion estimators with HDI

### DIFF
--- a/src/quant_engine/stats/estimators.py
+++ b/src/quant_engine/stats/estimators.py
@@ -5,6 +5,7 @@ from math import sqrt
 from statistics import NormalDist
 from typing import Dict, Tuple
 
+import numpy as np
 import pandas as pd
 
 
@@ -52,5 +53,100 @@ def baseline(outcomes: pd.Series) -> float:
     return phat(successes, n)
 
 
-__all__ = ["freq_with_wilson", "aggregate_binary", "baseline"]
+# Bayesian estimators
+
+
+def beta_binomial_posterior(
+    successes: int,
+    n: int,
+    alpha_prior: float = 0.5,
+    beta_prior: float = 0.5,
+) -> Tuple[float, float]:
+    """Return posterior alpha and beta parameters for a Beta prior."""
+
+    failures = n - successes
+    alpha_post = successes + alpha_prior
+    beta_post = failures + beta_prior
+    return alpha_post, beta_post
+
+
+def posterior_mean(alpha_post: float, beta_post: float) -> float:
+    """Return the posterior mean of the success probability."""
+
+    return alpha_post / (alpha_post + beta_post)
+
+
+def posterior_map(alpha_post: float, beta_post: float) -> float:
+    """Return the posterior MAP estimate of the success probability."""
+
+    if alpha_post > 1 and beta_post > 1:
+        return (alpha_post - 1) / (alpha_post + beta_post - 2)
+    return posterior_mean(alpha_post, beta_post)
+
+
+def beta_hdi(
+    alpha_post: float,
+    beta_post: float,
+    cred_mass: float = 0.95,
+    num_points: int = 2000,
+) -> Tuple[float, float]:
+    """Approximate the highest density interval for a Beta distribution."""
+
+    eps = 1e-8
+    xs = np.linspace(eps, 1 - eps, num_points)
+    log_pdf = (alpha_post - 1) * np.log(xs) + (beta_post - 1) * np.log(1 - xs)
+    log_pdf -= np.max(log_pdf)
+    pdf = np.exp(log_pdf)
+    norm = np.trapz(pdf, xs)
+    if norm == 0:
+        return 0.0, 1.0
+    pdf /= norm
+    dx = xs[1] - xs[0]
+    idx = np.argsort(pdf)[::-1]
+    cumsum = np.cumsum(pdf[idx] * dx)
+    k = np.searchsorted(cumsum, cred_mass)
+    threshold = pdf[idx[k]]
+    mask = pdf >= threshold
+    low = float(xs[mask][0])
+    high = float(xs[mask][-1])
+    return low, high
+
+
+def aggregate_binary_bayes(
+    successes: int,
+    n: int,
+    cred_mass: float = 0.95,
+    alpha_prior: float = 0.5,
+    beta_prior: float = 0.5,
+) -> Dict[str, float]:
+    """Aggregate binary outcomes using a Beta-Binomial model."""
+
+    alpha_post, beta_post = beta_binomial_posterior(
+        successes, n, alpha_prior, beta_prior
+    )
+    p_mean = posterior_mean(alpha_post, beta_post)
+    p_map = posterior_map(alpha_post, beta_post)
+    hdi_low, hdi_high = beta_hdi(alpha_post, beta_post, cred_mass)
+    return {
+        "n": n,
+        "successes": successes,
+        "alpha_post": alpha_post,
+        "beta_post": beta_post,
+        "p_mean": p_mean,
+        "p_map": p_map,
+        "hdi_low": hdi_low,
+        "hdi_high": hdi_high,
+    }
+
+
+__all__ = [
+    "freq_with_wilson",
+    "aggregate_binary",
+    "baseline",
+    "beta_binomial_posterior",
+    "posterior_mean",
+    "posterior_map",
+    "beta_hdi",
+    "aggregate_binary_bayes",
+]
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -62,6 +62,29 @@ def test_aggregate_binary():
     assert res["ci_low"] < res["p_hat"] < res["ci_high"]
 
 
+def test_bayes_estimators():
+    alpha_post, beta_post = estimators.beta_binomial_posterior(3, 4)
+    assert alpha_post == 3.5
+    assert beta_post == 1.5
+    p_mean = estimators.posterior_mean(alpha_post, beta_post)
+    p_map = estimators.posterior_map(alpha_post, beta_post)
+    assert round(p_mean, 2) == 0.70
+    assert round(p_map, 2) == 0.83
+    low, high = estimators.beta_hdi(alpha_post, beta_post)
+    assert 0 < low < p_mean < high < 1
+
+    a0, b0 = estimators.beta_binomial_posterior(0, 0)
+    assert estimators.posterior_map(a0, b0) == estimators.posterior_mean(a0, b0) == 0.5
+
+
+def test_aggregate_binary_bayes():
+    res = estimators.aggregate_binary_bayes(3, 4)
+    assert res["n"] == 4
+    assert res["successes"] == 3
+    assert round(res["p_mean"], 2) == 0.70
+    assert res["hdi_low"] < res["p_mean"] < res["hdi_high"]
+
+
 def test_runner_summary():
     spec = schemas.StatsSpec(
         data=schemas.StatsDataSpec(


### PR DESCRIPTION
## Summary
- add Beta-Binomial posterior calculation with mean, MAP, and HDI utilities
- expose aggregate_binary_bayes helper returning posterior metrics
- cover Bayesian estimators with tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c74168d480832398dbbd8185a6a615