### PR TITLE
Implement seasonality signal rules and backtest

### DIFF
--- a/src/quant_engine/seasonality/profiles.py
+++ b/src/quant_engine/seasonality/profiles.py
@@ -1,7 +1,8 @@
 """Helpers to work with seasonality profiles."""
 from __future__ import annotations
 
-from typing import Dict, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Dict, MutableMapping, Sequence
 
 try:  # pragma: no cover - optional dependency
     import polars as pl
@@ -13,49 +14,135 @@ def _require_polars() -> None:
     if pl is None:  # pragma: no cover - exercised when dependency missing
         raise RuntimeError("polars is required for seasonality computations")
 
-from ..api.schemas import SeasonalityProfileSpec, SeasonalitySignalSpec
+@dataclass
+class SeasonalityRules:
+    """Container holding the active bins and metadata for a signal."""
+
+    active_bins: Dict[str, set[int]] = field(default_factory=dict)
+    combine: str = "and"
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def to_serialisable(self) -> Dict[str, Any]:
+        """Return a JSON-friendly representation of the rules."""
+
+        return {
+            "active_bins": {dim: sorted(bins) for dim, bins in self.active_bins.items()},
+            "combine": self.combine,
+            "metadata": dict(self.metadata),
+        }
 
 
-def select_active_bins(
-    profiles: pl.DataFrame,
-    signal_spec: SeasonalitySignalSpec,
-    profile_spec: SeasonalityProfileSpec,
-) -> Dict[str, Sequence]:
-    """Return the active bins for each dimension according to the strategy."""
+def _score_column(measure: str, table: pl.DataFrame) -> str | None:
+    """Return the name of the score column used for ranking bins."""
 
-    _require_polars()
-    active: Dict[str, Sequence] = {}
-    if profiles.is_empty():
-        return active
+    preferred = ["p_hat", "lift"] if measure == "direction" else ["ret_mean", "lift"]
+    for col in preferred:
+        if col in table.columns:
+            return col
+    return None
 
-    for dim in signal_spec.dims:
-        selected = _select_bins_for_dimension(profiles, dim, signal_spec, profile_spec)
-        if selected:
-            active[dim] = selected
-    return active
+
+def _normalise_threshold(threshold: float | None, measure: str) -> float | None:
+    """Normalise the threshold according to the measure semantics."""
+
+    if threshold is None:
+        return None
+    if measure != "return":
+        return float(threshold)
+    value = float(threshold)
+    if abs(value) >= 0.01:
+        # Treat large magnitudes as basis points for convenience.
+        return value / 10000.0
+    return value
 
 
 def _select_bins_for_dimension(
-    profiles: pl.DataFrame,
-    dim: str,
-    signal_spec: SeasonalitySignalSpec,
-    profile_spec: SeasonalityProfileSpec,
-) -> Sequence:
-    _require_polars()
-    metric_col = "p_hat" if profile_spec.measure == "direction" else "ret_mean"
-    table = profiles.filter((pl.col("dim") == dim) & (~pl.col("insufficient")))
+    table: pl.DataFrame,
+    *,
+    method: str,
+    threshold: float | None,
+    topk: int,
+    score_col: str,
+) -> tuple[set[int], float | None]:
+    """Return the selected bins for a single dimension."""
+
+    table = table.filter(pl.col(score_col).is_not_null())
     if table.is_empty():
-        return []
-    table = table.filter(pl.col(metric_col).is_not_null())
-    if table.is_empty():
-        return []
-    if signal_spec.method == "threshold":
-        filtered = table.filter(pl.col(metric_col) >= signal_spec.threshold)
+        return set(), None
+    if method == "threshold":
+        thr = threshold if threshold is not None else float("-inf")
+        filtered = table.filter(pl.col(score_col) >= thr)
+        cutoff = thr
     else:
-        filtered = table.sort(metric_col, descending=True).head(signal_spec.topk)
+        k = max(int(topk), 0)
+        if k == 0:
+            return set(), None
+        filtered = table.sort(score_col, descending=True).head(k)
+        cutoff = (
+            float(filtered.get_column(score_col).min()) if not filtered.is_empty() else None
+        )
     if filtered.is_empty():
-        return []
-    return filtered.get_column("bin").to_list()
+        return set(), cutoff
+    bins = set(int(b) for b in filtered.get_column("bin").to_list())
+    return bins, cutoff
+
+
+def select_bins(
+    profiles: pl.DataFrame,
+    *,
+    method: str = "threshold",
+    threshold: float | None = 0.54,
+    topk: int = 3,
+    dims: Sequence[str] | None = None,
+    measure: str = "direction",
+    combine: str = "and",
+) -> SeasonalityRules:
+    """Convert profile tables into tradable rules."""
+
+    _require_polars()
+    if profiles.is_empty():
+        return SeasonalityRules(metadata={"thresholds": {}, "counts": {}})
+
+    requested_dims = list(dims) if dims is not None else []
+    if not requested_dims:
+        requested_dims = profiles.get_column("dim").unique().cast(pl.Utf8).to_list()
+
+    normalised_threshold = _normalise_threshold(threshold, measure)
+    active: Dict[str, set[int]] = {}
+    thresholds_meta: Dict[str, float | None] = {}
+    counts_meta: Dict[str, int] = {}
+
+    for dim in requested_dims:
+        table = profiles.filter((pl.col("dim") == dim) & (~pl.col("insufficient")))
+        if table.is_empty():
+            active[dim] = set()
+            thresholds_meta[dim] = normalised_threshold
+            counts_meta[dim] = 0
+            continue
+        score_col = _score_column(measure, table)
+        if score_col is None:
+            active[dim] = set()
+            thresholds_meta[dim] = normalised_threshold
+            counts_meta[dim] = 0
+            continue
+        bins, cutoff = _select_bins_for_dimension(
+            table,
+            method=method,
+            threshold=normalised_threshold,
+            topk=topk,
+            score_col=score_col,
+        )
+        active[dim] = bins
+        thresholds_meta[dim] = cutoff if cutoff is not None else normalised_threshold
+        counts_meta[dim] = len(bins)
+
+    metadata: Dict[str, Any] = {
+        "thresholds": thresholds_meta,
+        "counts": counts_meta,
+        "method": method,
+        "measure": measure,
+    }
+    return SeasonalityRules(active_bins=active, combine=combine, metadata=metadata)
 
 
 def summarise_profiles(profiles: pl.DataFrame) -> Dict[str, list[Dict[str, object]]]:

--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -1,9 +1,9 @@
 """Top-level orchestration for seasonality studies."""
 from __future__ import annotations
 
-from math import sqrt
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict, List, Sequence
 
 try:  # pragma: no cover - optional dependency
     import polars as pl
@@ -11,7 +11,13 @@ except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
     pl = None  # type: ignore
 
 from ..api.schemas import SeasonalitySpec
-from ..signals.seasonality_signal import build_seasonality_signal
+from ..backtest import engine
+from ..core import dataset as core_dataset
+from ..core.features import atr
+from ..core.spec import DataSpec
+from ..io import artifacts
+from ..signals.seasonality_signal import make_seasonality_signals
+from ..validate import splitter
 from . import compute, profiles, spec
 
 
@@ -20,97 +26,241 @@ def _require_polars() -> None:
         raise RuntimeError("polars is required for seasonality runs")
 
 
-def _load_dataset(path: Path) -> pl.DataFrame:
-    """Load a dataset from disk inferring the format from the extension."""
+def _rows_to_polars(rows: Sequence[Dict[str, Any]]) -> pl.DataFrame:
+    """Return a Polars dataframe from the list-based dataset representation."""
 
     _require_polars()
-    if not path.exists():
-        raise FileNotFoundError(path)
-    if path.suffix.lower() in {".parquet", ".pq"}:
-        return pl.read_parquet(path)
-    if path.suffix.lower() in {".csv", ".txt"}:
-        return pl.read_csv(path, try_parse_dates=True)
-    raise ValueError(f"Unsupported dataset format: {path.suffix}")
+    if not rows:
+        return pl.DataFrame()
+    df = pl.DataFrame(rows)
+    if "timestamp" in df.columns:
+        ts_dtype = df.schema.get("timestamp")
+        if ts_dtype == pl.Utf8:
+            df = df.with_columns(
+                pl.col("timestamp").str.strptime(pl.Datetime, strict=False)
+            )
+        elif ts_dtype != pl.Datetime:
+            df = df.with_columns(pl.col("timestamp").cast(pl.Datetime))
+    return df
 
 
-def _ensure_datetime(df: pl.DataFrame) -> pl.DataFrame:
-    _require_polars()
-    if df.is_empty():
-        return df
-    if df.schema.get("timestamp") == pl.Datetime:
-        return df
-    if df.schema.get("timestamp") == pl.Utf8:
-        return df.with_columns(pl.col("timestamp").str.strptime(pl.Datetime, strict=False))
-    return df.with_columns(pl.col("timestamp").cast(pl.Datetime))
+def _default_rules_metadata(rules: profiles.SeasonalityRules) -> Dict[str, Any]:
+    meta = dict(rules.metadata)
+    meta.setdefault("thresholds", {})
+    meta.setdefault("counts", {dim: len(bins) for dim, bins in rules.active_bins.items()})
+    return meta
+
+
+def _compute_profiles(
+    dataset: pl.DataFrame,
+    cfg: spec.NormalisedSeasonalitySpec,
+    fold_dir: Path | None,
+) -> pl.DataFrame:
+    horizon_features = compute.prepare_features(dataset, cfg.profile)
+    profiles_path = str(fold_dir) if fold_dir is not None else None
+    return compute.compute_profiles(
+        horizon_features,
+        cfg.profile,
+        timeframe=cfg.timeframe,
+        period_start=None,
+        period_end=None,
+        artifacts_out_dir=profiles_path,
+    )
+
+
+def _rules_from_profiles(
+    profiles_df: pl.DataFrame,
+    cfg: spec.NormalisedSeasonalitySpec,
+) -> profiles.SeasonalityRules:
+    return profiles.select_bins(
+        profiles_df,
+        method=cfg.signal.method,
+        threshold=cfg.signal.threshold,
+        topk=cfg.signal.topk,
+        dims=cfg.signal.dims,
+        measure=cfg.profile.measure,
+        combine=cfg.signal.combine,
+    )
+
+
+@dataclass
+class FoldResult:
+    index: int
+    metrics: Dict[str, Any]
+    rules: profiles.SeasonalityRules
+    profiles_path: Path | None
+    summary_path: Path | None
+    trades_path: Path | None
+    equity_path: Path | None
+
+
+def _build_signals(
+    rows: List[Dict[str, Any]],
+    rules: profiles.SeasonalityRules,
+) -> List[int]:
+    df = _rows_to_polars(rows)
+    df = compute.add_time_bins(df)
+    df = make_seasonality_signals(df, rules)
+    return [1 if bool(v) else 0 for v in df.get_column("long").to_list()]
+
+
+def _atr_settings(tp_sl) -> tuple[float, float]:
+    atr_mult = float(tp_sl.stop_loss) if tp_sl.stop_loss is not None else 1.0
+    r_mult = float(tp_sl.take_profit) if tp_sl.take_profit is not None else 1.0
+    return atr_mult, r_mult
 
 
 def run(spec_model: SeasonalitySpec) -> Dict[str, Any]:
-    """Execute a seasonality workflow and return the summary."""
+    """Execute a seasonality workflow and return aggregated metrics."""
 
     _require_polars()
     cfg = spec.normalise(spec_model)
-    df = _load_dataset(cfg.dataset_path)
-    df = _ensure_datetime(df)
-    if "symbol" in df.columns:
-        df = df.filter(pl.col("symbol").is_in(cfg.symbols))
-    if not df.is_empty():
-        df = df.filter(
-            (pl.col("timestamp") >= cfg.start) & (pl.col("timestamp") <= cfg.end)
-        )
-    artifact_paths: list[str] = []
-    profiles_artifact: Path | None = None
-    if cfg.artifacts.out_dir:
-        out_dir = Path(cfg.artifacts.out_dir)
-        artifact_paths.append(str(out_dir))
-        profiles_artifact = out_dir / "seasonality_profiles.parquet"
+    data_spec = DataSpec(
+        path=str(cfg.dataset_path),
+        symbols=list(cfg.symbols),
+        start=cfg.start.date(),
+        end=cfg.end.date(),
+    )
+    rows = core_dataset.load_dataset(data_spec)
 
-    if df.is_empty():
+    if not rows:
         return {
-            "summary": {"n_rows": 0, "n_trades": 0, "best_bins": {}},
-            "profiles": {},
-            "signal": {"active_bins": {}},
-            "artifacts": artifact_paths,
+            "best_metrics": {},
+            "active_bins": {},
+            "artifacts": {},
+            "folds": [],
         }
 
-    features = compute.prepare_features(df, cfg.profile)
-    profiles_df = compute.compute_profiles(
-        features,
-        cfg.profile,
-        timeframe=cfg.timeframe,
-        period_start=cfg.start,
-        period_end=cfg.end,
-        artifacts_out_dir=cfg.artifacts.out_dir,
-    )
-    if profiles_artifact is not None:
-        artifact_paths.append(str(profiles_artifact))
-    active_bins = profiles.select_active_bins(profiles_df, cfg.signal, cfg.profile)
-    signal_df = build_seasonality_signal(features, active_bins, cfg.signal.combine)
+    artifact_root: Path | None = None
+    if cfg.artifacts.out_dir:
+        artifact_root = Path(cfg.artifacts.out_dir)
+        artifact_root.mkdir(parents=True, exist_ok=True)
 
-    trades = signal_df.filter(pl.col("long") == 1)
-    returns = (
-        trades.get_column("forward_ret")
-        if "forward_ret" in trades.columns
-        else pl.Series(name="forward_ret", values=[], dtype=pl.Float64)
-    )
-    returns = returns.drop_nulls()
-    n_trades = int(trades.height)
-    avg_return = float(returns.mean()) if returns.len() else 0.0
-    std_return = float(returns.std()) if returns.len() > 1 else 0.0
-    hit_rate = float((returns > 0).sum() / returns.len()) if returns.len() else 0.0
-    sharpe = (avg_return / std_return * sqrt(252)) if std_return else 0.0
+    if cfg.validation.folds > 1:
+        folds = splitter.generate_folds(
+            rows,
+            cfg.validation.train_months,
+            cfg.validation.test_months,
+            cfg.validation.folds,
+            cfg.validation.embargo_days,
+        )
+    else:
+        folds = [{"train": rows, "test": rows}]
 
-    summary = {
-        "n_rows": int(df.height),
-        "n_trades": n_trades,
-        "avg_return": avg_return,
-        "hit_rate": hit_rate,
-        "sharpe": sharpe,
-        "best_bins": {dim: list(bins) for dim, bins in active_bins.items()},
-    }
+    if not folds:
+        folds = [{"train": rows, "test": rows}]
+
+    best_result: FoldResult | None = None
+    fold_summaries: List[Dict[str, Any]] = []
+    atr_mult, r_mult = _atr_settings(cfg.tp_sl)
+
+    for idx, fold in enumerate(folds):
+        train_rows = fold.get("train", [])
+        test_rows = fold.get("test", [])
+        if not train_rows or not test_rows:
+            continue
+
+        train_df = _rows_to_polars(train_rows)
+        if train_df.is_empty():
+            continue
+
+        fold_dir = artifact_root / f"fold_{idx}" if artifact_root is not None else None
+        if fold_dir is not None:
+            fold_dir.mkdir(parents=True, exist_ok=True)
+
+        profiles_df = _compute_profiles(train_df, cfg, fold_dir)
+        if profiles_df.is_empty():
+            continue
+
+        rules = _rules_from_profiles(profiles_df, cfg)
+        signals = _build_signals(test_rows, rules)
+        if not signals:
+            continue
+
+        atr_values = atr.compute(test_rows)
+        trades, equity, metrics = engine.run(
+            test_rows,
+            signals,
+            atr_values,
+            atr_mult,
+            r_mult,
+            cfg.execution.slippage_bps,
+            cfg.execution.commission_bps,
+        )
+
+        metrics = dict(metrics)
+        metrics["fold_index"] = idx
+        metrics["n_trades"] = int(metrics.get("trades", 0))
+        metrics["rules_counts"] = {
+            dim: len(bins) for dim, bins in rules.active_bins.items()
+        }
+        fold_summary = {
+            "fold": idx,
+            "metrics": metrics,
+            "rules": rules.to_serialisable(),
+        }
+        fold_summaries.append(fold_summary)
+
+        meets_min_trades = metrics["n_trades"] >= cfg.validation.min_trades
+        is_better = (
+            meets_min_trades
+            and (
+                best_result is None
+                or metrics.get("sharpe", 0.0) > best_result.metrics.get("sharpe", 0.0)
+            )
+        )
+
+        profiles_path = (
+            fold_dir / "seasonality_profiles.parquet" if fold_dir is not None else None
+        )
+
+        if is_better:
+            summary_path = None
+            trades_path = None
+            equity_path = None
+            if fold_dir is not None:
+                summary_payload = {
+                    "metrics": metrics,
+                    "rules": rules.to_serialisable(),
+                }
+                summary_path = fold_dir / "summary.json"
+                artifacts.write_summary(summary_path, summary_payload)
+                trades_path = fold_dir / "trades.parquet"
+                equity_path = fold_dir / "equity.parquet"
+                artifacts.write_trades(trades_path, trades)
+                artifacts.write_equity(equity_path, equity)
+            best_result = FoldResult(
+                index=idx,
+                metrics=metrics,
+                rules=rules,
+                profiles_path=profiles_path,
+                summary_path=summary_path,
+                trades_path=trades_path,
+                equity_path=equity_path,
+            )
+
+    if best_result is None:
+        return {
+            "best_metrics": {},
+            "active_bins": {},
+            "artifacts": {},
+            "folds": fold_summaries,
+        }
+
+    artifacts_info: Dict[str, Any] = {}
+    if best_result.profiles_path is not None and best_result.profiles_path.exists():
+        artifacts_info["profiles"] = str(best_result.profiles_path)
+    if best_result.summary_path is not None:
+        artifacts_info["summary"] = str(best_result.summary_path)
+    if best_result.trades_path is not None:
+        artifacts_info["trades"] = str(best_result.trades_path)
+    if best_result.equity_path is not None:
+        artifacts_info["equity"] = str(best_result.equity_path)
 
     return {
-        "summary": summary,
-        "profiles": profiles.summarise_profiles(profiles_df),
-        "signal": {"active_bins": summary["best_bins"]},
-        "artifacts": artifact_paths,
+        "best_metrics": best_result.metrics,
+        "active_bins": best_result.rules.to_serialisable()["active_bins"],
+        "rules_metadata": _default_rules_metadata(best_result.rules),
+        "artifacts": artifacts_info,
+        "folds": fold_summaries,
     }

--- a/src/quant_engine/signals/seasonality_signal.py
+++ b/src/quant_engine/signals/seasonality_signal.py
@@ -8,6 +8,8 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover - used when dependency missing
     pl = None  # type: ignore
 
+from ..seasonality.profiles import SeasonalityRules
+
 
 def _require_polars() -> None:
     if pl is None:  # pragma: no cover - exercised when dependency missing
@@ -21,7 +23,14 @@ DIMENSION_TO_COLUMN = {
 }
 
 
-def _combine_masks(masks: Sequence[pl.Expr], method: str) -> pl.Expr:
+def _combine_masks(
+    masks: Sequence[pl.Expr],
+    method: str,
+    *,
+    sum_threshold: int = 1,
+) -> pl.Expr:
+    """Combine the per-dimension activation masks according to ``method``."""
+
     _require_polars()
     if not masks:
         return pl.lit(False)
@@ -29,32 +38,28 @@ def _combine_masks(masks: Sequence[pl.Expr], method: str) -> pl.Expr:
         return pl.all_horizontal(masks)
     if method == "or":
         return pl.any_horizontal(masks)
-    # sum -> at least one match
     summed = pl.sum_horizontal([expr.cast(pl.Int64) for expr in masks])
-    return summed.gt(0)
+    return summed.ge(sum_threshold)
 
 
-def build_seasonality_signal(
-    dataset: pl.DataFrame,
-    active_bins: Mapping[str, Iterable],
-    combine: str = "and",
-) -> pl.DataFrame:
-    """Return the dataset with long/short columns for the seasonality signal."""
+def make_seasonality_signals(dataset: pl.DataFrame, rules: SeasonalityRules) -> pl.DataFrame:
+    """Return the dataset with boolean long/short signal columns."""
 
-    df = dataset
     _require_polars()
+    df = dataset
     masks: list[pl.Expr] = []
-    for dim, bins in active_bins.items():
+    for dim, bins in rules.active_bins.items():
         column = DIMENSION_TO_COLUMN.get(dim)
         if column is None or not bins:
             continue
         masks.append(pl.col(column).is_in(list(bins)))
     if masks:
-        long_expr = _combine_masks(masks, combine).cast(pl.Int64)
+        sum_threshold = int(rules.metadata.get("sum_threshold", 1)) if rules.metadata else 1
+        long_expr = _combine_masks(masks, rules.combine, sum_threshold=sum_threshold)
     else:
-        long_expr = pl.lit(0, dtype=pl.Int64)
+        long_expr = pl.lit(False)
     df = df.with_columns(
         long_expr.alias("long"),
-        pl.lit(0, dtype=pl.Int64).alias("short"),
+        pl.lit(False).alias("short"),
     )
     return df


### PR DESCRIPTION
## Summary
- introduce `SeasonalityRules` data structure and new `select_bins` helper for filtering active bins by threshold/top-k with metadata
- add seasonality signal builder that produces boolean long/short columns supporting different combination modes
- rework seasonality runner to load datasets via core loader, derive rules per fold, run backtests with the engine, and persist artefacts/metrics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc286d56688323b4b0cd96214396b4