### PR TITLE
Add Bayesian aggregation and lift metrics to stats runner

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -109,7 +109,12 @@ def test_runner_summary():
         'p_hat',
         'ci_low',
         'ci_high',
-        'lift',
+        'p_mean',
+        'p_map',
+        'hdi_low',
+        'hdi_high',
+        'lift_freq',
+        'lift_bayes',
         'insufficient',
         'split',
     ]
@@ -118,6 +123,9 @@ def test_runner_summary():
     row = df.iloc[0]
     assert row['n'] == 3
     assert row['successes'] == 3
-    assert row['lift'] == 0.0
+    assert row['lift_freq'] == 0.0
+    assert row['lift_bayes'] == 0.0
+    assert round(row['p_mean'], 3) == 0.875
+    assert round(row['p_map'], 3) == 0.875
     assert row['insufficient'] == True
     assert row['split'] == 'test'


### PR DESCRIPTION
## Summary
- compute frequentist and Bayesian statistics for each stats group
- add baseline-based lift calculations for frequentist and Bayesian estimates
- extend tests for new metrics in stats runner

## Testing
- `pre-commit run --files src/quant_engine/stats/runner.py tests/test_stats.py` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c74334ef4c8323a38fb3bc82515c6e