### PR TITLE
Implement evaluate_params for seasonality optimization

### DIFF
--- a/src/quant_engine/seasonality/optimize.py
+++ b/src/quant_engine/seasonality/optimize.py
@@ -46,7 +46,51 @@ def evaluate_params(params, spec):
         A numeric score indicating the quality of the provided parameters.
     """
 
-    pass
+    # Create an isolated copy of the base specification so the caller's
+    # instance is not mutated during the evaluation process.
+    cfg = spec.model_copy(deep=True)
+
+    profile_updates = {}
+    if "ret_horizon" in params:
+        profile_updates["ret_horizon"] = params["ret_horizon"]
+    if "min_samples_bin" in params:
+        profile_updates["min_samples_bin"] = params["min_samples_bin"]
+    if profile_updates:
+        cfg.profile = cfg.profile.model_copy(update=profile_updates)
+
+    signal_updates = {}
+    if "method" in params:
+        signal_updates["method"] = params["method"]
+    if "dims" in params:
+        signal_updates["dims"] = params["dims"]
+    if "combine" in params:
+        signal_updates["combine"] = params["combine"]
+
+    method = params.get("method")
+    if method == "threshold" and "threshold" in params:
+        signal_updates["threshold"] = params["threshold"]
+    if method == "topk" and "topk" in params:
+        signal_updates["topk"] = params["topk"]
+
+    if signal_updates:
+        cfg.signal = cfg.signal.model_copy(update=signal_updates)
+
+    from . import runner
+
+    result = runner.run(cfg)
+    metrics = dict(result.get("best_metrics", {}) or {})
+
+    n_trades = int(metrics.get("n_trades", metrics.get("trades", 0)) or 0)
+    if n_trades < 30:
+        objective = -1e9
+    else:
+        objective = float(metrics.get("sharpe", 0.0) or 0.0)
+
+    return {
+        "objective": objective,
+        "metrics": metrics,
+        "params": params,
+    }
 
 
 def run_optimization(spec):


### PR DESCRIPTION
## Summary
- clone the provided seasonality specification and apply suggested parameters
- execute the existing seasonality runner to obtain backtest metrics and return an objective score
- penalise configurations with insufficient trades to keep the optimizer focused on viable candidates

## Testing
- pytest tests/test_seasonality_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9db13204832394c460083abeab61