### PR TITLE
Add ADX, ATR, and EMA slope filters

### DIFF
--- a/specs/filters_volatility_trend_example.json
+++ b/specs/filters_volatility_trend_example.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "symbols": ["EURUSD"],
+    "start": "2024-01-01T00:00:00Z",
+    "end": "2024-01-07T00:00:00Z",
+    "dataset_path": "specs/examples/data/eurusd_m1_sample.json"
+  },
+  "filters": [
+    {
+      "type": "adx",
+      "params": {"window": 14, "thresh": 20}
+    },
+    {
+      "type": "atr",
+      "params": {"window": 14, "min_mult": 0.5, "max_mult": 2.0}
+    },
+    {
+      "type": "ema_slope",
+      "params": {"window": 50, "slope_thresh": 0.0001}
+    }
+  ]
+}

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -27,6 +27,7 @@ from ..stats import conditions as stats_conditions
 from ..stats.estimators import freq_with_wilson
 from ..seasonality import runner as seasonality_runner
 from ..seasonality.optimize import run_optimization as seasonality_run_optimization
+from ..filters import list_filter_types
 from . import schemas
 
 _jobs: Dict[str, Dict[str, Any]] = {}
@@ -89,6 +90,12 @@ def stats_condition_types() -> List[str]:
     """Return the list of supported condition factory names."""
 
     return stats_conditions.list_condition_types()
+
+
+def filters_list() -> List[str]:
+    """Return the list of supported filter identifiers."""
+
+    return list_filter_types()
 
 
 # ---------------------------------------------------------------------------
@@ -810,6 +817,13 @@ def stats_conditions_endpoint() -> List[str]:
     """Return the list of supported condition factories."""
 
     return stats_condition_types()
+
+
+@fastapi_app.get('/filters/list', response_model=List[str])
+def filters_list_endpoint() -> List[str]:
+    """Return the list of available filters."""
+
+    return filters_list()
 
 
 @fastapi_app.post('/stats/run', response_model=schemas.StatusResponse)

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -84,6 +84,13 @@ class StatsConditionSpec(BaseModel):
     params: Dict[str, Any] = Field(default_factory=dict)
 
 
+class FilterConditionSpec(BaseModel):
+    """Specification for applying a pre-trade filter."""
+
+    type: Literal["adx", "atr", "ema_slope"]
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
 class StatsTargetSpec(BaseModel):
     """Specification for a target metric."""
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -1,0 +1,24 @@
+"""Collection of reusable pre-trade filters."""
+from __future__ import annotations
+
+from .volatility_trend import adx_filter, atr_filter, ema_slope_filter
+
+__all__ = [
+    "adx_filter",
+    "atr_filter",
+    "ema_slope_filter",
+    "filters_registry",
+    "list_filter_types",
+]
+
+filters_registry = {
+    "adx": adx_filter,
+    "atr": atr_filter,
+    "ema_slope": ema_slope_filter,
+}
+
+
+def list_filter_types() -> list[str]:
+    """Return the list of available filter identifiers."""
+
+    return sorted(filters_registry)

--- a/src/quant_engine/filters/volatility_trend.py
+++ b/src/quant_engine/filters/volatility_trend.py
@@ -1,0 +1,117 @@
+"""Volatility and trend filters used to pre-screen trading opportunities."""
+from __future__ import annotations
+
+from importlib import util as importlib_util
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+_TALIB_AVAILABLE = importlib_util.find_spec("talib") is not None
+if _TALIB_AVAILABLE:  # pragma: no cover - optional dependency
+    import talib  # type: ignore
+
+
+_REQUIRED_OHLC_COLUMNS = ("high", "low", "close")
+
+
+def _ensure_columns(df: pd.DataFrame, columns: Iterable[str]) -> None:
+    missing = [col for col in columns if col not in df.columns]
+    if missing:
+        raise ValueError(f"DataFrame is missing required columns: {', '.join(missing)}")
+
+
+def _true_range(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
+    prev_close = close.shift(1)
+    components = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    )
+    tr = components.max(axis=1)
+    return tr
+
+
+def _wilder_smoothing(series: pd.Series, window: int) -> pd.Series:
+    return series.ewm(alpha=1 / float(window), adjust=False).mean()
+
+
+
+def adx_filter(df: pd.DataFrame, window: int = 14, thresh: float = 20.0) -> pd.Series:
+    """Return a boolean mask where the Average Directional Index exceeds ``thresh``."""
+
+    _ensure_columns(df, _REQUIRED_OHLC_COLUMNS)
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    close = df["close"].astype(float)
+
+    if _TALIB_AVAILABLE:  # pragma: no cover - optional dependency
+        adx_values = talib.ADX(high.values, low.values, close.values, timeperiod=window)
+        adx = pd.Series(adx_values, index=df.index, dtype=float)
+    else:
+        up_move = high.diff()
+        down_move = low.shift(1) - low
+        plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+        minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+
+        tr = _true_range(high, low, close)
+        tr_smoothed = _wilder_smoothing(tr, window)
+        plus_di = 100 * _wilder_smoothing(pd.Series(plus_dm, index=df.index), window) / tr_smoothed
+        minus_di = 100 * _wilder_smoothing(pd.Series(minus_dm, index=df.index), window) / tr_smoothed
+        denominator = (plus_di + minus_di).replace(0, np.nan)
+        dx = (plus_di.subtract(minus_di).abs() / denominator) * 100.0
+        adx = _wilder_smoothing(dx, window)
+
+    mask = (adx > float(thresh)).fillna(False)
+    return mask.astype(bool)
+
+
+
+def atr_filter(
+    df: pd.DataFrame,
+    window: int = 14,
+    min_mult: float = 0.5,
+    max_mult: float = 2.0,
+) -> pd.Series:
+    """Return a boolean mask keeping assets where ATR/close is within a band."""
+
+    _ensure_columns(df, _REQUIRED_OHLC_COLUMNS)
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    close = df["close"].astype(float)
+
+    if _TALIB_AVAILABLE:  # pragma: no cover - optional dependency
+        atr_values = talib.ATR(high.values, low.values, close.values, timeperiod=window)
+        atr = pd.Series(atr_values, index=df.index, dtype=float)
+    else:
+        tr = _true_range(high, low, close)
+        atr = _wilder_smoothing(tr, window)
+
+    close_safe = close.replace(0, np.nan)
+    ratio = atr / close_safe
+    min_ratio = float(min_mult) / 100.0
+    max_ratio = float(max_mult) / 100.0
+    mask = ratio.between(min_ratio, max_ratio)
+    return mask.fillna(False).astype(bool)
+
+
+
+def ema_slope_filter(df: pd.DataFrame, window: int = 50, slope_thresh: float = 0.0) -> pd.Series:
+    """Return ``True`` when the EMA slope is above ``slope_thresh``."""
+
+    if "close" not in df.columns:
+        raise ValueError("DataFrame is missing required column: close")
+    close = df["close"].astype(float)
+
+    if _TALIB_AVAILABLE:  # pragma: no cover - optional dependency
+        ema_values = talib.EMA(close.values, timeperiod=window)
+        ema = pd.Series(ema_values, index=df.index, dtype=float)
+    else:
+        ema = close.ewm(span=window, adjust=False).mean()
+
+    slope = ema.diff()
+    mask = slope > float(slope_thresh)
+    return mask.fillna(False).astype(bool)

--- a/tests/test_filters_volatility_trend_smoke.py
+++ b/tests/test_filters_volatility_trend_smoke.py
@@ -1,0 +1,34 @@
+"""Smoke tests for volatility and trend filters."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from quant_engine.filters import adx_filter, atr_filter, ema_slope_filter
+
+
+def _make_sample_df(rows: int = 256) -> pd.DataFrame:
+    rng = np.random.default_rng(42)
+    index = pd.date_range("2024-01-01", periods=rows, freq="1h", tz="UTC")
+    trend = np.linspace(1.0, 1.1, rows)
+    noise = rng.normal(scale=0.001, size=rows)
+    close = trend + noise
+    high = close + 0.003 + rng.normal(scale=0.0005, size=rows)
+    low = close - 0.003 - rng.normal(scale=0.0005, size=rows)
+    data = pd.DataFrame({"high": high, "low": low, "close": close}, index=index)
+    return data
+
+
+def test_filters_return_boolean_series() -> None:
+    df = _make_sample_df()
+    filters = [
+        (adx_filter, {"window": 14, "thresh": 20.0}),
+        (atr_filter, {"window": 14, "min_mult": 0.5, "max_mult": 2.0}),
+        (ema_slope_filter, {"window": 32, "slope_thresh": 0.0}),
+    ]
+    for func, kwargs in filters:
+        series = func(df, **kwargs)
+        assert isinstance(series, pd.Series)
+        assert series.index.equals(df.index)
+        assert len(series) == len(df)
+        assert series.dtype == bool


### PR DESCRIPTION
## Summary
- add a volatility and trend filters module with ADX, ATR, and EMA slope implementations and registry
- expose available filters through the API and add a schema helper plus example spec
- cover the new filters with a smoke test dataset

## Testing
- pytest tests/test_filters_volatility_trend_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e06e401ac48323911d85a44a628f2a