### PR TITLE
Add seasonality spec skeleton with API, CLI, and signal scaffolding

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -15,6 +15,7 @@ from ..io import ids
 from ..persistence import db
 from ..stats import runner as stats_runner
 from ..stats.estimators import freq_with_wilson
+from ..seasonality import runner as seasonality_runner
 from . import schemas
 
 _jobs: Dict[str, Dict[str, Any]] = {}
@@ -58,6 +59,17 @@ def stats_result() -> schemas.ResultResponse:
     """Return the last statistics result if available."""
 
     return schemas.ResultResponse(result=_last_stats)
+
+
+# ---------------------------------------------------------------------------
+# Seasonality endpoints
+
+
+def seasonality_run(spec: schemas.SeasonalitySpec) -> schemas.ResultResponse:
+    """Execute a seasonality run synchronously and return its summary."""
+
+    result = seasonality_runner.run(spec)
+    return schemas.ResultResponse(result=result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, Field
 
-from ..core.spec import ValidationSpec, ArtifactsSpec, PersistenceSpec
+from ..core.spec import (
+    ValidationSpec as CoreValidationSpec,
+    ArtifactsSpec as CoreArtifactsSpec,
+    PersistenceSpec as CorePersistenceSpec,
+)
 
 
 @dataclass
@@ -62,7 +66,92 @@ class StatsSpec(BaseModel):
     events: List[StatsEventSpec] = Field(default_factory=list)
     conditions: List[StatsConditionSpec] = Field(default_factory=list)
     targets: List[StatsTargetSpec] = Field(default_factory=list)
-    validation: ValidationSpec | None = None
-    artifacts: ArtifactsSpec | None = None
-    persistence: PersistenceSpec | None = None
+    validation: CoreValidationSpec | None = None
+    artifacts: CoreArtifactsSpec | None = None
+    persistence: CorePersistenceSpec | None = None
+
+
+class ExecutionSpec(BaseModel):
+    """Light-weight execution configuration for seasonality runs."""
+
+    slippage_bps: float = 0.0
+    commission_bps: float = 0.0
+
+
+class RiskSpec(BaseModel):
+    """Basic risk settings used when generating the signal."""
+
+    max_positions: int = 1
+    max_allocation: float = 1.0
+
+
+class TPSSLSpec(BaseModel):
+    """Simple take-profit/stop-loss configuration placeholder."""
+
+    take_profit: float | None = None
+    stop_loss: float | None = None
+
+
+class ValidationSpec(BaseModel):
+    """Validation configuration for seasonality workflows."""
+
+    min_trades: int = 0
+    train_months: int = 0
+    test_months: int = 1
+    folds: int = 1
+    embargo_days: int = 0
+
+
+class ArtifactsSpec(BaseModel):
+    """Configuration describing where to persist generated artifacts."""
+
+    out_dir: str | None = None
+
+
+class PersistenceSpec(BaseModel):
+    """Minimal database persistence settings."""
+
+    enabled: bool = False
+    spec_id: str | None = None
+    dataset_id: str | None = None
+
+
+class SeasonalityDataSpec(BaseModel):
+    dataset_path: str
+    symbols: list[str]
+    timeframe: str
+    start: str
+    end: str
+
+
+class SeasonalityProfileSpec(BaseModel):
+    # quelles dimensions de saisonnalité calculer
+    by_hour: bool = True
+    by_dow: bool = True
+    by_month: bool = False
+    # mesure : 'direction' (P(close_{t+1} > close_t)) ou 'return'
+    measure: Literal["direction", "return"] = "direction"
+    ret_horizon: int = 1  # nb de barres à regarder
+    min_samples_bin: int = 300  # n_min par bin
+
+
+class SeasonalitySignalSpec(BaseModel):
+    # comment transformer les profils en signal tradable
+    method: Literal["threshold", "topk"] = "threshold"
+    threshold: float = 0.54  # si measure=direction alors p_hat>=seuil
+    topk: int = 3  # si method=topk: prendre K bins les + forts
+    dims: list[Literal["hour", "dow", "month"]] = ["hour", "dow"]
+    combine: Literal["and", "or", "sum"] = "and"  # combine multi-dims
+
+
+class SeasonalitySpec(BaseModel):
+    data: SeasonalityDataSpec
+    profile: SeasonalityProfileSpec = SeasonalityProfileSpec()
+    signal: SeasonalitySignalSpec = SeasonalitySignalSpec()
+    execution: ExecutionSpec = ExecutionSpec()
+    risk: RiskSpec = RiskSpec()
+    tp_sl: TPSSLSpec = TPSSLSpec()
+    validation: ValidationSpec = ValidationSpec()
+    artifacts: ArtifactsSpec = ArtifactsSpec()
+    persistence: PersistenceSpec = PersistenceSpec()
 

--- a/src/quant_engine/cli/main.py
+++ b/src/quant_engine/cli/main.py
@@ -19,8 +19,10 @@ except Exception:  # pragma: no cover - fallback used when import fails
 app = typer.Typer()
 runs_app = typer.Typer()
 stats_app = typer.Typer()
+seasonality_app = typer.Typer()
 app.add_typer(runs_app, name="runs")
 app.add_typer(stats_app, name="stats")
+app.add_typer(seasonality_app, name="seasonality")
 
 
 class RunStatus(str, Enum):
@@ -158,6 +160,21 @@ def stats_show(
         if "q_value" in df.columns:
             display_cols.append("q_value")
         typer.echo(df[display_cols].to_string(index=False))
+
+
+@seasonality_app.command("run")
+def seasonality_run(
+    spec_path: Path = typer.Option(..., "--spec", exists=True, file_okay=True, dir_okay=False)
+) -> None:
+    """Execute a seasonality specification locally and display the summary."""
+
+    from ..api.schemas import SeasonalitySpec
+    from ..seasonality.runner import run as run_seasonality
+
+    spec_model = SeasonalitySpec.model_validate_json(spec_path.read_text())
+    result = run_seasonality(spec_model)
+    summary = result.get("summary", {})
+    typer.echo(json.dumps(summary, separators=(",", ":")))
 
 
 @runs_app.command("list")

--- a/src/quant_engine/core/spec.py
+++ b/src/quant_engine/core/spec.py
@@ -42,7 +42,7 @@ class TPSLSpec:
 class ValidationSpec:
     """Walk-forward validation configuration."""
 
-    min_trades: int
+    min_trades: int = 0
     train_months: int = 0
     test_months: int = 1
     folds: int = 1

--- a/src/quant_engine/seasonality/__init__.py
+++ b/src/quant_engine/seasonality/__init__.py
@@ -1,0 +1,5 @@
+"""Seasonality analysis module."""
+
+from .runner import run
+
+__all__ = ["run"]

--- a/src/quant_engine/seasonality/compute.py
+++ b/src/quant_engine/seasonality/compute.py
@@ -1,0 +1,127 @@
+"""Computation helpers for seasonality profiles."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
+    pl = None  # type: ignore
+
+from ..api.schemas import SeasonalityProfileSpec
+from ..stats.estimators import freq_with_wilson
+
+# ---------------------------------------------------------------------------
+# Feature preparation
+
+
+def _require_polars() -> None:
+    if pl is None:  # pragma: no cover - exercised when dependency missing
+        raise RuntimeError("polars is required for seasonality computations")
+
+
+def prepare_features(dataset: pl.DataFrame, profile: SeasonalityProfileSpec) -> pl.DataFrame:
+    """Return a dataframe with forward returns and calendar bins.
+
+    Parameters
+    ----------
+    dataset:
+        Input bars sorted by symbol and timestamp containing ``close`` prices.
+    profile:
+        Profile specification describing the return horizon and measure.
+    """
+
+    _require_polars()
+
+    if dataset.is_empty():
+        return dataset.clone()
+
+    df = dataset.sort(["symbol", "timestamp"])
+    horizon = max(int(profile.ret_horizon), 1)
+    df = df.with_columns(
+        pl.col("close").shift(-horizon).over("symbol").alias("close_fwd")
+    )
+    df = df.with_columns(
+        pl.when(pl.col("close").abs() <= 1e-12)
+        .then(None)
+        .otherwise((pl.col("close_fwd") - pl.col("close")) / pl.col("close"))
+        .alias("forward_ret")
+    )
+    df = df.with_columns(
+        pl.col("forward_ret").gt(0).cast(pl.Int64).alias("direction")
+    )
+    df = df.with_columns(
+        pl.col("timestamp").dt.hour().alias("hour"),
+        pl.col("timestamp").dt.weekday().alias("dow"),
+        pl.col("timestamp").dt.month().alias("month"),
+    )
+    return df.filter(pl.col("forward_ret").is_not_null())
+
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers
+
+
+def _aggregate_dimension(
+    dataset: pl.DataFrame,
+    dim: str,
+    profile: SeasonalityProfileSpec,
+) -> pl.DataFrame:
+    """Aggregate forward returns for a single dimension."""
+
+    _require_polars()
+
+    if dataset.is_empty():
+        return pl.DataFrame({dim: [], "n": [], "successes": [], "p_hat": [], "ci_low": [], "ci_high": [], "mean_ret": []})
+
+    rows: list[Dict[str, float | int]] = []
+    for group in dataset.partition_by(dim, maintain_order=False):
+        bin_value = group.get_column(dim)[0]
+        n = group.height
+        if n < profile.min_samples_bin:
+            continue
+        if profile.measure == "direction":
+            successes = int(group.get_column("direction").sum())
+        else:
+            successes = int((group.get_column("forward_ret") > 0).sum())
+        mean_val = group.get_column("forward_ret").mean()
+        mean_ret = float(mean_val) if mean_val is not None else 0.0
+        p_hat, ci_low, ci_high = freq_with_wilson(successes, n)
+        rows.append(
+            {
+                dim: bin_value,
+                "n": n,
+                "successes": successes,
+                "p_hat": p_hat,
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+                "mean_ret": mean_ret,
+            }
+        )
+    if not rows:
+        return pl.DataFrame({dim: [], "n": [], "successes": [], "p_hat": [], "ci_low": [], "ci_high": [], "mean_ret": []})
+    return pl.DataFrame(rows).sort(dim)
+
+
+def compute_profiles(dataset: pl.DataFrame, profile: SeasonalityProfileSpec) -> Dict[str, pl.DataFrame]:
+    """Compute seasonality profiles for the requested dimensions."""
+
+    result: Dict[str, pl.DataFrame] = {}
+    if profile.by_hour:
+        result["hour"] = _aggregate_dimension(dataset, "hour", profile)
+    if profile.by_dow:
+        result["dow"] = _aggregate_dimension(dataset, "dow", profile)
+    if profile.by_month:
+        result["month"] = _aggregate_dimension(dataset, "month", profile)
+    return result
+
+
+def iter_active_bins(profile: SeasonalityProfileSpec) -> Iterable[str]:
+    """Yield the dimensions enabled by the profile specification."""
+
+    if profile.by_hour:
+        yield "hour"
+    if profile.by_dow:
+        yield "dow"
+    if profile.by_month:
+        yield "month"

--- a/src/quant_engine/seasonality/profiles.py
+++ b/src/quant_engine/seasonality/profiles.py
@@ -1,0 +1,65 @@
+"""Helpers to work with seasonality profiles."""
+from __future__ import annotations
+
+from typing import Dict, Mapping, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
+    pl = None  # type: ignore
+
+
+def _require_polars() -> None:
+    if pl is None:  # pragma: no cover - exercised when dependency missing
+        raise RuntimeError("polars is required for seasonality computations")
+
+from ..api.schemas import SeasonalityProfileSpec, SeasonalitySignalSpec
+
+
+def select_active_bins(
+    profiles: Mapping[str, pl.DataFrame],
+    signal_spec: SeasonalitySignalSpec,
+    profile_spec: SeasonalityProfileSpec,
+) -> Dict[str, Sequence]:
+    """Return the active bins for each dimension according to the strategy."""
+
+    active: Dict[str, Sequence] = {}
+    _require_polars()
+    for dim in signal_spec.dims:
+        table = profiles.get(dim)
+        if table is None or table.is_empty():
+            continue
+        selected = _select_bins_for_dimension(table, signal_spec, profile_spec)
+        if selected:
+            active[dim] = selected
+    return active
+
+
+def _select_bins_for_dimension(
+    table: pl.DataFrame,
+    signal_spec: SeasonalitySignalSpec,
+    profile_spec: SeasonalityProfileSpec,
+) -> Sequence:
+    _require_polars()
+    metric_col = "p_hat" if profile_spec.measure == "direction" else "mean_ret"
+    if signal_spec.method == "threshold":
+        threshold = signal_spec.threshold
+        if profile_spec.measure == "return":
+            mask = table[metric_col] >= threshold
+        else:
+            mask = table[metric_col] >= threshold
+        filtered = table.filter(mask)
+    else:
+        sorted_table = table.sort(metric_col, descending=True)
+        filtered = sorted_table.head(signal_spec.topk)
+    return filtered.get_column(table.columns[0]).to_list()
+
+
+def summarise_profiles(profiles: Mapping[str, pl.DataFrame]) -> Dict[str, list[Dict[str, object]]]:
+    """Return a serialisable representation of the computed profiles."""
+
+    _require_polars()
+    serialised: Dict[str, list[Dict[str, object]]] = {}
+    for dim, table in profiles.items():
+        serialised[dim] = table.to_dicts()
+    return serialised

--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -1,0 +1,104 @@
+"""Top-level orchestration for seasonality studies."""
+from __future__ import annotations
+
+from math import sqrt
+from pathlib import Path
+from typing import Dict, Any
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
+    pl = None  # type: ignore
+
+from ..api.schemas import SeasonalitySpec
+from ..signals.seasonality_signal import build_seasonality_signal
+from . import compute, profiles, spec
+
+
+def _require_polars() -> None:
+    if pl is None:  # pragma: no cover - exercised when dependency missing
+        raise RuntimeError("polars is required for seasonality runs")
+
+
+def _load_dataset(path: Path) -> pl.DataFrame:
+    """Load a dataset from disk inferring the format from the extension."""
+
+    _require_polars()
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.suffix.lower() in {".parquet", ".pq"}:
+        return pl.read_parquet(path)
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pl.read_csv(path, try_parse_dates=True)
+    raise ValueError(f"Unsupported dataset format: {path.suffix}")
+
+
+def _ensure_datetime(df: pl.DataFrame) -> pl.DataFrame:
+    _require_polars()
+    if df.is_empty():
+        return df
+    if df.schema.get("timestamp") == pl.Datetime:
+        return df
+    if df.schema.get("timestamp") == pl.Utf8:
+        return df.with_columns(pl.col("timestamp").str.strptime(pl.Datetime, strict=False))
+    return df.with_columns(pl.col("timestamp").cast(pl.Datetime))
+
+
+def run(spec_model: SeasonalitySpec) -> Dict[str, Any]:
+    """Execute a seasonality workflow and return the summary."""
+
+    _require_polars()
+    cfg = spec.normalise(spec_model)
+    df = _load_dataset(cfg.dataset_path)
+    df = _ensure_datetime(df)
+    if "symbol" in df.columns:
+        df = df.filter(pl.col("symbol").is_in(cfg.symbols))
+    if not df.is_empty():
+        df = df.filter(
+            (pl.col("timestamp") >= cfg.start) & (pl.col("timestamp") <= cfg.end)
+        )
+    artifact_paths: list[str] = []
+    if cfg.artifacts.out_dir:
+        artifact_paths.append(str(Path(cfg.artifacts.out_dir)))
+
+    if df.is_empty():
+        return {
+            "summary": {"n_rows": 0, "n_trades": 0, "best_bins": {}},
+            "profiles": {},
+            "signal": {"active_bins": {}},
+            "artifacts": artifact_paths,
+        }
+
+    features = compute.prepare_features(df, cfg.profile)
+    profiles_map = compute.compute_profiles(features, cfg.profile)
+    active_bins = profiles.select_active_bins(profiles_map, cfg.signal, cfg.profile)
+    signal_df = build_seasonality_signal(features, active_bins, cfg.signal.combine)
+
+    trades = signal_df.filter(pl.col("long") == 1)
+    returns = (
+        trades.get_column("forward_ret")
+        if "forward_ret" in trades.columns
+        else pl.Series(name="forward_ret", values=[], dtype=pl.Float64)
+    )
+    returns = returns.drop_nulls()
+    n_trades = int(trades.height)
+    avg_return = float(returns.mean()) if returns.len() else 0.0
+    std_return = float(returns.std()) if returns.len() > 1 else 0.0
+    hit_rate = float((returns > 0).sum() / returns.len()) if returns.len() else 0.0
+    sharpe = (avg_return / std_return * sqrt(252)) if std_return else 0.0
+
+    summary = {
+        "n_rows": int(df.height),
+        "n_trades": n_trades,
+        "avg_return": avg_return,
+        "hit_rate": hit_rate,
+        "sharpe": sharpe,
+        "best_bins": {dim: list(bins) for dim, bins in active_bins.items()},
+    }
+
+    return {
+        "summary": summary,
+        "profiles": profiles.summarise_profiles(profiles_map),
+        "signal": {"active_bins": summary["best_bins"]},
+        "artifacts": artifact_paths,
+    }

--- a/src/quant_engine/seasonality/spec.py
+++ b/src/quant_engine/seasonality/spec.py
@@ -1,0 +1,57 @@
+"""Utilities to normalise seasonality specifications."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from ..api.schemas import (
+    SeasonalitySpec,
+    SeasonalityProfileSpec,
+    SeasonalitySignalSpec,
+    ExecutionSpec,
+    RiskSpec,
+    TPSSLSpec,
+    ValidationSpec,
+    ArtifactsSpec,
+    PersistenceSpec,
+)
+
+
+@dataclass
+class NormalisedSeasonalitySpec:
+    dataset_path: Path
+    symbols: list[str]
+    timeframe: str
+    start: datetime
+    end: datetime
+    profile: SeasonalityProfileSpec
+    signal: SeasonalitySignalSpec
+    execution: ExecutionSpec
+    risk: RiskSpec
+    tp_sl: TPSSLSpec
+    validation: ValidationSpec
+    artifacts: ArtifactsSpec
+    persistence: PersistenceSpec
+
+
+def normalise(spec: SeasonalitySpec) -> NormalisedSeasonalitySpec:
+    """Convert the Pydantic specification into python-native objects."""
+
+    start = datetime.fromisoformat(spec.data.start)
+    end = datetime.fromisoformat(spec.data.end)
+    return NormalisedSeasonalitySpec(
+        dataset_path=Path(spec.data.dataset_path),
+        symbols=list(spec.data.symbols),
+        timeframe=spec.data.timeframe,
+        start=start,
+        end=end,
+        profile=spec.profile,
+        signal=spec.signal,
+        execution=spec.execution,
+        risk=spec.risk,
+        tp_sl=spec.tp_sl,
+        validation=spec.validation,
+        artifacts=spec.artifacts,
+        persistence=spec.persistence,
+    )

--- a/src/quant_engine/signals/seasonality_signal.py
+++ b/src/quant_engine/signals/seasonality_signal.py
@@ -1,0 +1,60 @@
+"""Helpers to convert seasonality profiles into trading signals."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
+    pl = None  # type: ignore
+
+
+def _require_polars() -> None:
+    if pl is None:  # pragma: no cover - exercised when dependency missing
+        raise RuntimeError("polars is required for seasonality signals")
+
+
+DIMENSION_TO_COLUMN = {
+    "hour": "hour",
+    "dow": "dow",
+    "month": "month",
+}
+
+
+def _combine_masks(masks: Sequence[pl.Expr], method: str) -> pl.Expr:
+    _require_polars()
+    if not masks:
+        return pl.lit(False)
+    if method == "and":
+        return pl.all_horizontal(masks)
+    if method == "or":
+        return pl.any_horizontal(masks)
+    # sum -> at least one match
+    summed = pl.sum_horizontal([expr.cast(pl.Int64) for expr in masks])
+    return summed.gt(0)
+
+
+def build_seasonality_signal(
+    dataset: pl.DataFrame,
+    active_bins: Mapping[str, Iterable],
+    combine: str = "and",
+) -> pl.DataFrame:
+    """Return the dataset with long/short columns for the seasonality signal."""
+
+    df = dataset
+    _require_polars()
+    masks: list[pl.Expr] = []
+    for dim, bins in active_bins.items():
+        column = DIMENSION_TO_COLUMN.get(dim)
+        if column is None or not bins:
+            continue
+        masks.append(pl.col(column).is_in(list(bins)))
+    if masks:
+        long_expr = _combine_masks(masks, combine).cast(pl.Int64)
+    else:
+        long_expr = pl.lit(0, dtype=pl.Int64)
+    df = df.with_columns(
+        long_expr.alias("long"),
+        pl.lit(0, dtype=pl.Int64).alias("short"),
+    )
+    return df


### PR DESCRIPTION
## Summary
- add Seasonality spec models and defaults to the API schemas module
- implement seasonality compute/profile/signal helpers with a runner orchestrator
- expose the seasonality run endpoint together with a CLI command

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1e9fffec8323af1de4b9e0cfb138