### PR TITLE
Add session/OR-IB/prev O-C levels and fill workflows

### DIFF
--- a/docs/levels_overview.md
+++ b/docs/levels_overview.md
@@ -19,6 +19,23 @@ The current detectors cover the following level types:
 
 Round numbers (RN) can also be generated statically for convenience.
 
+## Phase 1.5 additions
+
+* **Fills:** `valid_to_ts` is populated on the first closing price that touches
+  the gap or fair value gap zone (MVP logic). Future iterations will add a full
+  intrabar overlap mode.
+* **Endpoints:**
+  * `POST /levels/fill` refreshes FVG/GAP fills. The body is a
+    `LevelsBuildSpec` providing the data source and date range.
+  * `GET /levels/active` returns open zones (`valid_to_ts IS NULL`) filtered by
+    symbol, level types and optional date window.
+* **New levels:** session highs/lows, opening range (ORH/ORL), initial balance
+  (IBH/IBL) and previous open/close levels for daily/weekly/monthly periods
+  (PDO/PDC, PWO/PWC, PMO/PMC).
+* **Configuration:** session windows and Opening Range/Initial Balance durations
+  are configurable via the `session_windows` and `orib` sections of the
+  `LevelsBuildSpec`.
+
 ## Running detections
 
 ### CLI

--- a/specs/levels_phase15_build.json
+++ b/specs/levels_phase15_build.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume",
+      "timeframe_col": null
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-07T23:59:00Z"
+  },
+  "symbols": ["EURUSD"],
+  "range_start": "2025-01-01T00:00:00Z",
+  "range_end": "2025-01-07T23:59:00Z",
+  "session_windows": { "asia": [0, 7], "europe": [8, 12], "overlap": [13, 16], "us": [17, 21] },
+  "orib": { "or_minutes": 30, "ib_minutes": 60 },
+  "targets": [
+    { "type": "SESSION_HIGH", "params": {} },
+    { "type": "SESSION_LOW",  "params": {} },
+    { "type": "ORH", "params": {} },
+    { "type": "ORL", "params": {} },
+    { "type": "IBH", "params": {} },
+    { "type": "IBL", "params": {} },
+    { "type": "PDO", "params": {} },
+    { "type": "PDC", "params": {} },
+    { "type": "PWO", "params": {} },
+    { "type": "PWC", "params": {} },
+    { "type": "PMO", "params": {} },
+    { "type": "PMC", "params": {} }
+  ],
+  "output_schema": "marketdata",
+  "output_table": "levels",
+  "upsert": true
+}

--- a/specs/levels_phase15_fill.json
+++ b/specs/levels_phase15_fill.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume",
+      "timeframe_col": null
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-31T23:59:00Z"
+  },
+  "symbols": ["EURUSD"],
+  "range_start": "2025-01-01T00:00:00Z",
+  "range_end": "2025-01-31T23:59:00Z",
+  "targets": [
+    { "type": "FILL_FVG", "params": {} },
+    { "type": "FILL_GAP", "params": {} }
+  ]
+}

--- a/src/quant_engine/cli/main.py
+++ b/src/quant_engine/cli/main.py
@@ -199,6 +199,34 @@ def seasonality_optimize(
     typer.echo(json.dumps(payload, separators=(",", ":")))
 
 
+@levels_app.command("build")
+def levels_build_cli(
+    spec_path: Path = typer.Option(..., "--spec", exists=True, file_okay=True, dir_okay=False)
+) -> None:
+    """Build levels as defined in a specification file."""
+
+    from ..levels.schemas import LevelsBuildSpec
+    from ..levels.runner import run_levels_build
+
+    spec_model = LevelsBuildSpec.model_validate_json(spec_path.read_text())
+    result = run_levels_build(spec_model)
+    typer.echo(json.dumps(result, separators=(",", ":")))
+
+
+@levels_app.command("fill")
+def levels_fill_cli(
+    spec_path: Path = typer.Option(..., "--spec", exists=True, file_okay=True, dir_okay=False)
+) -> None:
+    """Refresh valid_to_ts for active GAP/FVG levels."""
+
+    from ..levels.schemas import LevelsBuildSpec
+    from ..levels.runner import run_levels_fill
+
+    spec_model = LevelsBuildSpec.model_validate_json(spec_path.read_text())
+    result = run_levels_fill(spec_model)
+    typer.echo(json.dumps(result, separators=(",", ":")))
+
+
 @seasonality_app.command("profiles")
 def seasonality_profiles(
     symbol: Optional[str] = typer.Option(None, "--symbol"),

--- a/src/quant_engine/levels/__init__.py
+++ b/src/quant_engine/levels/__init__.py
@@ -1,11 +1,14 @@
 """Levels detection and persistence package."""
 
-from .schemas import LevelRecord, LevelsBuildSpec, LevelType
-from .runner import run_levels_build
+from .schemas import LevelRecord, LevelsBuildSpec, LevelType, ORIBSpec, SessionWindows
+from .runner import run_levels_build, run_levels_fill
 
 __all__ = [
     "LevelRecord",
     "LevelsBuildSpec",
     "LevelType",
+    "SessionWindows",
+    "ORIBSpec",
     "run_levels_build",
+    "run_levels_fill",
 ]

--- a/src/quant_engine/levels/detectors.py
+++ b/src/quant_engine/levels/detectors.py
@@ -7,7 +7,7 @@ from typing import Iterable, List, Optional
 import numpy as np
 import pandas as pd
 
-from .schemas import LevelRecord
+from .schemas import LevelRecord, SessionWindows
 
 
 _PERIOD_CONFIG = {
@@ -15,6 +15,15 @@ _PERIOD_CONFIG = {
     "W": {"freq": "1W", "timeframe": "W1", "high_type": "PWH", "low_type": "PWL"},
     "M": {"freq": "1M", "timeframe": "M1", "high_type": "PMH", "low_type": "PML"},
 }
+
+
+def _to_utc_timestamp(value) -> Optional[pd.Timestamp]:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
 
 
 def _ensure_utc(series: pd.Series) -> None:
@@ -49,6 +58,154 @@ def _resample_ohlc(df: pd.DataFrame, period: str) -> pd.DataFrame:
     resampled = resampled.reset_index(drop=False)
     resampled.rename(columns={"ts": "period_end"}, inplace=True)
     return resampled
+
+
+def detect_session_high_low(df_symbol: pd.DataFrame, session_windows: SessionWindows) -> List[LevelRecord]:
+    """Compute per-session high and low levels for a symbol."""
+
+    if df_symbol.empty:
+        return []
+    df_prep = _prepare_ohlcv(df_symbol)
+    if "symbol" in df_prep.columns:
+        symbol = str(df_prep["symbol"].iloc[0])
+    else:  # pragma: no cover - defensive fallback
+        raise ValueError("Session detection requires a symbol column")
+
+    bounds = {
+        "ASIA": session_windows.asia,
+        "EUROPE": session_windows.europe,
+        "EU_US_OVERLAP": session_windows.overlap,
+        "US": session_windows.us,
+    }
+    hours = df_prep["ts"].dt.hour
+    sessions = pd.Series(data=pd.NA, index=df_prep.index, dtype="object")
+    for name, (start, end) in bounds.items():
+        if start <= end:
+            mask = hours.between(start, end, inclusive="both")
+        else:
+            mask = (hours >= start) | (hours <= end)
+        sessions = sessions.where(~mask, name)
+    df_prep["session"] = sessions
+    df_prep = df_prep.dropna(subset=["session"]).copy()
+    if df_prep.empty:
+        return []
+    df_prep["session_date"] = df_prep["ts"].dt.floor("D")
+
+    groups: List[dict] = []
+    for (session_date, session_name), group in df_prep.groupby(["session_date", "session"], sort=False):
+        if group.empty:
+            continue
+        start_ts = group["ts"].iloc[0]
+        end_ts = group["ts"].iloc[-1]
+        groups.append(
+            {
+                "session_date": session_date,
+                "session": str(session_name),
+                "start_ts": start_ts,
+                "end_ts": end_ts,
+                "high": float(group["high"].max()),
+                "low": float(group["low"].min()),
+            }
+        )
+    if not groups:
+        return []
+    groups.sort(key=lambda item: (pd.Timestamp(item["start_ts"]).value))
+
+    records: List[LevelRecord] = []
+    for idx, info in enumerate(groups):
+        anchor_ts = pd.Timestamp(info["end_ts"]).to_pydatetime().astimezone(timezone.utc)
+        next_start = groups[idx + 1]["start_ts"] if idx + 1 < len(groups) else None
+        next_start_ts = _to_utc_timestamp(next_start)
+        if next_start_ts is not None:
+            valid_from = next_start_ts.to_pydatetime().astimezone(timezone.utc)
+        else:
+            valid_from = anchor_ts
+        records.append(
+            LevelRecord(
+                symbol=symbol,
+                timeframe="SESSION",
+                level_type="SESSION_HIGH",
+                price=info["high"],
+                anchor_ts=anchor_ts,
+                valid_from_ts=valid_from,
+            )
+        )
+        records.append(
+            LevelRecord(
+                symbol=symbol,
+                timeframe="SESSION",
+                level_type="SESSION_LOW",
+                price=info["low"],
+                anchor_ts=anchor_ts,
+                valid_from_ts=valid_from,
+            )
+        )
+    return records
+
+
+def _detect_intraday_range(
+    df_symbol: pd.DataFrame,
+    minutes: int,
+    high_type: str,
+    low_type: str,
+) -> List[LevelRecord]:
+    if df_symbol.empty:
+        return []
+    df_prep = _prepare_ohlcv(df_symbol)
+    if "symbol" not in df_prep.columns:
+        raise ValueError("Intraday range detection requires a symbol column")
+    symbol = str(df_prep["symbol"].iloc[0])
+    window = pd.Timedelta(minutes=int(minutes))
+    df_prep["session_date"] = df_prep["ts"].dt.floor("D")
+    records: List[LevelRecord] = []
+    for session_date, group in df_prep.groupby("session_date", sort=False):
+        if group.empty:
+            continue
+        day_start = pd.Timestamp(session_date)
+        if day_start.tzinfo is None:
+            day_start = day_start.tz_localize("UTC")
+        else:
+            day_start = day_start.tz_convert("UTC")
+        window_end = day_start + window
+        window_df = group[group["ts"] < window_end]
+        if window_df.empty:
+            continue
+        high = float(window_df["high"].max())
+        low = float(window_df["low"].min())
+        anchor = window_end.to_pydatetime().astimezone(timezone.utc)
+        records.append(
+            LevelRecord(
+                symbol=symbol,
+                timeframe="D1",
+                level_type=high_type,
+                price=high,
+                anchor_ts=anchor,
+                valid_from_ts=anchor,
+            )
+        )
+        records.append(
+            LevelRecord(
+                symbol=symbol,
+                timeframe="D1",
+                level_type=low_type,
+                price=low,
+                anchor_ts=anchor,
+                valid_from_ts=anchor,
+            )
+        )
+    return records
+
+
+def detect_opening_range(df_symbol: pd.DataFrame, minutes: int = 30) -> List[LevelRecord]:
+    """Detect opening range high/low levels for each UTC session."""
+
+    return _detect_intraday_range(df_symbol, minutes=minutes, high_type="ORH", low_type="ORL")
+
+
+def detect_initial_balance(df_symbol: pd.DataFrame, minutes: int = 60) -> List[LevelRecord]:
+    """Detect initial balance high/low levels for each UTC session."""
+
+    return _detect_intraday_range(df_symbol, minutes=minutes, high_type="IBH", low_type="IBL")
 
 
 def detect_previous_high_low(df: pd.DataFrame, symbol: str, period: str = "D") -> List[LevelRecord]:
@@ -100,6 +257,70 @@ def detect_previous_high_low(df: pd.DataFrame, symbol: str, period: str = "D") -
                     price=float(prev_low.iloc[idx]),
                     anchor_ts=anchor_dt,
                     valid_from_ts=anchor_dt,
+                )
+            )
+    return records
+
+
+_OPEN_CLOSE_TYPES = {
+    "D": {"open_type": "PDO", "close_type": "PDC", "timeframe": "D1"},
+    "W": {"open_type": "PWO", "close_type": "PWC", "timeframe": "W1"},
+    "M": {"open_type": "PMO", "close_type": "PMC", "timeframe": "M1"},
+}
+
+
+def detect_previous_open_close(df_symbol: pd.DataFrame, period: str = "D") -> List[LevelRecord]:
+    """Compute previous period open/close levels for the provided symbol."""
+
+    if df_symbol.empty:
+        return []
+    period = period.upper()
+    if period not in _OPEN_CLOSE_TYPES:
+        raise ValueError(f"Unsupported period '{period}' for previous open/close detection")
+    df_prep = _prepare_ohlcv(df_symbol)
+    if "symbol" not in df_prep.columns:
+        raise ValueError("Previous open/close detection requires a symbol column")
+    symbol = str(df_prep["symbol"].iloc[0])
+    grouped = _resample_ohlc(df_prep, period)
+    if grouped.empty:
+        return []
+
+    cfg = _OPEN_CLOSE_TYPES[period]
+    prev_open = grouped["open"].shift(1)
+    prev_close = grouped["close"].shift(1)
+    next_open_ts = grouped["open_ts"].shift(-1)
+
+    records: List[LevelRecord] = []
+    for idx, row in grouped.iterrows():
+        anchor_raw = row.get("close_ts")
+        if pd.isna(anchor_raw):
+            continue
+        anchor_ts = pd.Timestamp(anchor_raw).to_pydatetime().astimezone(timezone.utc)
+        valid_from_raw = next_open_ts.iloc[idx]
+        if pd.isna(valid_from_raw):
+            valid_from_ts = anchor_ts
+        else:
+            valid_from_ts = pd.Timestamp(valid_from_raw).to_pydatetime().astimezone(timezone.utc)
+        if not pd.isna(prev_open.iloc[idx]):
+            records.append(
+                LevelRecord(
+                    symbol=symbol,
+                    timeframe=cfg["timeframe"],
+                    level_type=cfg["open_type"],
+                    price=float(prev_open.iloc[idx]),
+                    anchor_ts=anchor_ts,
+                    valid_from_ts=valid_from_ts,
+                )
+            )
+        if not pd.isna(prev_close.iloc[idx]):
+            records.append(
+                LevelRecord(
+                    symbol=symbol,
+                    timeframe=cfg["timeframe"],
+                    level_type=cfg["close_type"],
+                    price=float(prev_close.iloc[idx]),
+                    anchor_ts=anchor_ts,
+                    valid_from_ts=valid_from_ts,
                 )
             )
     return records
@@ -212,6 +433,85 @@ def detect_fvg(
     return records
 
 
+def _prepare_fill_dataframe(levels: pd.DataFrame) -> pd.DataFrame:
+    df = levels.copy()
+    if not df.empty:
+        for col in ("valid_from_ts", "anchor_ts", "valid_to_ts"):
+            if col in df.columns:
+                df[col] = pd.to_datetime(df[col], utc=True, errors="coerce")
+    return df
+
+
+def fill_gaps(df_symbol: pd.DataFrame, gaps: pd.DataFrame) -> pd.DataFrame:
+    """Populate ``valid_to_ts`` for gap zones touched by closing prices."""
+
+    if gaps.empty or df_symbol.empty:
+        return gaps.copy()
+    df_prep = _prepare_ohlcv(df_symbol)
+    closes = df_prep[["ts", "close"]].copy()
+    closes.rename(columns={"ts": "bar_ts"}, inplace=True)
+    levels = _prepare_fill_dataframe(gaps)
+    if "valid_to_ts" not in levels.columns:
+        levels["valid_to_ts"] = pd.NaT
+
+    for idx, row in levels.iterrows():
+        if pd.notna(row.get("valid_to_ts")):
+            continue
+        price_lo = row.get("price_lo")
+        price_hi = row.get("price_hi")
+        valid_from = row.get("valid_from_ts") or row.get("anchor_ts")
+        valid_from_ts = _to_utc_timestamp(valid_from)
+        if price_lo is None or price_hi is None or valid_from_ts is None:
+            continue
+        window = closes.loc[closes["bar_ts"] >= valid_from_ts]
+        if window.empty:
+            continue
+        lo = float(min(price_lo, price_hi))
+        hi = float(max(price_lo, price_hi))
+        touched = window[(window["close"] >= lo) & (window["close"] <= hi)]
+        if touched.empty:
+            continue
+        fill_ts = touched.iloc[0]["bar_ts"]
+        levels.at[idx, "valid_to_ts"] = fill_ts
+    return levels
+
+
+def fill_fvgs(df_symbol: pd.DataFrame, fvgs: pd.DataFrame) -> pd.DataFrame:
+    """Populate ``valid_to_ts`` for Fair Value Gaps when retouched."""
+
+    if fvgs.empty or df_symbol.empty:
+        return fvgs.copy()
+    df_prep = _prepare_ohlcv(df_symbol)
+    closes = df_prep[["ts", "close", "high", "low"]].copy()
+    closes.rename(columns={"ts": "bar_ts"}, inplace=True)
+    levels = _prepare_fill_dataframe(fvgs)
+    if "valid_to_ts" not in levels.columns:
+        levels["valid_to_ts"] = pd.NaT
+
+    for idx, row in levels.iterrows():
+        if pd.notna(row.get("valid_to_ts")):
+            continue
+        price_lo = row.get("price_lo")
+        price_hi = row.get("price_hi")
+        if price_lo is None or price_hi is None:
+            continue
+        valid_from = row.get("valid_from_ts") or row.get("anchor_ts")
+        valid_from_ts = _to_utc_timestamp(valid_from)
+        if valid_from_ts is None:
+            continue
+        lo = float(min(price_lo, price_hi))
+        hi = float(max(price_lo, price_hi))
+        window = closes[closes["bar_ts"] >= valid_from_ts]
+        if window.empty:
+            continue
+        touched = window[(window["close"] >= lo) & (window["close"] <= hi)]
+        if touched.empty:
+            continue
+        fill_ts = touched.iloc[0]["bar_ts"]
+        levels.at[idx, "valid_to_ts"] = fill_ts
+    return levels
+
+
 def detect_poc(
     df: pd.DataFrame,
     symbol: str,
@@ -303,4 +603,10 @@ __all__ = [
     "detect_fvg",
     "detect_poc",
     "generate_round_numbers",
+    "detect_session_high_low",
+    "detect_opening_range",
+    "detect_initial_balance",
+    "detect_previous_open_close",
+    "fill_gaps",
+    "fill_fvgs",
 ]

--- a/src/quant_engine/levels/runner.py
+++ b/src/quant_engine/levels/runner.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 from typing import Dict
 
+import pandas as pd
+
 from ..core.dataset import load_ohlcv
 from .builders import build_levels
-from .repo import ensure_table, get_engine, upsert_levels
+from .detectors import fill_fvgs, fill_gaps
+from .repo import ensure_table, get_engine, select_levels, upsert_levels, upsert_valid_to_ts
 from .schemas import LevelsBuildSpec
 
 
@@ -26,4 +29,70 @@ def run_levels_build(spec: LevelsBuildSpec) -> Dict[str, object]:
     return payload
 
 
-__all__ = ["run_levels_build"]
+def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
+    """Refresh ``valid_to_ts`` for active FVG and GAP levels."""
+
+    ohlcv = load_ohlcv(spec.data)
+    if ohlcv.empty:
+        return {"updated": 0, "checked": 0}
+    df = ohlcv.copy()
+    df["ts"] = pd.to_datetime(df["ts"], utc=True)
+
+    do_fill_fvg = any(target.type.upper() == "FILL_FVG" for target in spec.targets)
+    do_fill_gap = any(target.type.upper() == "FILL_GAP" for target in spec.targets)
+    if not (do_fill_fvg or do_fill_gap):
+        return {"updated": 0, "checked": 0}
+
+    table_fqn = f"{spec.output_schema}.{spec.output_table}" if spec.output_schema else spec.output_table
+    engine = get_engine()
+    ensure_table(engine, table_fqn)
+
+    total_checked = 0
+    pending_updates: list[pd.DataFrame] = []
+    for symbol in spec.symbols:
+        sym_df = df[df["symbol"] == symbol]
+        if sym_df.empty:
+            continue
+        level_types: list[str] = []
+        if do_fill_fvg:
+            level_types.append("FVG")
+        if do_fill_gap:
+            level_types.extend(["GAP_D", "GAP_W"])
+        if not level_types:
+            continue
+        levels = select_levels(
+            engine,
+            table_fqn,
+            symbol=symbol,
+            level_types=list(dict.fromkeys(level_types)),
+            active_only=True,
+            start=spec.range_start,
+            end=spec.range_end,
+            limit=10000,
+        )
+        if levels.empty:
+            continue
+        total_checked += int(len(levels))
+        if do_fill_fvg:
+            fvgs_active = levels[levels["level_type"] == "FVG"]
+            if not fvgs_active.empty:
+                fvgs_filled = fill_fvgs(sym_df, fvgs_active)
+                fvgs_updates = fvgs_filled[fvgs_filled["valid_to_ts"].notna()]
+                if not fvgs_updates.empty:
+                    pending_updates.append(fvgs_updates)
+        if do_fill_gap:
+            gaps_active = levels[levels["level_type"].isin(["GAP_D", "GAP_W"])]
+            if not gaps_active.empty:
+                gaps_filled = fill_gaps(sym_df, gaps_active)
+                gaps_updates = gaps_filled[gaps_filled["valid_to_ts"].notna()]
+                if not gaps_updates.empty:
+                    pending_updates.append(gaps_updates)
+    if pending_updates:
+        updates_df = pd.concat(pending_updates, ignore_index=True)
+        updated_count = upsert_valid_to_ts(engine, table_fqn, updates_df)
+    else:
+        updated_count = 0
+    return {"updated": int(updated_count), "checked": int(total_checked)}
+
+
+__all__ = ["run_levels_build", "run_levels_fill"]

--- a/src/quant_engine/levels/schemas.py
+++ b/src/quant_engine/levels/schemas.py
@@ -24,6 +24,18 @@ class LevelType(str, Enum):
     FVG = "FVG"
     POC = "POC"
     RN = "RN"
+    SESSION_HIGH = "SESSION_HIGH"
+    SESSION_LOW = "SESSION_LOW"
+    ORH = "ORH"
+    ORL = "ORL"
+    IBH = "IBH"
+    IBL = "IBL"
+    PDO = "PDO"
+    PDC = "PDC"
+    PWO = "PWO"
+    PWC = "PWC"
+    PMO = "PMO"
+    PMC = "PMC"
 
 
 class LevelRecord(BaseModel):
@@ -45,6 +57,18 @@ class LevelRecord(BaseModel):
         "FVG",
         "POC",
         "RN",
+        "SESSION_HIGH",
+        "SESSION_LOW",
+        "ORH",
+        "ORL",
+        "IBH",
+        "IBL",
+        "PDO",
+        "PDC",
+        "PWO",
+        "PWC",
+        "PMO",
+        "PMC",
     ]
     price: Optional[float] = None
     price_lo: Optional[float] = None
@@ -54,6 +78,26 @@ class LevelRecord(BaseModel):
     valid_to_ts: Optional[datetime] = None
     params_hash: Optional[str] = None
     source: str = "python-levels"
+
+
+class SessionWindows(BaseModel):
+    """UTC session windows described by inclusive hour bounds."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    asia: tuple[int, int] = (0, 7)
+    europe: tuple[int, int] = (8, 12)
+    overlap: tuple[int, int] = (13, 16)
+    us: tuple[int, int] = (17, 21)
+
+
+class ORIBSpec(BaseModel):
+    """Opening range and initial balance configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    or_minutes: int = 30
+    ib_minutes: int = 60
 
 
 class LevelsBuildItem(BaseModel):
@@ -74,6 +118,8 @@ class LevelsBuildSpec(BaseModel):
     output_schema: str = "marketdata"
     output_table: str = "levels"
     upsert: bool = True
+    session_windows: Optional[SessionWindows] = None
+    orib: Optional[ORIBSpec] = None
 
 
 __all__ = [
@@ -81,4 +127,6 @@ __all__ = [
     "LevelsBuildSpec",
     "LevelsBuildItem",
     "LevelType",
+    "SessionWindows",
+    "ORIBSpec",
 ]

--- a/tests/test_levels_phase15_smoke.py
+++ b/tests/test_levels_phase15_smoke.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from quant_engine.api import app as api_app
+from quant_engine.levels import repo as levels_repo
+
+
+@pytest.mark.skipif(
+    "QE_MARKETDATA_MYSQL_URL" not in os.environ,
+    reason="Requires QE_MARKETDATA_MYSQL_URL for persistence",
+)
+def test_levels_phase15_end_to_end() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    build_spec = repo_root / "specs" / "levels_phase15_build.json"
+    fill_spec = repo_root / "specs" / "levels_phase15_fill.json"
+    env = {**os.environ, "PYTHONPATH": str(repo_root / "src")}
+
+    build_cmd = [
+        sys.executable,
+        "-m",
+        "quant_engine.cli.main",
+        "levels",
+        "build",
+        "--spec",
+        str(build_spec),
+    ]
+    build_result = subprocess.run(
+        build_cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert build_result.returncode == 0, build_result.stderr
+
+    fill_cmd = [
+        sys.executable,
+        "-m",
+        "quant_engine.cli.main",
+        "levels",
+        "fill",
+        "--spec",
+        str(fill_spec),
+    ]
+    fill_result = subprocess.run(
+        fill_cmd,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert fill_result.returncode == 0, fill_result.stderr
+
+    active = api_app.levels_active(symbol="EURUSD", level_types=["FVG"], limit=10)
+    assert isinstance(active, list)
+
+    engine = levels_repo.get_engine()
+    table_fqn = "marketdata.levels"
+    df_sessions = levels_repo.select_levels(
+        engine,
+        table_fqn,
+        symbol="EURUSD",
+        level_types=["SESSION_HIGH", "SESSION_LOW"],
+        active_only=False,
+        start="2025-01-01T00:00:00Z",
+        end="2025-01-07T23:59:00Z",
+        limit=10000,
+    )
+    assert isinstance(df_sessions, pd.DataFrame)
+    assert not df_sessions.empty


### PR DESCRIPTION
## Summary
- extend levels schemas and detectors to support session highs/lows, opening range/initial balance, and previous open/close levels
- add GAP/FVG fill refresh pipeline with repository helpers, CLI/API entry points, and sample specs
- update documentation and smoke tests for the new build/fill capabilities

## Testing
- pytest tests/test_levels_phase15_smoke.py *(fails: pytest missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0557bd03c83239d947b7170598101