### PR TITLE
Add documentation overview and integration roadmap

### DIFF
--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -1,0 +1,65 @@
+# Quant Engine – Architecture Map
+
+## API FastAPI
+| Endpoint | Méthode | Description | Entrée/Sortie | Référence |
+|----------|---------|-------------|---------------|-----------|
+| `/submit` | POST | Lance une optimisation synchronisée et enregistre le run en mémoire. | Body = spec JSON validée via Pydantic → `{ "id": run_id }`. | 【F:src/quant_engine/api/app.py†L540-L555】 |
+| `/status/{job_id}` | GET | Vérifie l’état (`completed`, `unknown`, …) d’un job soumis. | Path param `job_id` → `{ "status": ... }`. | 【F:src/quant_engine/api/app.py†L557-L566】 |
+| `/result/{job_id}` | GET | Récupère le résultat complet d’un job (paramètres, métriques, artefacts). | Path param `job_id` → `{ "result": {...} }`. | 【F:src/quant_engine/api/app.py†L568-L576】 |
+| `/stats/run` | POST | Calcule un run Market Stats synchrone. | Body = `StatsSpec` → `{ "status": "completed" }`. | 【F:src/quant_engine/api/app.py†L578-L587】 |
+| `/stats/result` | GET | Renvoie la dernière table de stats calculée. | `{ "result": {columns, rows} }`. | 【F:src/quant_engine/api/app.py†L589-L600】 |
+| `/stats` | GET | Liste les stats persistées filtrables (symbol, event, target, split, significance). | Query params → liste de lignes enrichies (p_hat, lifts, FDR). | 【F:src/quant_engine/api/app.py†L602-L622】 |
+| `/stats/summary` | GET | Agrège les stats par condition/target et calcule Wilson CI. | Query params (symbol/timeframe/event) → tableau agrégé. | 【F:src/quant_engine/api/app.py†L624-L648】 |
+| `/stats/heatmap` | GET | Retourne les bins ordonnés (train/test) pour une condition donnée. | Query params `symbol,timeframe,event,target,condition_name`. | 【F:src/quant_engine/api/app.py†L650-L662】 |
+| `/stats/top` | GET | Top-k patterns classés par lift fréquentiste ou bayésien. | Query `k`, `method`, `significant_only`. | 【F:src/quant_engine/api/app.py†L664-L678】 |
+| `/seasonality/run` | POST | Exécute un profil saisonnalité complet (compute + persistance). | Body = `SeasonalitySpec` → résumé JSON. | 【F:src/quant_engine/api/app.py†L680-L688】 |
+| `/seasonality/optimize` | POST | Lance l’optimisation Optuna dédiée saisonnalité. | Body = `SeasonalitySpec` → `{best_value, best_params, ...}`. | 【F:src/quant_engine/api/app.py†L690-L698】 |
+| `/seasonality/profiles` | GET | Paginer les profils saisonniers stockés (filtrés par symbol/dim/metrics). | Query (metrics optionnelles) → liste de profils + metrics JSON. | 【F:src/quant_engine/api/app.py†L700-L720】 |
+| `/seasonality/runs` | GET | Historique des runs saisonnalité (status, best_summary). | Query (status/spec_id/dataset_id). | 【F:src/quant_engine/api/app.py†L722-L740】 |
+| `/seasonality/runs/{run_id}` | GET | Détail d’un run saisonnalité (404 si absent). | Path `run_id`. | 【F:src/quant_engine/api/app.py†L742-L753】 |
+| `/runs` | GET | Liste des runs d’optimisation persistés (status, objective, dates). | Query `status/date_from/date_to`. | 【F:src/quant_engine/api/app.py†L755-L772】 |
+| `/runs/{run_id}` | GET | Détails d’un run (metrics agrégés, folds, params). | Path `run_id`. | 【F:src/quant_engine/api/app.py†L774-L786】 |
+| `/runs/{run_id}/trials` | GET | Leaderboard des essais Optuna. | Query `order_by`, pagination. | 【F:src/quant_engine/api/app.py†L788-L801】 |
+| `/runs/{run_id}/metrics` | GET | Vue agrégée et par fold des métriques. | Path `run_id`. | 【F:src/quant_engine/api/app.py†L803-L812】 |
+
+## CLI Typer
+| Commande | Rôle | Paramètres clés | Référence |
+|----------|------|-----------------|-----------|
+| `qe run-local --spec` | Exécuter une spec en local (JobManager ou runner direct). | `--spec path/to/spec.json`. | 【F:src/quant_engine/cli/main.py†L23-L59】 |
+| `qe submit --spec` | Soumettre la spec à l’API HTTP. | URL API fixe `http://127.0.0.1:8000`. | 【F:src/quant_engine/cli/main.py†L61-L105】 |
+| `qe stats run --spec` | Calculer des Market Stats localement et afficher le top. | Option `--spec`. | 【F:src/quant_engine/cli/main.py†L107-L147】 |
+| `qe stats show --symbol --event --target` | Lire les stats persistées depuis l’API. | `--method {freq|bayes}`, `--limit`, `--significant-only`. | 【F:src/quant_engine/cli/main.py†L149-L199】 |
+| `qe seasonality run --spec` | Exécuter un profil saisonnalité local. | `--spec`. | 【F:src/quant_engine/cli/main.py†L201-L226】 |
+| `qe seasonality optimize --spec` | Boucle Optuna saisonnalité. | `--spec`. | 【F:src/quant_engine/cli/main.py†L228-L252】 |
+| `qe seasonality profiles` | Consommer l’endpoint `/seasonality/profiles`. | `--metrics`, `--limit`. | 【F:src/quant_engine/cli/main.py†L254-L304】 |
+| `qe seasonality compare --symbols A --symbols B --dim` | Comparer les lifts saisonniers de deux symboles. | `--timeframe`, `--measure`. | 【F:src/quant_engine/cli/main.py†L306-L368】 |
+| `qe runs list --status` | Liste les runs d’optimisation. | `--limit`. | 【F:src/quant_engine/cli/main.py†L370-L402】 |
+| `qe runs show RUN_ID` | Affiche les détails (metrics, best params) d’un run. | `run_id`. | 【F:src/quant_engine/cli/main.py†L404-L437】 |
+
+## Modules principaux
+- `stats/`
+  - `events.py` : événements (k consecutives, choc ATR, breakouts).【F:src/quant_engine/stats/events.py†L7-L39】
+  - `conditions.py` : contextes HTF trend, tertiles de volatilité, session.【F:src/quant_engine/stats/conditions.py†L8-L44】
+  - `targets.py` : outcomes `up_next_bar`, `continuation_n`, `time_to_reversal`.【F:src/quant_engine/stats/targets.py†L10-L33】
+  - `estimators.py` : Wilson CI, Beta-Binomial, Benjamini–Hochberg, agrégations.【F:src/quant_engine/stats/estimators.py†L19-L180】
+  - `runner.py` : orchestration du pipeline stats (chargement data, apply events/conditions/targets, persistance).【F:src/quant_engine/stats/runner.py†L1-L220】
+- `seasonality/`
+  - `compute.py` : construction des profils (dimensions hour/dow/etc., agrégats direction/retour).【F:docs/seasonality_reference.md†L9-L83】【F:src/quant_engine/seasonality/compute.py†L1-L80】
+  - `profiles.py` : formatage, comparaison, corrélation des lifts.【F:src/quant_engine/seasonality/profiles.py†L1-L112】
+  - `runner.py` : orchestration (chargement dataset, calcul, export Parquet/DB).【F:src/quant_engine/seasonality/runner.py†L1-L220】
+  - `optimize.py` : optimisation Optuna (recherche des meilleures combinaisons saisonnières).【F:src/quant_engine/seasonality/optimize.py†L1-L90】
+- `backtest/` : moteur bar-based, calculs metrics (Sharpe, Sortino, maxDD).【F:docs/architecture_overview.md†L19-L43】【F:src/quant_engine/backtest/metrics.py†L1-L56】
+- `tpsl/` : règles de stops/targets (ATR multiples, take-profit en R).【F:docs/architecture_overview.md†L25-L33】【F:src/quant_engine/tpsl/rules.py†L1-L32】
+- `optimize/` : runner Optuna, job manager, persistence des trials.【F:docs/architecture_overview.md†L19-L36】【F:src/quant_engine/optimize/runner.py†L1-L120】
+- `validate/` : splitters Walk-Forward, embargo.【F:docs/architecture_overview.md†L23-L31】【F:src/quant_engine/validate/splitter.py†L1-L38】
+- `persistence/` : accès DB (SQLite/MySQL via SQLAlchemy), modèles dataclass, dépôts.【F:src/quant_engine/persistence/db.py†L8-L215】【F:src/quant_engine/persistence/models.py†L1-L58】
+- `datafeeds/` : chargement OHLCV via CSV/Parquet/MySQL (`load_ohlcv_mysql`).【F:src/quant_engine/datafeeds/mysql_feed.py†L1-L118】
+
+## Base de données (schéma quant)
+- `experiment_runs` : statut du run, spec/dataset, objectif, timestamps.【F:src/quant_engine/persistence/db.py†L48-L69】
+- `run_metrics` : métriques agrégées et par fold (Unique par run/fold/metric).【F:src/quant_engine/persistence/db.py†L70-L91】
+- `trials` : historique Optuna (params JSON, objectif, métriques auxiliaires).【F:src/quant_engine/persistence/db.py†L92-L119】
+- `market_stats` : résultats stats conditionnelles (p_hat, lifts, FDR, bornes temporelles).【F:src/quant_engine/persistence/db.py†L120-L167】
+- `seasonality_profiles` : profils saisonniers, lifts et métriques sérialisées.【F:src/quant_engine/persistence/db.py†L168-L206】
+- `seasonality_runs` : suivi des runs saisonnalité (status, best_summary).【F:src/quant_engine/persistence/db.py†L207-L215】
+- Migrations : gérées via Alembic (déclaré côté dépendances, migrations custom dans `persistence/`).【F:pyproject.toml†L9-L20】【F:docs/architecture_overview.md†L11-L36】

--- a/docs/FEATURE_CATALOG.md
+++ b/docs/FEATURE_CATALOG.md
@@ -1,0 +1,36 @@
+# Quant Engine – Feature Catalog
+
+## Market Stats
+- **Événements** :
+  - `k_consecutive` – détecte `k` bougies consécutives dans une direction donnée.【F:src/quant_engine/stats/events.py†L7-L24】
+  - `shock_atr` – marque les bougies dont la True Range dépasse un multiple d’ATR.【F:src/quant_engine/stats/events.py†L26-L37】
+  - `breakout_hhll` – signale les cassures de plus hauts/plus bas sur un lookback configurable.【F:src/quant_engine/stats/events.py†L38-L55】
+- **Conditions** : `htf_trend` (EMA sur timeframe supérieur), `vol_tertile` (binning ATR), `session` (mapping horaire).【F:src/quant_engine/stats/conditions.py†L8-L46】
+- **Targets** : `up_next_bar`, `continuation_n` (run-length directionnel), `time_to_reversal` (horizon max avant retournement).【F:src/quant_engine/stats/targets.py†L10-L35】
+- **Estimateurs & contrôles** :
+  - Fréquentiste : `freq_with_wilson` (p̂ + Wilson CI), `p_value_binomial_onesided_normal` pour les p-values.【F:src/quant_engine/stats/estimators.py†L19-L86】
+  - Bayésien : posterior Beta-Binomial (`aggregate_binary_bayes`, `posterior_mean`, `beta_hdi`).【F:src/quant_engine/stats/estimators.py†L118-L178】
+  - Multiplicité : correction Benjamini–Hochberg (`benjamini_hochberg`).【F:src/quant_engine/stats/estimators.py†L96-L114】
+- **Production & persistance** : pipeline `runner.py` agrège p_hat, lifts (freq/bayes), flags `insufficient`, écrit en DB + artefacts Parquet.【F:src/quant_engine/stats/runner.py†L1-L160】【F:src/quant_engine/persistence/db.py†L120-L167】
+
+## Seasonality
+- **Dimensions couvertes** : hour, dow, month, session, flags calendaires (month_start/end, week_in_month, day_in_month, quarter, third_friday, etc.).【F:docs/seasonality_reference.md†L9-L48】
+- **Métriques directionnelles & de rendement** : `p_hat`, `ci_low/ci_high`, `baseline`, `lift`, `ret_mean/std`, quantiles de retours.【F:docs/seasonality_reference.md†L52-L75】
+- **Amplitude & séquences** : `amp_mean/std`, quantiles d’amplitude, probabilités de breakouts/reversal, run lengths.【F:docs/seasonality_reference.md†L77-L139】
+- **Calcul** : `compute.prepare_features/compute_profiles` construit les tables conditionnelles et métriques dérivées (lift, metrics conditionnels).【F:src/quant_engine/seasonality/compute.py†L1-L80】【F:src/quant_engine/seasonality/compute.py†L82-L140】
+- **Profils & règles** : `profiles.select_bins` filtre les bins selon seuil/top-k, `SeasonalityRules` encapsule les combinaisons (combine=and/or).【F:src/quant_engine/seasonality/profiles.py†L1-L112】
+- **Runner & artefacts** : `runner.py` orchestre chargement dataset, Walk-Forward (`splitter.generate_folds`), sélection des bins, export DB (`seasonality_profiles`, `seasonality_runs`) et artefacts (`profiles.parquet`, `summary.json`, `trades/equity`).【F:src/quant_engine/seasonality/runner.py†L1-L120】【F:src/quant_engine/seasonality/runner.py†L120-L220】【F:src/quant_engine/persistence/db.py†L168-L215】
+- **Optimisation Optuna** : `seasonality/optimize.py` normalise l’espace de recherche (dims, threshold/topk, min_samples), propose des suggestions, retourne `best_value/best_params`.【F:src/quant_engine/seasonality/optimize.py†L1-L90】【F:src/quant_engine/api/app.py†L690-L698】
+
+## Backtest & TP-SL
+- **Backtest** : moteur bar-based appliquant signaux EMA/VWAP, exécution trade-by-trade, agrège les métriques Sharpe/Sortino/MaxDD/CAGR/Hit rate/Avg-R.【F:docs/architecture_overview.md†L19-L43】【F:src/quant_engine/backtest/metrics.py†L1-L56】
+- **TP/SL** : stops ATR multiples (`StopInitializer.fixed_atr`), take-profit en R multiples (`TakeProfit.r_multiple`).【F:docs/architecture_overview.md†L24-L33】【F:src/quant_engine/tpsl/rules.py†L1-L32】
+- **Walk-Forward Analysis** : génération de folds train/test avec embargo via `splitter.generate_folds`.【F:docs/architecture_overview.md†L21-L29】【F:src/quant_engine/validate/splitter.py†L1-L38】
+- **Optimisation** : runner Optuna explore search space EMA & R multiples, écrit artefacts `trials.parquet`, `summary.json`, `trades_*.parquet`, `equity_*.parquet`.【F:src/quant_engine/optimize/runner.py†L1-L76】【F:src/quant_engine/optimize/runner.py†L78-L120】
+
+## Persistance & Artefacts
+- **Base SQL (quant)** : tables `experiment_runs`, `run_metrics`, `trials`, `market_stats`, `seasonality_profiles`, `seasonality_runs` (clé unique, timestamps).【F:src/quant_engine/persistence/db.py†L48-L215】
+- **Modèles dataclass** : `MarketStat`, `SeasonalityProfile`, `SeasonalityRun` pour manipuler les entités persistées.【F:src/quant_engine/persistence/models.py†L1-L58】
+- **Formats disques** : `artifacts.write_*` produit `trials.parquet`, `equity_{fold}.parquet`, `trades_{fold}.parquet`, `summary.json`.【F:src/quant_engine/optimize/runner.py†L80-L118】
+- **Sources marché** : lecture OHLCV via CSV/JSON (spec), ou MySQL via `load_ohlcv_mysql` alimentée par `QE_MARKETDATA_MYSQL_URL`.【F:README.md†L74-L123】【F:src/quant_engine/datafeeds/mysql_feed.py†L45-L118】
+- **Cibles MySQL** : résultats écrits dans la base quant (MySQL/SQLite via SQLAlchemy/Alembic).【F:docs/architecture_overview.md†L11-L36】【F:src/quant_engine/persistence/db.py†L8-L215】

--- a/docs/INTEGRATIONS_ROADMAP.md
+++ b/docs/INTEGRATIONS_ROADMAP.md
@@ -1,0 +1,17 @@
+# Quant Engine – Integrations & Roadmap
+
+## Intégrations actuelles
+- **Lecture OHLCV (CSV/JSON)** : specs `ExperimentSpec` acceptent des chemins locaux pour charger les séries via le loader générique (`dataset_path`).【F:README.md†L7-L65】【F:docs/architecture_overview.md†L19-L36】
+- **Lecture OHLCV (MySQL marketdata)** : datafeed `load_ohlcv_mysql` (SQLAlchemy) alimenté par `QE_MARKETDATA_MYSQL_URL`, options de lookup symbol/timeframe/chunking.【F:README.md†L74-L123】【F:src/quant_engine/datafeeds/mysql_feed.py†L45-L118】
+- **Écriture des résultats** : persistance SQL (SQLite/MySQL) via `experiment_runs`, `market_stats`, `seasonality_*` + artefacts Parquet/JSON sur disque.【F:src/quant_engine/persistence/db.py†L48-L215】【F:src/quant_engine/optimize/runner.py†L78-L118】
+
+## Interfaces front/back (Java/Angular)
+- **Spécifications JSON** : contrats d’entrée pour API/CLI (`submit`, `stats.run`, `seasonality.run`), exemples fournis dans `specs/examples/*.json`.【F:src/quant_engine/api/app.py†L540-L698】【F:specs/examples/submit_mysql.json†L1-L49】
+- **Endpoints de lecture** : `/runs`, `/runs/{id}`, `/runs/{id}/trials`, `/stats`, `/stats/summary`, `/stats/heatmap`, `/seasonality/profiles`, `/seasonality/runs`. Les réponses exposent JSON plat compatible clients Java/Angular.【F:src/quant_engine/api/app.py†L602-L812】
+- **Conventions** : identifiants `run_id`, champs `spec_id/dataset_id`, schémas JSON normalisés (listes de colonnes + rows pour les stats, payloads `metrics` sérialisés).【F:src/quant_engine/api/app.py†L589-L720】【F:src/quant_engine/seasonality/runner.py†L160-L220】
+
+## Roadmap proposée
+- **Seasonality V2→V5** : élargir le set de dimensions/métriques (ex. edges spécifiques, corrélations multi-symboles) – *unknown (à définir)*.
+- **Nouveaux datafeeds** : connecteur direct Binance (REST/WebSocket) pour bypass MySQL – *unknown (design à produire)*.
+- **Parallélisation compute** : distribution des calculs seasonality/stats via multiprocessing ou Ray – *unknown (architecture à valider)*.
+- **Dashboards Angular** : UI riche pour visualiser lifts, profils saisonniers, leaderboard d’optimisation – *unknown (design produit)*.

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,46 @@
+# Quant Engine – Project Overview
+
+## Rôle
+- **Moteur d'optimisation** : orchestration FastAPI/CLI pour lancer des backtests, optimiser une stratégie Optuna et historiser les runs.【F:README.md†L7-L65】【F:src/quant_engine/api/app.py†L14-L112】
+- **Analyse statistique** : calcul de statistiques de marché (probabilités, intervalles de confiance, filtrage FDR) et profils de saisonnalité persistés en base.【F:README.md†L102-L171】【F:src/quant_engine/stats/estimators.py†L19-L180】
+
+## Stack technique
+- **Langage** : Python 3.11 (gestion via Poetry).【F:pyproject.toml†L1-L27】
+- **API** : FastAPI + Pydantic pour l’exposition REST et la validation des specs.【F:pyproject.toml†L9-L20】【F:src/quant_engine/api/app.py†L536-L754】
+- **CLI** : Typer pour `quant-engine` et sous-commandes runs/stats/seasonality.【F:pyproject.toml†L9-L20】【F:src/quant_engine/cli/main.py†L12-L212】
+- **Optimisation** : Optuna pour la recherche d’hyperparamètres.【F:pyproject.toml†L9-L20】【F:README.md†L7-L21】
+- **Persistance** : SQLAlchemy + Alembic, artefacts Parquet/JSON, MLflow optionnel.【F:pyproject.toml†L9-L20】【F:docs/architecture_overview.md†L11-L36】
+- **Colonnes & calculs** : Polars/NumPy/Pandas pour transformations vectorisées.【F:pyproject.toml†L9-L20】【F:docs/seasonality_reference.md†L1-L74】
+
+## Installation & exécution
+1. **Installer les dépendances** : `poetry install` après avoir configuré Python 3.11 via pyenv/Poetry.【F:README.md†L12-L47】
+2. **Variables d’environnement** :
+   - `QE_DB_URL` : *unknown* (la base actuelle s’appuie sur `DB_DSN`).【F:src/quant_engine/config.py†L15-L38】
+   - `QE_MARKETDATA_MYSQL_URL` : DSN MySQL requis pour lire les OHLCV via datafeed dédié.【F:README.md†L74-L123】【F:src/quant_engine/datafeeds/mysql_feed.py†L45-L118】
+3. **Lancer l’API** : `poetry run uvicorn quant_engine.api.app:app --reload --app-dir src`.【F:README.md†L49-L54】
+4. **Utiliser la CLI** :
+   - `poetry run quant-engine run-local --spec path/to/spec.json`
+   - `poetry run quant-engine submit --spec path/to/spec.json`
+   - `poetry run quant-engine runs list --status running`
+   - `poetry run quant-engine runs show RUN_ID`
+   - `poetry run quant-engine stats run --spec specs/stats_run.json`
+   - `poetry run quant-engine stats show --symbol EURUSD --event k_consecutive --target up_next_bar`
+   - `poetry run quant-engine seasonality run --spec specs/seasonality.json`
+   - `poetry run quant-engine seasonality optimize --spec specs/seasonality.json`【F:README.md†L56-L101】【F:src/quant_engine/cli/main.py†L23-L211】
+
+## Arborescence condensée
+```
+src/quant_engine/
+  api/            # FastAPI (routes, schémas)
+  cli/            # Typer CLI
+  backtest/       # Moteur bar-based + métriques
+  optimize/       # Optuna runner & job manager
+  stats/          # Events, conditions, targets, estimators
+  seasonality/    # Compute, profiles, optimisation
+  tpsl/           # Règles take-profit/stop-loss
+  validate/       # Walk-forward & validation
+  persistence/    # SQLAlchemy/Alembic + repositories
+  datafeeds/      # Connecteurs CSV/MySQL
+  io/             # Gestion d’artefacts et IDs
+```
+【F:src/quant_engine/__init__.py†L1-L1】【F:docs/architecture_overview.md†L11-L23】【F:src/quant_engine/persistence/db.py†L8-L115】


### PR DESCRIPTION
## Summary
- add a project overview covering stack, usage, and repo layout
- document API/CLI architecture, feature catalog, and integrations roadmap

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e0402748888323995c4e8f0dd2ddd4