### PR TITLE
Add structure level detectors, helpers, and API search

### DIFF
--- a/specs/levels_phase2a_build.json
+++ b/specs/levels_phase2a_build.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "dataset_path": "specs/examples/data/eurusd_m1_sample.json",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2024-01-01T00:00:00Z",
+    "end": "2024-01-03T23:59:00Z"
+  },
+  "symbols": ["EURUSD"],
+  "range_start": "2024-01-01T00:00:00Z",
+  "range_end": "2024-01-03T23:59:00Z",
+  "targets": [
+    { "type": "SWING_H", "params": { "left": 2, "right": 2 } },
+    { "type": "SWING_L", "params": { "left": 2, "right": 2 } },
+    {
+      "type": "EQH",
+      "params": {
+        "tolerance_ticks": 1,
+        "price_increment": 0.0001,
+        "min_count": 3,
+        "lookback_bars": 200
+      }
+    },
+    {
+      "type": "EQL",
+      "params": {
+        "tolerance_ticks": 1,
+        "price_increment": 0.0001,
+        "min_count": 3,
+        "lookback_bars": 200
+      }
+    },
+    { "type": "BOS_H", "params": { "left": 2, "right": 2 } },
+    { "type": "BOS_L", "params": { "left": 2, "right": 2 } },
+    { "type": "MSS", "params": { "left": 2, "right": 2 } }
+  ],
+  "output_schema": "marketdata",
+  "output_table": "levels",
+  "upsert": true
+}

--- a/src/quant_engine/levels/helpers.py
+++ b/src/quant_engine/levels/helpers.py
@@ -1,0 +1,200 @@
+"""Helper utilities to consume detected levels within analytics pipelines."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _normalise_timestamp(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, utc=True, errors="coerce")
+
+
+def _prepare_levels(levels_df: pd.DataFrame) -> pd.DataFrame:
+    levels = levels_df.copy()
+    if levels.empty:
+        return levels
+    for col in ("ts", "anchor_ts", "valid_from_ts", "valid_to_ts"):
+        if col in levels.columns:
+            levels[col] = _normalise_timestamp(levels[col])
+    if "valid_from_ts" not in levels.columns:
+        levels["valid_from_ts"] = levels.get("anchor_ts")
+    levels["effective_from"] = levels["valid_from_ts"].fillna(levels.get("anchor_ts"))
+    return levels
+
+
+def join_levels(
+    df: pd.DataFrame,
+    levels_df: pd.DataFrame,
+    how: str = "asof",
+    on: str = "ts",
+    by: str = "symbol",
+) -> pd.DataFrame:
+    """Join OHLCV bars with the most recent active levels."""
+
+    if df.empty:
+        return df.copy()
+    left = df.copy()
+    left[on] = _normalise_timestamp(left[on])
+    if levels_df.empty:
+        return left
+    if how != "asof":
+        raise ValueError("Only 'asof' joins are currently supported")
+
+    right = _prepare_levels(levels_df)
+    right_cols = [col for col in right.columns if col not in {by, "effective_from"}]
+    left["__orig_idx"] = left.index
+
+    if by in left.columns and by in right.columns:
+        left_sorted = left.sort_values([by, on])
+        right_sorted = right.sort_values([by, "effective_from"])
+        merged = pd.merge_asof(
+            left_sorted,
+            right_sorted,
+            left_on=on,
+            right_on="effective_from",
+            by=by,
+            direction="backward",
+        )
+    else:
+        left_sorted = left.sort_values(on)
+        right_sorted = right.sort_values("effective_from")
+        merged = pd.merge_asof(
+            left_sorted,
+            right_sorted,
+            left_on=on,
+            right_on="effective_from",
+            direction="backward",
+        )
+
+    if "valid_from_ts" in merged.columns or "valid_to_ts" in merged.columns:
+        valid_from = merged.get("valid_from_ts")
+        if valid_from is None:
+            valid_from = merged.get("anchor_ts")
+        valid_to = merged.get("valid_to_ts")
+        ts_series = merged[on]
+        active_mask = pd.Series(True, index=merged.index)
+        if valid_from is not None:
+            active_mask &= ts_series >= valid_from.fillna(pd.Timestamp.min.tz_localize("UTC"))
+        if valid_to is not None:
+            active_mask &= valid_to.isna() | (ts_series <= valid_to)
+        inactive = ~active_mask
+        if inactive.any():
+            cols_to_clear = [col for col in right_cols if col in merged.columns]
+            merged.loc[inactive, cols_to_clear] = np.nan
+
+    merged.sort_values("__orig_idx", inplace=True)
+    merged.set_index("__orig_idx", inplace=True)
+    merged.index.name = None
+    merged.drop(columns=[col for col in ["effective_from"] if col in merged.columns], inplace=True)
+    return merged
+
+
+def _filter_levels(levels_df: pd.DataFrame, level_type: str) -> pd.DataFrame:
+    if levels_df.empty:
+        return levels_df
+    return levels_df[levels_df["level_type"] == level_type].copy()
+
+
+def distance_to(
+    df: pd.DataFrame,
+    levels_df: pd.DataFrame,
+    level_type: str,
+    side: str = "mid",
+) -> pd.Series:
+    """Return absolute price distance from the close to the requested level."""
+
+    if df.empty:
+        return pd.Series(dtype="float64", index=df.index)
+    filtered = _filter_levels(levels_df, level_type)
+    enriched = join_levels(df, filtered)
+    if enriched.empty or "close" not in enriched.columns:
+        return pd.Series(dtype="float64", index=enriched.index)
+    close = enriched["close"].astype(float)
+    distances = pd.Series(np.nan, index=enriched.index, dtype="float64")
+    level_col = enriched.get("level_type")
+    if level_col is None:
+        return distances
+    level_mask = level_col.fillna("") == level_type
+    if not level_mask.any():
+        return distances
+    price = enriched.get("price")
+    price_lo = enriched.get("price_lo")
+    price_hi = enriched.get("price_hi")
+    if side == "mid":
+        mid = price
+        if mid is None:
+            mid = pd.Series(np.nan, index=enriched.index)
+        if price_lo is not None and price_hi is not None:
+            zone_mid = (price_lo + price_hi) / 2.0
+            mid = mid.fillna(zone_mid)
+        distances.loc[level_mask] = (close - mid).abs()[level_mask]
+    elif side == "edge":
+        diff_price = pd.Series(np.nan, index=enriched.index)
+        if price_lo is not None and price_hi is not None:
+            lower = (close - price_lo).abs()
+            upper = (close - price_hi).abs()
+            edge_dist = pd.concat([lower, upper], axis=1).min(axis=1)
+            diff_price = edge_dist
+        if price is not None:
+            diff_price = diff_price.fillna((close - price).abs())
+        distances.loc[level_mask] = diff_price[level_mask]
+    else:
+        raise ValueError("side must be 'mid' or 'edge'")
+    return distances
+
+
+def in_zone(
+    df: pd.DataFrame,
+    levels_df: pd.DataFrame,
+    level_type: str,
+    tolerance: float = 0.0,
+) -> pd.Series:
+    """Return a boolean Series indicating whether the close trades within the zone."""
+
+    if df.empty:
+        return pd.Series(dtype="boolean", index=df.index)
+    filtered = _filter_levels(levels_df, level_type)
+    enriched = join_levels(df, filtered)
+    result = pd.Series(False, index=enriched.index, dtype="boolean")
+    if enriched.empty or "close" not in enriched.columns:
+        return result
+    level_col = enriched.get("level_type")
+    if level_col is None:
+        return result
+    level_mask = level_col.fillna("") == level_type
+    if not level_mask.any():
+        return result
+    close = enriched["close"].astype(float)
+    price = enriched.get("price")
+    price_lo = enriched.get("price_lo")
+    price_hi = enriched.get("price_hi")
+    tol = float(tolerance)
+    if price_lo is not None and price_hi is not None:
+        lower = price_lo - tol
+        upper = price_hi + tol
+        zone_mask = (close >= lower) & (close <= upper)
+        result.loc[level_mask] = zone_mask[level_mask]
+    elif price is not None:
+        point_mask = (close - price).abs() <= tol
+        result.loc[level_mask] = point_mask[level_mask]
+    return result
+
+
+def touched_since(
+    df: pd.DataFrame,
+    levels_df: pd.DataFrame,
+    level_type: str,
+    bars: int = 1,
+) -> pd.Series:
+    """Return True when the zone has been touched within the lookback window."""
+
+    bars = max(int(bars), 1)
+    hits = in_zone(df, levels_df, level_type)
+    if hits.empty:
+        return hits
+    rolled = hits.astype(int).rolling(window=bars, min_periods=1).max()
+    return rolled.astype(bool).astype("boolean")
+
+
+__all__ = ["join_levels", "distance_to", "in_zone", "touched_since"]
+

--- a/src/quant_engine/levels/schemas.py
+++ b/src/quant_engine/levels/schemas.py
@@ -36,6 +36,13 @@ class LevelType(str, Enum):
     PWC = "PWC"
     PMO = "PMO"
     PMC = "PMC"
+    SWING_H = "SWING_H"
+    SWING_L = "SWING_L"
+    EQH = "EQH"
+    EQL = "EQL"
+    BOS_H = "BOS_H"
+    BOS_L = "BOS_L"
+    MSS = "MSS"
 
 
 class LevelRecord(BaseModel):
@@ -69,6 +76,13 @@ class LevelRecord(BaseModel):
         "PWC",
         "PMO",
         "PMC",
+        "SWING_H",
+        "SWING_L",
+        "EQH",
+        "EQL",
+        "BOS_H",
+        "BOS_L",
+        "MSS",
     ]
     price: Optional[float] = None
     price_lo: Optional[float] = None

--- a/src/quant_engine/stats/conditions.py
+++ b/src/quant_engine/stats/conditions.py
@@ -1,8 +1,41 @@
 """Regime condition helpers for statistics runs."""
 from __future__ import annotations
 
+from functools import lru_cache
+from typing import Dict
+
 import numpy as np
 import pandas as pd
+
+from ..levels import helpers as level_helpers
+from ..levels import repo as levels_repo
+
+
+LEVELS_TABLE = "marketdata.levels"
+
+
+def _safe_select_levels(symbol: str, level_type: str) -> pd.DataFrame:
+    try:
+        engine = levels_repo.get_engine()
+    except Exception:
+        return pd.DataFrame()
+    try:
+        df_levels = levels_repo.select_levels(
+            engine,
+            LEVELS_TABLE,
+            symbol=symbol,
+            level_types=[level_type],
+            active_only=False,
+            limit=100000,
+        )
+    except Exception:
+        return pd.DataFrame()
+    return df_levels
+
+
+@lru_cache(maxsize=128)
+def _cached_levels(symbol: str, level_type: str) -> pd.DataFrame:
+    return _safe_select_levels(symbol, level_type)
 
 
 def htf_trend(df: pd.DataFrame, *, tf_multiplier: int, ema_period: int) -> pd.Series:
@@ -43,4 +76,87 @@ def session(df: pd.DataFrame, *, col: str = "session_id") -> pd.Series:
     """Return the session label as a categorical series."""
 
     return df[col].astype("category")
+
+
+def _apply_per_symbol(
+    df: pd.DataFrame,
+    level_type: str,
+    func,
+    default: pd.Series,
+) -> pd.Series:
+    if df.empty:
+        return default
+    parts: Dict[int, object] = {}
+    for symbol, group in df.groupby("symbol"):
+        levels = _cached_levels(symbol, level_type).copy()
+        series = func(group, levels)
+        parts.update({idx: series.loc[idx] for idx in series.index})
+    result = default.copy()
+    for idx, value in parts.items():
+        result.loc[idx] = value
+    return result
+
+
+def in_zone_level(level_type: str, tolerance: float = 0.0):
+    """Wrapper returning a boolean series when price trades inside a level."""
+
+    def _inner(df: pd.DataFrame) -> pd.Series:
+        base = pd.Series(False, index=df.index, dtype="boolean")
+
+        def _compute(group: pd.DataFrame, levels: pd.DataFrame) -> pd.Series:
+            if levels.empty:
+                return pd.Series(False, index=group.index, dtype="boolean")
+            series = level_helpers.in_zone(group, levels, level_type, tolerance=tolerance)
+            return series.reindex(group.index, fill_value=False).astype("boolean")
+
+        return _apply_per_symbol(df, level_type, _compute, base)
+
+    return _inner
+
+
+def distance_to_level(
+    level_type: str,
+    side: str = "mid",
+    thresh: float | None = None,
+):
+    """Return distance to a level or a boolean mask if ``thresh`` is provided."""
+
+    def _inner(df: pd.DataFrame) -> pd.Series:
+        if thresh is None:
+            base = pd.Series(np.nan, index=df.index, dtype="float64")
+        else:
+            base = pd.Series(False, index=df.index, dtype="boolean")
+
+        def _compute(group: pd.DataFrame, levels: pd.DataFrame) -> pd.Series:
+            if levels.empty:
+                if thresh is None:
+                    return pd.Series(np.nan, index=group.index, dtype="float64")
+                return pd.Series(False, index=group.index, dtype="boolean")
+            distances = level_helpers.distance_to(group, levels, level_type, side=side)
+            distances = distances.reindex(group.index)
+            if thresh is None:
+                return distances
+            mask = (distances <= float(thresh)).fillna(False)
+            return mask.astype("boolean")
+
+        return _apply_per_symbol(df, level_type, _compute, base)
+
+    return _inner
+
+
+def touched_level_since(level_type: str, bars: int = 1):
+    """Return a boolean series when a level has been touched within ``bars`` bars."""
+
+    def _inner(df: pd.DataFrame) -> pd.Series:
+        base = pd.Series(False, index=df.index, dtype="boolean")
+
+        def _compute(group: pd.DataFrame, levels: pd.DataFrame) -> pd.Series:
+            if levels.empty:
+                return pd.Series(False, index=group.index, dtype="boolean")
+            touched = level_helpers.touched_since(group, levels, level_type, bars=bars)
+            return touched.reindex(group.index, fill_value=False).astype("boolean")
+
+        return _apply_per_symbol(df, level_type, _compute, base)
+
+    return _inner
 

--- a/tests/test_levels_phase2a_smoke.py
+++ b/tests/test_levels_phase2a_smoke.py
@@ -1,0 +1,135 @@
+"""Smoke tests for structure and liquidity pool detectors."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from quant_engine.levels.builders import build_levels
+from quant_engine.levels.schemas import LevelsBuildSpec
+
+
+def test_levels_phase2a_smoke(tmp_path) -> None:
+    ts = pd.date_range("2024-01-01", periods=40, freq="h", tz="UTC")
+    close_vals = np.array(
+        [
+            1.0000,
+            1.0008,
+            1.0016,
+            1.0028,
+            1.0020,
+            1.0012,
+            1.0004,
+            0.9992,
+            1.0005,
+            1.0018,
+            1.0032,
+            1.0040,
+            1.0046,
+            1.0038,
+            1.0024,
+            1.0008,
+            0.9988,
+            0.9980,
+            0.9992,
+            1.0008,
+            1.0026,
+            1.0044,
+            1.0062,
+            1.0075,
+            1.0088,
+            1.0096,
+            1.0104,
+            1.0112,
+            1.0118,
+            1.0125,
+            1.0132,
+            1.0138,
+            1.0145,
+            1.0152,
+            1.0158,
+            1.0165,
+            1.0172,
+            1.0178,
+            1.0185,
+            1.0190,
+        ]
+    )
+    open_vals = close_vals - 0.0002
+    high_vals = close_vals + 0.0004
+    low_vals = close_vals - 0.0004
+
+    # Equal highs cluster around 1.0065 within tolerance.
+    high_vals[22] = 1.0065
+    high_vals[23] = 1.0066
+    high_vals[24] = 1.0065
+    # Equal lows cluster around 0.9982 within tolerance.
+    low_vals[15] = 0.9982
+    low_vals[16] = 0.9983
+    low_vals[17] = 0.9982
+
+    df = pd.DataFrame(
+        {
+            "ts": ts,
+            "symbol": "TEST",
+            "open": open_vals,
+            "high": high_vals,
+            "low": low_vals,
+            "close": close_vals,
+            "volume": 1000,
+        }
+    )
+
+    csv_path = tmp_path / "ohlcv.csv"
+    df.to_csv(csv_path, index=False)
+
+    spec_payload = {
+        "data": {
+            "dataset_path": str(csv_path),
+            "symbols": ["TEST"],
+            "timeframe": "H1",
+            "start": ts.min().isoformat(),
+            "end": ts.max().isoformat(),
+        },
+        "symbols": ["TEST"],
+        "range_start": ts.min().isoformat(),
+        "range_end": ts.max().isoformat(),
+        "targets": [
+            {"type": "SWING_H", "params": {"left": 2, "right": 2}},
+            {"type": "SWING_L", "params": {"left": 2, "right": 2}},
+            {
+                "type": "EQH",
+                "params": {
+                    "tolerance_ticks": 1,
+                    "price_increment": 0.0001,
+                    "min_count": 2,
+                    "lookback_bars": 20,
+                },
+            },
+            {
+                "type": "EQL",
+                "params": {
+                    "tolerance_ticks": 1,
+                    "price_increment": 0.0001,
+                    "min_count": 2,
+                    "lookback_bars": 20,
+                },
+            },
+            {"type": "BOS_H", "params": {"left": 2, "right": 2}},
+            {"type": "BOS_L", "params": {"left": 2, "right": 2}},
+            {"type": "MSS", "params": {"left": 2, "right": 2}},
+        ],
+    }
+    spec = LevelsBuildSpec.model_validate(spec_payload)
+    records = build_levels(spec, df)
+
+    by_type = {}
+    for record in records:
+        by_type.setdefault(record.level_type, []).append(record)
+
+    assert len(by_type.get("SWING_H", [])) > 0
+    assert len(by_type.get("SWING_L", [])) > 0
+    assert len(by_type.get("EQH", [])) > 0
+    assert len(by_type.get("EQL", [])) > 0
+    assert len(by_type.get("BOS_H", [])) > 0
+    assert len(by_type.get("BOS_L", [])) > 0
+    assert len(by_type.get("MSS", [])) > 0


### PR DESCRIPTION
## Summary
- add fractal swing, liquidity pool, and BOS/MSS detectors with builder wiring and schema updates
- expose helper utilities, stats condition wrappers, docs, and example spec for structure levels
- add `/levels/search` API endpoint and smoke test covering the new detectors

## Testing
- poetry run pytest tests/test_levels_phase2a_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e058e5ac6483238a1891fd5c4bbcd3