### PR TITLE
Add session and month edge dimensions to seasonality profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ poetry run qe seasonality run --spec specs/eurusd_m1_seasonality.json
 - `measure` choisit la métrique : `direction` (taux de réussite) ou `return` (moyenne des rendements).
 - `threshold` / `topk` contrôlent la sélection des bins : seuil sur la proba ou top-k meilleurs profils.
 - `combine` indique comment combiner plusieurs dimensions (`and`, `or`, `sum`).
+- `by_session` active la dimension `session` (Asia, Europe, EU_US_overlap, US, Other) basée sur l'heure UTC.
+- `by_month_start` et `by_month_end` ajoutent des flags booléens pour le premier et le dernier jour du mois.
+
+### Exemple d'activation sessions & fins de mois
+
+```json
+{
+  "profile": {
+    "by_hour": false,
+    "by_dow": false,
+    "by_month": false,
+    "by_session": true,
+    "by_month_start": false,
+    "by_month_end": true,
+    "measure": "direction",
+    "ret_horizon": 1,
+    "min_samples_bin": 100
+  },
+  "signal": {
+    "method": "threshold",
+    "threshold": 0.55,
+    "dims": ["session", "is_month_end"],
+    "combine": "and"
+  }
+}
+```
 
 ## 📖 Documentation
 

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -129,6 +129,9 @@ class SeasonalityProfileSpec(BaseModel):
     by_hour: bool = True
     by_dow: bool = True
     by_month: bool = False
+    by_session: bool = False
+    by_month_start: bool = False
+    by_month_end: bool = False
     # mesure : 'direction' (P(close_{t+1} > close_t)) ou 'return'
     measure: Literal["direction", "return"] = "direction"
     ret_horizon: int = 1  # nb de barres à regarder
@@ -140,7 +143,16 @@ class SeasonalitySignalSpec(BaseModel):
     method: Literal["threshold", "topk"] = "threshold"
     threshold: float = 0.54  # si measure=direction alors p_hat>=seuil
     topk: int = 3  # si method=topk: prendre K bins les + forts
-    dims: list[Literal["hour", "dow", "month"]] = ["hour", "dow"]
+    dims: list[
+        Literal[
+            "hour",
+            "dow",
+            "month",
+            "session",
+            "is_month_start",
+            "is_month_end",
+        ]
+    ] = ["hour", "dow"]
     combine: Literal["and", "or", "sum"] = "and"  # combine multi-dims
 
 

--- a/src/quant_engine/seasonality/profiles.py
+++ b/src/quant_engine/seasonality/profiles.py
@@ -18,7 +18,7 @@ def _require_polars() -> None:
 class SeasonalityRules:
     """Container holding the active bins and metadata for a signal."""
 
-    active_bins: Dict[str, set[int]] = field(default_factory=dict)
+    active_bins: Dict[str, set[Any]] = field(default_factory=dict)
     combine: str = "and"
     metadata: MutableMapping[str, Any] = field(default_factory=dict)
 
@@ -63,7 +63,7 @@ def _select_bins_for_dimension(
     threshold: float | None,
     topk: int,
     score_col: str,
-) -> tuple[set[int], float | None]:
+) -> tuple[set[Any], float | None]:
     """Return the selected bins for a single dimension."""
 
     table = table.filter(pl.col(score_col).is_not_null())
@@ -83,7 +83,7 @@ def _select_bins_for_dimension(
         )
     if filtered.is_empty():
         return set(), cutoff
-    bins = set(int(b) for b in filtered.get_column("bin").to_list())
+    bins = set(filtered.get_column("bin").to_list())
     return bins, cutoff
 
 
@@ -108,7 +108,7 @@ def select_bins(
         requested_dims = profiles.get_column("dim").unique().cast(pl.Utf8).to_list()
 
     normalised_threshold = _normalise_threshold(threshold, measure)
-    active: Dict[str, set[int]] = {}
+    active: Dict[str, set[Any]] = {}
     thresholds_meta: Dict[str, float | None] = {}
     counts_meta: Dict[str, int] = {}
 

--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -119,10 +119,14 @@ def _profiles_to_records(
     for row in profiles_df.to_dicts():
         timeframe_value = row.get("timeframe") or timeframe
         bin_value = row.get("bin")
-        try:
-            bin_int = int(bin_value) if bin_value is not None else None
-        except (TypeError, ValueError):
-            bin_int = None
+        if isinstance(bin_value, bool):
+            stored_bin = int(bin_value)
+        elif isinstance(bin_value, (int, float)) and bin_value is not None:
+            stored_bin = int(bin_value)
+        elif bin_value is None:
+            stored_bin = None
+        else:
+            stored_bin = str(bin_value)
         score_value = row.get("p_hat") if measure == "direction" else row.get("ret_mean")
         baseline_value = row.get("baseline")
         lift_value = row.get("lift")
@@ -131,7 +135,7 @@ def _profiles_to_records(
             "symbol": row.get("symbol"),
             "timeframe": timeframe_value,
             "dim": row.get("dim"),
-            "bin": bin_int,
+            "bin": stored_bin,
             "measure": measure,
             "score": float(score_value) if score_value is not None else None,
             "n": int(n_value) if n_value is not None else None,

--- a/src/quant_engine/signals/seasonality_signal.py
+++ b/src/quant_engine/signals/seasonality_signal.py
@@ -20,6 +20,9 @@ DIMENSION_TO_COLUMN = {
     "hour": "hour",
     "dow": "dow",
     "month": "month",
+    "session": "session",
+    "is_month_start": "is_month_start",
+    "is_month_end": "is_month_end",
 }
 
 

--- a/tests/test_seasonality_sessions.py
+++ b/tests/test_seasonality_sessions.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from quant_engine.api import schemas
+from quant_engine.seasonality import compute
+
+
+def test_assign_session_buckets() -> None:
+    assert compute.assign_session(datetime(2025, 1, 1, 0, 0)) == "Asia"
+    assert compute.assign_session(datetime(2025, 1, 1, 8, 0)) == "Europe"
+    assert compute.assign_session(datetime(2025, 1, 1, 14, 0)) == "EU_US_overlap"
+    assert compute.assign_session(datetime(2025, 1, 1, 18, 0)) == "US"
+    assert compute.assign_session(datetime(2025, 1, 1, 23, 0)) == "Other"
+
+
+def test_add_time_bins_includes_sessions_and_month_edges() -> None:
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 1, 1, 0, 0),
+                datetime(2025, 1, 15, 8, 0),
+                datetime(2025, 1, 31, 14, 0),
+                datetime(2025, 2, 1, 18, 0),
+            ],
+            "symbol": ["TEST"] * 4,
+            "close": [1.0, 1.1, 1.2, 1.3],
+        }
+    )
+    enriched = compute.add_time_bins(df)
+    assert "session" in enriched.columns
+    assert "is_month_start" in enriched.columns
+    assert "is_month_end" in enriched.columns
+    sessions = enriched.get_column("session").to_list()
+    assert sessions[0] == "Asia"
+    assert sessions[2] == "EU_US_overlap"
+    month_start = enriched.get_column("is_month_start").to_list()
+    month_end = enriched.get_column("is_month_end").to_list()
+    assert month_start[0] is True
+    assert month_end[2] is True
+
+
+def test_compute_profiles_handles_new_dimensions() -> None:
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 1, 1, 0, 0),
+                datetime(2025, 1, 15, 8, 0),
+                datetime(2025, 1, 31, 14, 0),
+                datetime(2025, 2, 1, 18, 0),
+            ],
+            "symbol": ["TEST"] * 4,
+            "close": [1.0, 1.1, 1.2, 1.3],
+        }
+    )
+    profile_spec = schemas.SeasonalityProfileSpec(
+        by_hour=False,
+        by_dow=False,
+        by_month=False,
+        by_session=True,
+        by_month_start=True,
+        by_month_end=True,
+        measure="direction",
+        ret_horizon=1,
+        min_samples_bin=1,
+    )
+    features = compute.prepare_features(df, profile_spec)
+    profiles_df = compute.compute_profiles(features, profile_spec)
+    dims = set(profiles_df.get_column("dim").to_list())
+    assert {"session", "is_month_start", "is_month_end"}.issubset(dims)
+
+
+def test_signal_spec_accepts_new_dims() -> None:
+    spec = schemas.SeasonalitySignalSpec(dims=["session", "is_month_end"])
+    assert spec.dims == ["session", "is_month_end"]


### PR DESCRIPTION
## Summary
- add session, month start, and month end features to seasonality preprocessing and profile computation
- allow signal specifications and rules to handle non-numeric bins and expose the new dimensions
- document the new dimensions and provide regression tests covering the updated behaviours

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdf18ed1b48323af2986d45ba96d03