### PR TITLE
Add persistence for seasonality runs and profiles

### DIFF
--- a/src/quant_engine/persistence/__init__.py
+++ b/src/quant_engine/persistence/__init__.py
@@ -2,7 +2,11 @@
 
 from .db import connect, init_db, session
 from .repositories import RunsRepository, MetricsRepository, TrialsRepository
-from .repo import MarketStatsRepository
+from .repo import (
+    MarketStatsRepository,
+    SeasonalityProfilesRepository,
+    SeasonalityRunsRepository,
+)
 
 __all__ = [
     "connect",
@@ -12,5 +16,7 @@ __all__ = [
     "MetricsRepository",
     "TrialsRepository",
     "MarketStatsRepository",
+    "SeasonalityProfilesRepository",
+    "SeasonalityRunsRepository",
 ]
 

--- a/src/quant_engine/persistence/db.py
+++ b/src/quant_engine/persistence/db.py
@@ -168,6 +168,54 @@ def init_db(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS seasonality_profiles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol TEXT NOT NULL,
+            timeframe TEXT,
+            dim TEXT NOT NULL,
+            bin INTEGER NOT NULL,
+            measure TEXT NOT NULL,
+            score REAL,
+            n INTEGER,
+            baseline REAL,
+            lift REAL,
+            start TEXT,
+            end TEXT,
+            spec_id TEXT,
+            dataset_id TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(symbol, timeframe, dim, bin, measure, start, end, spec_id, dataset_id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_seasonality_profiles_lookup
+        ON seasonality_profiles(symbol, timeframe, dim, measure)
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS seasonality_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL UNIQUE,
+            spec_id TEXT,
+            dataset_id TEXT,
+            out_dir TEXT,
+            status TEXT NOT NULL,
+            best_summary TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_seasonality_runs_run_id
+        ON seasonality_runs(run_id)
+        """
+    )
     conn.commit()
 
 

--- a/src/quant_engine/persistence/models.py
+++ b/src/quant_engine/persistence/models.py
@@ -31,5 +31,40 @@ class MarketStat:
     created_at: str | None = None
 
 
-__all__ = ["MarketStat"]
+@dataclass
+class SeasonalityProfile:
+    """Represents a row in the ``seasonality_profiles`` table."""
+
+    id: Optional[int] = None
+    symbol: str | None = None
+    timeframe: str | None = None
+    dim: str | None = None
+    bin: int | None = None
+    measure: str | None = None
+    score: float | None = None
+    n: int | None = None
+    baseline: float | None = None
+    lift: float | None = None
+    start: str | None = None
+    end: str | None = None
+    spec_id: str | None = None
+    dataset_id: str | None = None
+    created_at: str | None = None
+
+
+@dataclass
+class SeasonalityRun:
+    """Represents a row in the ``seasonality_runs`` table."""
+
+    id: Optional[int] = None
+    run_id: str | None = None
+    spec_id: str | None = None
+    dataset_id: str | None = None
+    out_dir: str | None = None
+    status: str | None = None
+    best_summary: Any = None
+    created_at: str | None = None
+
+
+__all__ = ["MarketStat", "SeasonalityProfile", "SeasonalityRun"]
 


### PR DESCRIPTION
## Summary
- add seasonality run and profile models, repositories, and schema migrations for SQLite persistence
- persist seasonality best-run artefacts when enabled and expose run IDs from the runner
- implement seasonality persistence API endpoints with coverage in the persistence API test suite

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc2ddc23b08323ae2b0cd9a5ec3415