### PR TITLE
Add derivative-aware seasonality dimensions and comparison CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ poetry run qe seasonality run --spec specs/eurusd_m1_seasonality.json
 poetry run qe seasonality profiles --symbol EURUSD --metrics run_len_up_mean,p_breakout_up
 ```
 
+```bash
+# Comparer deux symboles sur une dimension et afficher la corrélation des lifts
+poetry run qe seasonality compare --symbols EURUSD DXY --dim hour --timeframe M1
+```
+
 ### Dimensions & signal
 
 - `by_hour`, `by_dow`, `by_month` activent les agrégations par heure, jour de semaine ou mois pour les profils.
@@ -165,6 +170,11 @@ poetry run qe seasonality profiles --symbol EURUSD --metrics run_len_up_mean,p_b
 - `combine` indique comment combiner plusieurs dimensions (`and`, `or`, `sum`).
 - `by_session` active la dimension `session` (Asia, Europe, EU_US_overlap, US, Other) basée sur l'heure UTC.
 - `by_month_start` et `by_month_end` ajoutent des flags booléens pour le premier et le dernier jour du mois.
+- `by_news_hour` ajoute `is_news_hour` (heures macro sensibles 13h, 14h, 20h UTC).
+- `by_third_friday` ajoute `is_third_friday` pour le 3ᵉ vendredi de chaque mois (expiration d'options).
+- `by_rollover_day` expose `is_rollover_day` lorsque la série contient un `roll_id` (changement de contrat).
+
+Les colonnes `is_news_hour`, `is_third_friday` et `is_rollover_day` sont calculées automatiquement dans les features. Elles permettent d'isoler les heures clés des publications économiques, les séances d'expiration d'options mensuelles et les journées de rollover des contrats dérivés.
 
 ### Exemple d'activation sessions & fins de mois
 

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -132,6 +132,9 @@ class SeasonalityProfileSpec(BaseModel):
     by_session: bool = False
     by_month_start: bool = False
     by_month_end: bool = False
+    by_news_hour: bool = False
+    by_rollover_day: bool = False
+    by_third_friday: bool = False
     # mesure : 'direction' (P(close_{t+1} > close_t)) ou 'return'
     measure: Literal["direction", "return"] = "direction"
     ret_horizon: int = 1  # nb de barres à regarder
@@ -151,6 +154,9 @@ class SeasonalitySignalSpec(BaseModel):
             "session",
             "is_month_start",
             "is_month_end",
+            "is_news_hour",
+            "is_rollover_day",
+            "is_third_friday",
         ]
     ] = ["hour", "dow"]
     combine: Literal["and", "or", "sum"] = "and"  # combine multi-dims

--- a/tests/test_seasonality_profiles_compare.py
+++ b/tests/test_seasonality_profiles_compare.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from quant_engine.seasonality import profiles
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float:
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / (n - 1)
+    var_x = sum((x - mean_x) ** 2 for x in xs) / (n - 1)
+    var_y = sum((y - mean_y) ** 2 for y in ys) / (n - 1)
+    return cov / math.sqrt(var_x * var_y)
+
+
+def test_compare_profiles_returns_correlation() -> None:
+    pl = pytest.importorskip("polars")
+    df_a = pl.DataFrame(
+        {
+            "symbol": ["EURUSD", "EURUSD", "EURUSD"],
+            "dim": ["hour", "hour", "hour"],
+            "bin": [0, 1, 2],
+            "lift": [0.10, 0.20, 0.05],
+            "baseline": [0.0, 0.0, 0.0],
+            "n": [10, 15, 12],
+            "insufficient": [False, False, False],
+        }
+    )
+    df_b = pl.DataFrame(
+        {
+            "symbol": ["DXY", "DXY", "DXY"],
+            "dim": ["hour", "hour", "hour"],
+            "bin": [0, 1, 2],
+            "lift": [0.08, 0.25, 0.00],
+            "baseline": [0.0, 0.0, 0.0],
+            "n": [8, 12, 9],
+            "insufficient": [False, False, False],
+        }
+    )
+
+    comparison, corr = profiles.compare_profiles(df_a, df_b, "hour")
+
+    assert not comparison.is_empty()
+    assert {"lift_EURUSD", "lift_DXY", "lift_diff"}.issubset(set(comparison.columns))
+    lifts_a = comparison.get_column("lift_EURUSD").to_list()
+    lifts_b = comparison.get_column("lift_DXY").to_list()
+    assert corr is not None
+    expected_corr = _pearson(lifts_a, lifts_b)
+    assert corr == pytest.approx(expected_corr)
+    assert comparison.get_column("lift_diff").to_list() == [
+        pytest.approx(a - b) for a, b in zip(lifts_a, lifts_b)
+    ]

--- a/tests/test_seasonality_sessions.py
+++ b/tests/test_seasonality_sessions.py
@@ -44,6 +44,30 @@ def test_add_time_bins_includes_sessions_and_month_edges() -> None:
     assert month_end[2] is True
 
 
+def test_add_time_bins_adds_special_flags() -> None:
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 1, 16, 12, 0),
+                datetime(2025, 1, 17, 13, 0),
+                datetime(2025, 1, 20, 20, 0),
+                datetime(2025, 1, 21, 9, 0),
+            ],
+            "symbol": ["TEST"] * 4,
+            "close": [1.0, 1.1, 1.2, 1.3],
+            "roll_id": [1, 1, 2, 2],
+        }
+    )
+    enriched = compute.add_time_bins(df)
+    assert {"is_news_hour", "is_third_friday", "is_rollover_day"}.issubset(
+        set(enriched.columns)
+    )
+    assert enriched.get_column("is_news_hour").to_list() == [False, True, True, False]
+    assert enriched.get_column("is_third_friday").to_list() == [False, True, False, False]
+    assert enriched.get_column("is_rollover_day").to_list() == [False, False, True, False]
+
+
 def test_compute_profiles_handles_new_dimensions() -> None:
     pl = pytest.importorskip("polars")
     df = pl.DataFrame(
@@ -56,6 +80,7 @@ def test_compute_profiles_handles_new_dimensions() -> None:
             ],
             "symbol": ["TEST"] * 4,
             "close": [1.0, 1.1, 1.2, 1.3],
+            "roll_id": [1, 1, 2, 2],
         }
     )
     profile_spec = schemas.SeasonalityProfileSpec(
@@ -65,6 +90,9 @@ def test_compute_profiles_handles_new_dimensions() -> None:
         by_session=True,
         by_month_start=True,
         by_month_end=True,
+        by_news_hour=True,
+        by_third_friday=True,
+        by_rollover_day=True,
         measure="direction",
         ret_horizon=1,
         min_samples_bin=1,
@@ -72,11 +100,25 @@ def test_compute_profiles_handles_new_dimensions() -> None:
     features = compute.prepare_features(df, profile_spec)
     profiles_df = compute.compute_profiles(features, profile_spec)
     dims = set(profiles_df.get_column("dim").to_list())
-    assert {"session", "is_month_start", "is_month_end"}.issubset(dims)
+    assert {
+        "session",
+        "is_month_start",
+        "is_month_end",
+        "is_news_hour",
+        "is_third_friday",
+        "is_rollover_day",
+    }.issubset(dims)
     for col in CONDITIONAL_METRIC_NAMES:
         assert col in profiles_df.columns
 
 
 def test_signal_spec_accepts_new_dims() -> None:
-    spec = schemas.SeasonalitySignalSpec(dims=["session", "is_month_end"])
-    assert spec.dims == ["session", "is_month_end"]
+    spec = schemas.SeasonalitySignalSpec(
+        dims=["session", "is_month_end", "is_news_hour", "is_third_friday"]
+    )
+    assert spec.dims == [
+        "session",
+        "is_month_end",
+        "is_news_hour",
+        "is_third_friday",
+    ]


### PR DESCRIPTION
## Summary
- add news hour, rollover day and third Friday flags to the feature engineering pipeline and expose them in seasonality profile specs
- extend the CLI with a `seasonality compare` command and provide a helper to correlate lifts across symbols
- document the new dimensions and comparison flow, plus add unit tests covering the new behaviour

## Testing
- `poetry run pytest tests/test_seasonality_sessions.py tests/test_seasonality_profiles_compare.py`


------
https://chatgpt.com/codex/tasks/task_e_68cdf6cec62483238d1951e79430f2d9