### PR TITLE
Implement seasonality suggest_params

### DIFF
--- a/src/quant_engine/seasonality/optimize.py
+++ b/src/quant_engine/seasonality/optimize.py
@@ -14,7 +14,25 @@ def suggest_params(trial, spec):
         A dictionary of suggested parameter values for the optimization.
     """
 
-    pass
+    dims = trial.suggest_categorical(
+        "dims", [["hour"], ["dow"], ["hour", "dow"]]
+    )
+
+    method = trial.suggest_categorical("method", ["threshold", "topk"])
+    params = {
+        "dims": dims,
+        "method": method,
+        "combine": trial.suggest_categorical("combine", ["and", "or"]),
+        "ret_horizon": trial.suggest_int("ret_horizon", 1, 3),
+        "min_samples_bin": trial.suggest_int("min_samples_bin", 200, 700),
+    }
+
+    if method == "threshold":
+        params["threshold"] = trial.suggest_float("threshold", 0.52, 0.58)
+    else:
+        params["topk"] = trial.suggest_int("topk", 1, 6)
+
+    return params
 
 
 def evaluate_params(params, spec):


### PR DESCRIPTION
## Summary
- implement `suggest_params` to sample seasonality dimensions, selection method, combination mode, horizon, and minimum samples
- add conditional suggestions for threshold and top-k hyperparameters based on the chosen method

## Testing
- pytest tests/test_seasonality_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9c7f3af883239560fd5f4f37b382