### PR TITLE
Add FDR-adjusted p-values to stats runner

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -117,6 +117,9 @@ def test_runner_summary():
         'lift_bayes',
         'insufficient',
         'split',
+        'p_value',
+        'q_value',
+        'significant',
     ]
     assert list(df.columns) == cols
     assert len(df) == 1


### PR DESCRIPTION
## Summary
- add normal-approximate one-sided binomial p-value and Benjamini–Hochberg FDR helper functions
- compute per-cohort p-values in stats runner and adjust via BH procedure, exposing `p_value`, `q_value` and `significant` columns
- update tests for new statistical outputs

## Testing
- `pytest`
- `pre-commit run --files src/quant_engine/stats/estimators.py src/quant_engine/stats/runner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d58012083238ef31e8407e52923