### PR TITLE
feat: add conditional seasonality metrics and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ poetry run quant-engine stats show --symbol EURUSD --event k_consecutive --targe
 poetry run qe seasonality run --spec specs/eurusd_m1_seasonality.json
 ```
 
+```bash
+# Lister les profils saisonnalité persistés en filtrant sur des métriques conditionnelles
+poetry run qe seasonality profiles --symbol EURUSD --metrics run_len_up_mean,p_breakout_up
+```
+
 ### Dimensions & signal
 
 - `by_hour`, `by_dow`, `by_month` activent les agrégations par heure, jour de semaine ou mois pour les profils.
@@ -184,6 +189,24 @@ poetry run qe seasonality run --spec specs/eurusd_m1_seasonality.json
   }
 }
 ```
+
+### Métriques conditionnelles stockées dans `seasonality_profiles.parquet`
+
+| Colonne | Description |
+| --- | --- |
+| `run_len_up_mean` | Longueur moyenne des runs haussiers démarrant dans le bin. |
+| `run_len_down_mean` | Longueur moyenne des runs baissiers démarrant dans le bin. |
+| `n_runs` | Nombre de runs observés dans le bin. |
+| `p_reversal_n` | Probabilité qu'un run se retourne en ≤ `ret_horizon` barres (estimateur Wilson). |
+| `p_reversal_ci_low` / `p_reversal_ci_high` | Intervalle de confiance Wilson 95 % pour `p_reversal_n`. |
+| `p_reversal_lift` | Écart du taux de reversal vs. le baseline du symbole. |
+| `p_reversal_baseline` | Probabilité de reversal globale pour le symbole. |
+| `amp_mean` | Amplitude moyenne (high-low) conditionnelle au bin. |
+| `amp_std` | Écart-type de l'amplitude (high-low). |
+| `atr_mean` | Moyenne de l'ATR si la série contient cette colonne. |
+| `p_breakout_up` | Fréquence de franchissement du plus-haut de la veille. |
+| `p_breakout_down` | Fréquence de cassure du plus-bas de la veille. |
+| `p_in_range` | Probabilité de rester dans le range de la veille. |
 
 ## 📖 Documentation
 

--- a/src/quant_engine/persistence/db.py
+++ b/src/quant_engine/persistence/db.py
@@ -181,6 +181,7 @@ def init_db(conn: sqlite3.Connection) -> None:
             n INTEGER,
             baseline REAL,
             lift REAL,
+            metrics TEXT,
             start TEXT,
             end TEXT,
             spec_id TEXT,
@@ -190,6 +191,10 @@ def init_db(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    try:
+        cur.execute("ALTER TABLE seasonality_profiles ADD COLUMN metrics TEXT")
+    except sqlite3.OperationalError:
+        pass
     cur.execute(
         """
         CREATE INDEX IF NOT EXISTS ix_seasonality_profiles_lookup

--- a/src/quant_engine/persistence/models.py
+++ b/src/quant_engine/persistence/models.py
@@ -45,6 +45,7 @@ class SeasonalityProfile:
     n: int | None = None
     baseline: float | None = None
     lift: float | None = None
+    metrics: Any = None
     start: str | None = None
     end: str | None = None
     spec_id: str | None = None

--- a/src/quant_engine/persistence/repo.py
+++ b/src/quant_engine/persistence/repo.py
@@ -74,6 +74,8 @@ class SeasonalityProfilesRepository:
         cur = self.conn.cursor()
         rows: List[tuple] = []
         for r in profiles_rows:
+            metrics = r.get("metrics") or {}
+            metrics_json = json.dumps(metrics)
             rows.append(
                 (
                     r.get("symbol"),
@@ -85,6 +87,7 @@ class SeasonalityProfilesRepository:
                     r.get("n"),
                     r.get("baseline"),
                     r.get("lift"),
+                    metrics_json,
                     r.get("start"),
                     r.get("end"),
                     r.get("spec_id"),
@@ -95,14 +98,15 @@ class SeasonalityProfilesRepository:
             """
             INSERT INTO seasonality_profiles (
                 symbol, timeframe, dim, bin, measure, score, n, baseline, lift,
-                start, end, spec_id, dataset_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                metrics, start, end, spec_id, dataset_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(symbol, timeframe, dim, bin, measure, start, end, spec_id, dataset_id)
             DO UPDATE SET
                 score = excluded.score,
                 n = excluded.n,
                 baseline = excluded.baseline,
-                lift = excluded.lift
+                lift = excluded.lift,
+                metrics = excluded.metrics
             """,
             rows,
         )

--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -131,6 +131,15 @@ def _profiles_to_records(
         baseline_value = row.get("baseline")
         lift_value = row.get("lift")
         n_value = row.get("n")
+        metrics_payload: Dict[str, Any] = {}
+        for key in compute.CONDITIONAL_METRIC_NAMES:
+            value = row.get(key)
+            if value is None:
+                continue
+            if key == "n_runs":
+                metrics_payload[key] = int(value)
+            else:
+                metrics_payload[key] = float(value)
         record = {
             "symbol": row.get("symbol"),
             "timeframe": timeframe_value,
@@ -146,6 +155,7 @@ def _profiles_to_records(
             "spec_id": spec_id,
             "dataset_id": dataset_id,
         }
+        record["metrics"] = metrics_payload
         records.append(record)
     return records
 

--- a/tests/test_persistence_api.py
+++ b/tests/test_persistence_api.py
@@ -69,6 +69,7 @@ def test_persistence_and_api(tmp_path):
                     "n": 500,
                     "baseline": 0.52,
                     "lift": 0.08,
+                    "metrics": {"p_breakout_up": 0.3, "run_len_up_mean": 2.1},
                     "start": "2021-01-01",
                     "end": "2021-06-01",
                     "spec_id": "spec-season",
@@ -102,6 +103,15 @@ def test_persistence_and_api(tmp_path):
 
     profiles = app.list_seasonality_profiles(symbol="BTCUSDT")
     assert profiles and profiles[0]["measure"] == "direction"
+    assert profiles[0]["metrics"]["p_breakout_up"] == 0.3
+
+    filtered = app.list_seasonality_profiles(
+        symbol="BTCUSDT", metrics=["p_breakout_up", "run_len_up_mean"]
+    )
+    assert filtered and filtered[0]["metrics"]["run_len_up_mean"] == 2.1
+
+    missing = app.list_seasonality_profiles(symbol="BTCUSDT", metrics=["amp_mean"])
+    assert missing == []
 
     os.environ.pop("DB_DSN", None)
     reset_settings_cache()

--- a/tests/test_seasonality_sessions.py
+++ b/tests/test_seasonality_sessions.py
@@ -6,6 +6,7 @@ import pytest
 
 from quant_engine.api import schemas
 from quant_engine.seasonality import compute
+from quant_engine.seasonality.compute import CONDITIONAL_METRIC_NAMES
 
 
 def test_assign_session_buckets() -> None:
@@ -72,6 +73,8 @@ def test_compute_profiles_handles_new_dimensions() -> None:
     profiles_df = compute.compute_profiles(features, profile_spec)
     dims = set(profiles_df.get_column("dim").to_list())
     assert {"session", "is_month_start", "is_month_end"}.issubset(dims)
+    for col in CONDITIONAL_METRIC_NAMES:
+        assert col in profiles_df.columns
 
 
 def test_signal_spec_accepts_new_dims() -> None:

--- a/tests/test_seasonality_smoke.py
+++ b/tests/test_seasonality_smoke.py
@@ -8,6 +8,7 @@ import pytest
 
 from quant_engine.api import schemas
 from quant_engine.seasonality import runner
+from quant_engine.seasonality.compute import CONDITIONAL_METRIC_NAMES
 
 _ = pytest.importorskip("polars")
 
@@ -87,5 +88,9 @@ def test_seasonality_smoke(tmp_path: Path) -> None:
 
     profiles_path = out_dir / "fold_0" / "seasonality_profiles.parquet"
     assert profiles_path.exists()
+    pl = pytest.importorskip("polars")
+    profiles_df = pl.read_parquet(profiles_path)
+    for col in CONDITIONAL_METRIC_NAMES:
+        assert col in profiles_df.columns
     active_bins = result.get("active_bins", {})
     assert active_bins.get("hour")


### PR DESCRIPTION
## Summary
- compute conditional run-length, reversal, amplitude and breakout metrics for seasonality profiles and include them in parquet outputs
- persist metric payloads in the seasonality profile repository and expose API/CLI filtering with a new `--metrics` option
- document the new metrics and extend regression tests to assert their presence and persistence

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdf3f12b408323814b4a45e4c6b986