### PR TITLE
Add seasonality smoke test and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,58 @@ poetry run quant-engine stats show --symbol EURUSD --event k_consecutive --targe
 - `GET /stats/result`
 - `GET /stats`
 
+## Seasonality Backtest
+
+### Exemple de spécification
+
+```json
+{
+  "data": {
+    "dataset_path": "data/eurusd_m1_2025H1.csv",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01",
+    "end": "2025-06-30"
+  },
+  "profile": {
+    "by_hour": true,
+    "by_dow": true,
+    "by_month": false,
+    "measure": "direction",
+    "ret_horizon": 1,
+    "min_samples_bin": 300
+  },
+  "signal": {
+    "method": "threshold",
+    "threshold": 0.54,
+    "dims": ["hour", "dow"],
+    "combine": "and"
+  },
+  "execution": { "slippage_bps": 0.5, "fee_bps": 0.2 },
+  "risk": { "position_sizing": "fixed_fraction", "risk_per_trade": 0.005 },
+  "tp_sl": {
+    "stop": { "type": "fixed_atr", "atr_mult": 1.5 },
+    "take_profit": { "type": "r_multiple", "r_values": [1, 2, 3, 4, 5] }
+  },
+  "validation": { "scheme": "walk_forward", "train_months": 2, "test_months": 1, "folds": 3, "embargo_days": 2 },
+  "artifacts": { "out_dir": "runs/seasonality_eurusd_m1_2025H1", "save_equity": true, "save_trades": true },
+  "persistence": { "store_trades_in_db": false, "store_equity_in_db": false }
+}
+```
+
+### CLI
+
+```bash
+poetry run qe seasonality run --spec specs/eurusd_m1_seasonality.json
+```
+
+### Dimensions & signal
+
+- `by_hour`, `by_dow`, `by_month` activent les agrégations par heure, jour de semaine ou mois pour les profils.
+- `measure` choisit la métrique : `direction` (taux de réussite) ou `return` (moyenne des rendements).
+- `threshold` / `topk` contrôlent la sélection des bins : seuil sur la proba ou top-k meilleurs profils.
+- `combine` indique comment combiner plusieurs dimensions (`and`, `or`, `sum`).
+
 ## 📖 Documentation
 
 - [Architecture & Récap Fonctionnel](docs/architecture_overview.md)

--- a/specs/eurusd_m1_seasonality.json
+++ b/specs/eurusd_m1_seasonality.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "dataset_path": "data/eurusd_m1_2025H1.csv",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01",
+    "end": "2025-06-30"
+  },
+  "profile": {
+    "by_hour": true,
+    "by_dow": true,
+    "by_month": false,
+    "measure": "direction",
+    "ret_horizon": 1,
+    "min_samples_bin": 300
+  },
+  "signal": {
+    "method": "threshold",
+    "threshold": 0.54,
+    "dims": ["hour", "dow"],
+    "combine": "and"
+  },
+  "execution": { "slippage_bps": 0.5, "fee_bps": 0.2 },
+  "risk": { "position_sizing": "fixed_fraction", "risk_per_trade": 0.005 },
+  "tp_sl": {
+    "stop": { "type": "fixed_atr", "atr_mult": 1.5 },
+    "take_profit": { "type": "r_multiple", "r_values": [1, 2, 3, 4, 5] }
+  },
+  "validation": { "scheme": "walk_forward", "train_months": 2, "test_months": 1, "folds": 3, "embargo_days": 2 },
+  "artifacts": { "out_dir": "runs/seasonality_eurusd_m1_2025H1", "save_equity": true, "save_trades": true },
+  "persistence": { "store_trades_in_db": false, "store_equity_in_db": false }
+}

--- a/src/quant_engine/core/dataset.py
+++ b/src/quant_engine/core/dataset.py
@@ -3,20 +3,63 @@
 The real project would use `polars` to read Parquet files.  The exercise
 environment does not provide these third party packages, therefore this
 module falls back to JSON input while keeping a compatible API.  The
-returned dataset is a list of dictionaries sorted by timestamp.
+returned dataset is a list of dictionaries sorted by timestamp.  CSV
+datasets are also supported to keep fixtures fully text-based.
 """
 from __future__ import annotations
 
+import csv
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List, Any
 
 from .spec import DataSpec
 
 
 def _parse_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value)
+
+
+def _parse_row_types(row: Dict[str, str]) -> Dict[str, Any]:
+    """Convert CSV row values to appropriate python types."""
+
+    parsed: Dict[str, Any] = {}
+    for key, value in row.items():
+        if value is None:
+            parsed[key] = None
+            continue
+        value = value.strip()
+        if value == "":
+            parsed[key] = None
+            continue
+        if key == "timestamp" or key == "symbol":
+            parsed[key] = value
+            continue
+        # Attempt integer then float conversion, falling back to the raw string
+        try:
+            if "." not in value and "e" not in value and "E" not in value:
+                parsed[key] = int(value)
+                continue
+        except ValueError:
+            pass
+        try:
+            parsed[key] = float(value)
+            continue
+        except ValueError:
+            parsed[key] = value
+    return parsed
+
+
+def _read_dataset_rows(path: Path) -> List[Dict[str, Any]]:
+    """Return dataset rows from either JSON or CSV sources."""
+
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        with path.open(newline="") as handle:
+            reader = csv.DictReader(handle)
+            return [_parse_row_types(row) for row in reader]
+    return json.loads(path.read_text())
 
 
 def load_dataset(spec: DataSpec) -> List[Dict]:
@@ -26,7 +69,7 @@ def load_dataset(spec: DataSpec) -> List[Dict]:
     In a production setting this would read a Parquet file using ``polars``;
     here we rely on a simple JSON file for portability.
     """
-    raw = json.loads(Path(spec.path).read_text())
+    raw = _read_dataset_rows(Path(spec.path))
     out = []
     for row in raw:
         ts = _parse_timestamp(row["timestamp"]).date()

--- a/tests/test_seasonality_smoke.py
+++ b/tests/test_seasonality_smoke.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from quant_engine.api import schemas
+from quant_engine.seasonality import runner
+
+_ = pytest.importorskip("polars")
+
+
+def _write_synthetic_csv(path: Path, *, rows: int = 240) -> None:
+    start = datetime(2025, 1, 1, 0, 0)
+    price = 100.0
+    fieldnames = [
+        "timestamp",
+        "symbol",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for idx in range(rows):
+            ts = start + timedelta(hours=idx)
+            direction = 1 if ts.hour == 9 else 0
+            change = 0.02 if direction else -0.01
+            next_price = price * (1 + change)
+            writer.writerow(
+                {
+                    "timestamp": ts.isoformat(),
+                    "symbol": "TEST",
+                    "open": f"{price:.4f}",
+                    "high": f"{max(price, next_price) + 0.5:.4f}",
+                    "low": f"{min(price, next_price) - 0.5:.4f}",
+                    "close": f"{price:.4f}",
+                    "volume": "1000",
+                }
+            )
+            price = next_price
+
+
+def test_seasonality_smoke(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "seasonality.csv"
+    _write_synthetic_csv(dataset_path)
+
+    out_dir = tmp_path / "artifacts"
+    spec = schemas.SeasonalitySpec(
+        data=schemas.SeasonalityDataSpec(
+            dataset_path=str(dataset_path),
+            symbols=["TEST"],
+            timeframe="M1",
+            start="2025-01-01",
+            end="2025-01-20",
+        ),
+        profile=schemas.SeasonalityProfileSpec(
+            by_hour=True,
+            by_dow=False,
+            by_month=False,
+            measure="direction",
+            ret_horizon=1,
+            min_samples_bin=5,
+        ),
+        signal=schemas.SeasonalitySignalSpec(
+            method="threshold",
+            threshold=0.54,
+            dims=["hour"],
+            combine="and",
+        ),
+        validation=schemas.ValidationSpec(
+            min_trades=0,
+            train_months=0,
+            test_months=1,
+            folds=1,
+            embargo_days=0,
+        ),
+        artifacts=schemas.ArtifactsSpec(out_dir=str(out_dir)),
+    )
+
+    result = runner.run(spec)
+
+    profiles_path = out_dir / "fold_0" / "seasonality_profiles.parquet"
+    assert profiles_path.exists()
+    active_bins = result.get("active_bins", {})
+    assert active_bins.get("hour")


### PR DESCRIPTION
## Summary
- add a smoke test covering the seasonality runner with a synthetic CSV dataset
- extend dataset loading utilities to handle CSV inputs alongside JSON
- document the seasonality backtest workflow and add a sample specification file

## Testing
- poetry run pytest tests/test_seasonality_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68cc30c99d908323ac00b752d004d41b