### PR TITLE
Add MySQL OHLCV feed and update loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,48 @@ pre-commit run --all-files
 }
 ```
 
+### Charger OHLCV depuis MySQL (schéma marketdata)
+
+```json
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume",
+      "timeframe_col": null,
+      "extra_where": null,
+      "chunk_minutes": 0
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-10T23:59:00Z"
+  }
+}
+```
+
+Variables d’environnement à définir :
+
+```bash
+export QE_MARKETDATA_MYSQL_URL='mysql+pymysql://py_user:***@mysql-host:3306/marketdata'  # READ (schema marketdata)
+export QE_DB_URL='mysql+pymysql://py_user:***@mysql-host:3306/quant'                     # WRITE (schema quant)
+```
+
+Index recommandés dans `marketdata` :
+
+- `(symbol, ts)` lorsque la table est partitionnée par timeframe (ex. `ohlcv_m1`).
+- `(symbol, timeframe, ts)` lorsqu’une table unique regroupe plusieurs timeframes.
+
+Les timestamps (`ts`) doivent être en UTC.
+
 ### CLI
 
 ```bash

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from ..core.spec import (
     ValidationSpec as CoreValidationSpec,
@@ -28,14 +28,42 @@ class ResultResponse:
     result: Dict[str, Any] | None
 
 
-class StatsDataSpec(BaseModel):
-    """Dataset location and window for statistics runs."""
+class MySQLDataSpec(BaseModel):
+    """MySQL data feed configuration."""
 
-    dataset_path: str
+    model_config = ConfigDict(protected_namespaces=())
+
+    connection_url: Optional[str] = None
+    env_var: Optional[str] = "QE_MARKETDATA_MYSQL_URL"
+    schema_: Optional[str] = Field("marketdata", alias="schema")
+    table: str = "ohlcv"
+    symbol_col: str = "symbol"
+    ts_col: str = "ts"
+    open_col: str = "open"
+    high_col: str = "high"
+    low_col: str = "low"
+    close_col: str = "close"
+    volume_col: str = "volume"
+    timeframe_col: Optional[str] = "timeframe"
+    extra_where: Optional[str] = None
+    chunk_minutes: int = 0
+
+    @property
+    def schema(self) -> Optional[str]:
+        return self.schema_
+
+
+class DataInputSpec(BaseModel):
+    dataset_path: Optional[str] = None
+    mysql: Optional[MySQLDataSpec] = None
     symbols: List[str]
     timeframe: str
     start: str
     end: str
+
+
+class StatsDataSpec(DataInputSpec):
+    """Dataset location and window for statistics runs."""
 
 
 class StatsEventSpec(BaseModel):
@@ -116,12 +144,8 @@ class PersistenceSpec(BaseModel):
     dataset_id: str | None = None
 
 
-class SeasonalityDataSpec(BaseModel):
-    dataset_path: str
-    symbols: list[str]
-    timeframe: str
-    start: str
-    end: str
+class SeasonalityDataSpec(DataInputSpec):
+    pass
 
 
 class SeasonalityProfileSpec(BaseModel):

--- a/src/quant_engine/datafeeds/__init__.py
+++ b/src/quant_engine/datafeeds/__init__.py
@@ -1,0 +1,3 @@
+"""Data feed helpers for loading market data."""
+
+__all__ = ["mysql_feed"]

--- a/src/quant_engine/datafeeds/mysql_feed.py
+++ b/src/quant_engine/datafeeds/mysql_feed.py
@@ -1,0 +1,88 @@
+"""MySQL data feed helpers."""
+from __future__ import annotations
+
+import os
+from typing import Optional, List, Dict
+
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+
+def _qualify_table(table: str, schema: Optional[str]) -> str:
+    if "." in table:
+        return table
+    return f"{schema}.{table}" if schema else table
+
+
+def load_ohlcv_mysql(
+    connection_url: Optional[str],
+    env_var: Optional[str],
+    schema: Optional[str],
+    table: str,
+    symbols: List[str],
+    timeframe: str,
+    start: str,
+    end: str,
+    cols: Dict[str, str],
+    timeframe_col: Optional[str] = "timeframe",
+    extra_where: Optional[str] = None,
+    chunk_minutes: int = 0,
+) -> pd.DataFrame:
+    """Read OHLCV data from MySQL into a pandas dataframe."""
+
+    url = connection_url or (os.environ.get(env_var) if env_var else None)
+    if not url:
+        raise RuntimeError("MySQL URL manquante (connection_url/env_var).")
+    engine = create_engine(url)
+
+    table_q = _qualify_table(table, schema)
+    ts_col = cols["ts"]
+    sym_col = cols["symbol"]
+    o_col = cols["open"]
+    h_col = cols["high"]
+    l_col = cols["low"]
+    c_col = cols["close"]
+    v_col = cols["volume"]
+
+    symbols_in = ",".join([f":s{i}" for i, _ in enumerate(symbols)])
+    tf_filter = f"AND {timeframe_col} = :tf" if timeframe_col else ""
+    extra = f"AND ({extra_where})" if extra_where else ""
+
+    base_sql = f"""
+      SELECT {ts_col} AS ts, {sym_col} AS symbol,
+             {o_col} AS open, {h_col} AS high, {l_col} AS low, {c_col} AS close, {v_col} AS volume
+      FROM {table_q}
+      WHERE {sym_col} IN ({symbols_in})
+        {tf_filter}
+        AND {ts_col} >= :start AND {ts_col} <= :end
+        {extra}
+      ORDER BY {ts_col} ASC
+    """
+
+    params = {**{f"s{i}": s for i, s in enumerate(symbols)}, "start": start, "end": end}
+    if timeframe_col:
+        params["tf"] = timeframe
+
+    if chunk_minutes and chunk_minutes > 0:
+        start_dt = pd.to_datetime(start, utc=True)
+        end_dt = pd.to_datetime(end, utc=True)
+        out = []
+        cur = start_dt
+        while cur <= end_dt:
+            nxt = min(cur + pd.Timedelta(minutes=chunk_minutes), end_dt)
+            p = params.copy()
+            p["start"] = cur.isoformat()
+            p["end"] = nxt.isoformat()
+            out.append(pd.read_sql(text(base_sql), engine, params=p))
+            cur = nxt + pd.Timedelta(minutes=1)
+        df = pd.concat(out, ignore_index=True) if out else pd.DataFrame()
+    else:
+        df = pd.read_sql(text(base_sql), engine, params=params)
+
+    if df.empty:
+        return df
+    df["ts"] = pd.to_datetime(df["ts"], utc=True)
+    return df.sort_values(["symbol", "ts"]).reset_index(drop=True)
+
+
+__all__ = ["load_ohlcv_mysql"]

--- a/src/quant_engine/seasonality/spec.py
+++ b/src/quant_engine/seasonality/spec.py
@@ -21,7 +21,7 @@ from ..api.schemas import (
 
 @dataclass
 class NormalisedSeasonalitySpec:
-    dataset_path: Path
+    dataset_path: Path | None
     symbols: list[str]
     timeframe: str
     start: datetime
@@ -43,7 +43,7 @@ def normalise(spec: SeasonalitySpec) -> NormalisedSeasonalitySpec:
     start = datetime.fromisoformat(spec.data.start)
     end = datetime.fromisoformat(spec.data.end)
     return NormalisedSeasonalitySpec(
-        dataset_path=Path(spec.data.dataset_path),
+        dataset_path=Path(spec.data.dataset_path) if spec.data.dataset_path else None,
         symbols=list(spec.data.symbols),
         timeframe=spec.data.timeframe,
         start=start,

--- a/tests/test_mysql_feed_smoke.py
+++ b/tests/test_mysql_feed_smoke.py
@@ -1,0 +1,60 @@
+import os
+from typing import List
+
+import pytest
+
+from quant_engine.api.schemas import DataInputSpec, MySQLDataSpec
+from quant_engine.core.dataset import load_ohlcv
+
+
+def _parse_symbols() -> List[str]:
+    symbols_env = os.environ.get("QE_MARKETDATA_MYSQL_SYMBOLS")
+    if symbols_env:
+        return [s.strip() for s in symbols_env.split(",") if s.strip()]
+    symbol = os.environ.get("QE_MARKETDATA_MYSQL_SYMBOL", "EURUSD")
+    return [symbol]
+
+
+def _parse_optional(name: str):
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    if value.strip().lower() in {"", "none", "null"}:
+        return None
+    return value
+
+
+@pytest.mark.skipif(
+    not os.environ.get("QE_MARKETDATA_MYSQL_URL"),
+    reason="no MySQL url",
+)
+def test_mysql_feed_smoke() -> None:
+    url = os.environ["QE_MARKETDATA_MYSQL_URL"]
+    schema = os.environ.get("QE_MARKETDATA_MYSQL_SCHEMA")
+    table = os.environ.get("QE_MARKETDATA_MYSQL_TABLE")
+    timeframe_col = _parse_optional("QE_MARKETDATA_MYSQL_TIMEFRAME_COL")
+    extra_where = _parse_optional("QE_MARKETDATA_MYSQL_EXTRA_WHERE")
+    chunk_minutes = int(os.environ.get("QE_MARKETDATA_MYSQL_CHUNK_MINUTES", "0"))
+
+    mysql_spec = MySQLDataSpec(
+        connection_url=url,
+        env_var=None,
+        schema=schema or None,
+        table=table or "ohlcv",
+        timeframe_col=timeframe_col,
+        extra_where=extra_where,
+        chunk_minutes=chunk_minutes,
+    )
+
+    spec = DataInputSpec(
+        dataset_path=None,
+        mysql=mysql_spec,
+        symbols=_parse_symbols(),
+        timeframe=os.environ.get("QE_MARKETDATA_MYSQL_TIMEFRAME", "M1"),
+        start=os.environ.get("QE_MARKETDATA_MYSQL_START", "2024-01-01T00:00:00Z"),
+        end=os.environ.get("QE_MARKETDATA_MYSQL_END", "2024-01-01T01:00:00Z"),
+    )
+
+    df = load_ohlcv(spec)
+    expected = {"ts", "symbol", "open", "high", "low", "close", "volume"}
+    assert expected.issubset(df.columns)


### PR DESCRIPTION
## Summary
- add a MySQL-backed datafeed module and a unified OHLCV loader that supports CSV/JSON or database sources
- extend API schemas and runners to consume the new data input specification while keeping backward compatibility
- document MySQL usage and add a smoke test that exercises the loader when a database URL is configured

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01b233c2c8323a09a27334bd2c1d8