### PR TITLE
Add volume profile filters and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ export $(grep -v '^#' .env | xargs)
 ```
 
 ## 📖 Documentation
+- [Getting started](docs/getting_started.md)
+- [Filtres pré-trade](docs/filters.md)
 - [Seasonality – Dimensions & Métriques](docs/seasonality_reference.md)
 
 ## Lancer l'API

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -1,0 +1,29 @@
+# Filter reference
+
+This document provides a concise reference for the pre-trade filters available in the Quant Engine.
+
+## Core volatility & trend filters
+
+These filters rely on volatility or trend metrics computed directly from the OHLCV stream. Refer to the individual function docstrings for the latest parameter details.
+
+- `adx`
+- `atr`
+- `ema_slope`
+
+## Volume & Market Profile filters
+
+### `volume_surge`
+- **Paramètres** : `window` (int), `mode` = `"z"` \| `"ratio"`, `z_thresh`, `ratio_thresh`.
+- **Retour** : `True` si pic de volume (z-score≥seuil ou ratio≥seuil).
+- **Notes** : si `volume` absent → renvoie `False` partout.
+
+### `vwap_side`
+- **Paramètres** : `anchor` = `"day"` \| `"session"`, `side` = `"above"` \| `"below"`, `from_levels` (bool), `symbol`.
+- **Retour** : `True` si `close` est du bon côté du VWAP ancré.
+- **Sources** : tente de lire `VWAP_DAY` / `VWAP_SESSION` depuis `marketdata.levels`, sinon **fallback** VWAP journalier local.
+- **Avertissement** : la qualité dépend du volume dispo ; en FX spot, le VWAP peut être approximatif.
+
+### `poc_distance`
+- **Paramètres** : `max_distance` (float), `unit` = `"abs"` \| `"pct"`, `symbol`, `level_type="POC"`.
+- **Retour** : `True` si la distance au **POC actif** le plus proche ≤ seuil.
+- **Notes** : nécessite des **POC** en DB (`marketdata.levels`). Sans POC: renvoie `False`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,36 @@
+# Getting started
+
+Ce guide résume les premières étapes pour utiliser Quant Engine en local.
+
+## Installation rapide
+
+1. Installe les dépendances système (voir README).
+2. Clone le dépôt et installe l'environnement Poetry :
+   ```bash
+   poetry install
+   ```
+3. Configure les variables d'environnement nécessaires (`QE_MARKETDATA_MYSQL_URL`, `DB_DSN`, etc.).
+
+## Lancer l'API localement
+
+```bash
+poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
+```
+
+## Lancer la CLI
+
+Les commandes Typer sont exposées sous l'alias `qe` :
+
+```bash
+poetry run qe --help
+```
+
+## Essayer les filtres Volume/Profile
+
+Les filtres pré-trade peuvent être évalués dans les workflows de statistiques. Un exemple complet est fourni dans `specs/filters_volume_profile_example.json`.
+
+```bash
+poetry run qe stats run --spec specs/filters_volume_profile_example.json
+```
+
+Le résultat présente les lifts calculés après application des filtres `volume_surge`, `vwap_side` et `poc_distance`. Lorsque la base `marketdata.levels` n'est pas accessible, les filtres reviennent automatiquement sur leurs fallbacks (ou renvoient `False`).

--- a/specs/filters_volume_profile_example.json
+++ b/specs/filters_volume_profile_example.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume",
+      "timeframe_col": null
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-05T00:00:00Z",
+    "end": "2025-01-10T23:59:00Z"
+  },
+  "filters": [
+    { "type": "volume_surge", "params": { "window": 20, "mode": "z", "z_thresh": 1.8 } },
+    { "type": "vwap_side", "params": { "anchor": "day", "side": "above", "from_levels": true, "symbol": "EURUSD" } },
+    { "type": "poc_distance", "params": { "max_distance": 0.0007, "unit": "abs", "symbol": "EURUSD" } }
+  ]
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -87,7 +87,14 @@ class StatsConditionSpec(BaseModel):
 class FilterConditionSpec(BaseModel):
     """Specification for applying a pre-trade filter."""
 
-    type: Literal["adx", "atr", "ema_slope"]
+    type: Literal[
+        "adx",
+        "atr",
+        "ema_slope",
+        "volume_surge",
+        "vwap_side",
+        "poc_distance",
+    ]
     params: Dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from .volatility_trend import adx_filter, atr_filter, ema_slope_filter
+from .volume_profile import volume_surge_filter, vwap_side_filter, poc_distance_filter
 
 __all__ = [
     "adx_filter",
     "atr_filter",
     "ema_slope_filter",
+    "volume_surge_filter",
+    "vwap_side_filter",
+    "poc_distance_filter",
     "filters_registry",
     "list_filter_types",
 ]
@@ -15,6 +19,9 @@ filters_registry = {
     "adx": adx_filter,
     "atr": atr_filter,
     "ema_slope": ema_slope_filter,
+    "volume_surge": volume_surge_filter,
+    "vwap_side": vwap_side_filter,
+    "poc_distance": poc_distance_filter,
 }
 
 

--- a/src/quant_engine/filters/volume_profile.py
+++ b/src/quant_engine/filters/volume_profile.py
@@ -1,0 +1,154 @@
+import numpy as np
+import pandas as pd
+from typing import Optional, Literal
+
+try:
+    from quant_engine.levels import repo as lvl_repo
+    from quant_engine.levels import helpers as lvl_helpers
+except Exception:
+    lvl_repo = None
+    lvl_helpers = None
+
+
+def _zscore(x: pd.Series, window: int) -> pd.Series:
+    m = x.rolling(window, min_periods=max(3, window//3)).mean()
+    s = x.rolling(window, min_periods=max(3, window//3)).std(ddof=0)
+    return (x - m) / s.replace(0, np.nan)
+
+
+def volume_surge_filter(
+    df: pd.DataFrame,
+    window: int = 20,
+    mode: Literal["z", "ratio"] = "z",
+    z_thresh: float = 1.5,
+    ratio_thresh: float = 1.5,
+    volume_col: str = "volume",
+) -> pd.Series:
+    """
+    True si pic de volume.
+    - mode="z": z-score(volume) >= z_thresh
+    - mode="ratio": volume / moyenne_rolling >= ratio_thresh
+    Fallback : si pas de colonne volume -> False partout.
+    """
+    if volume_col not in df.columns:
+        return pd.Series(False, index=df.index)
+    v = df[volume_col].astype(float)
+    if mode == "z":
+        z = _zscore(v, window)
+        out = z >= z_thresh
+    else:
+        ma = v.rolling(window, min_periods=max(3, window // 3)).mean()
+        ratio = v / ma.replace(0, np.nan)
+        out = ratio >= ratio_thresh
+    return out.fillna(False)
+
+
+def _compute_intraday_vwap(df: pd.DataFrame, price_col="close", volume_col="volume") -> pd.Series:
+    """
+    VWAP cumulatif par JOUR (UTC). Si volume absent : proxy TPO (moyenne cumulée du prix).
+    """
+    grp = df.index.normalize()
+    if volume_col not in df.columns:
+        cum_price = df.groupby(grp)[price_col].cumsum()
+        counts = df.groupby(grp).cumcount() + 1
+        return (cum_price / counts).reindex(df.index)
+    pv = (df[price_col] * df[volume_col]).groupby(grp).cumsum()
+    vv = df.groupby(grp)[volume_col].cumsum().replace(0, np.nan)
+    return (pv / vv).reindex(df.index)
+
+
+def vwap_side_filter(
+    df: pd.DataFrame,
+    anchor: Literal["day", "session"] = "day",
+    side: Literal["above", "below"] = "above",
+    price_col: str = "close",
+    volume_col: str = "volume",
+    from_levels: bool = True,
+    symbol: Optional[str] = None,
+) -> pd.Series:
+    """
+    True si le prix est du 'bon côté' du VWAP ancré:
+    - anchor="day" ou "session"
+    - from_levels=True : tente de lire un VWAP depuis marketdata.levels ; fallback -> calcul local
+    Hypothèses : index UTC croissant; symbol optionnel pour la lecture DB.
+    """
+    price = df[price_col].astype(float)
+    vwap_series = None
+
+    if from_levels and lvl_repo is not None and symbol is not None:
+        try:
+            level_types = ["VWAP_DAY"] if anchor == "day" else ["VWAP_SESSION"]
+            lv = lvl_repo.select_levels(
+                engine=None, table_fqn=None,
+                symbol=symbol, level_types=level_types,
+                active_only=False,
+                start=df.index.min().isoformat(),
+                end=df.index.max().isoformat(),
+                limit=100000
+            )
+            if isinstance(lv, pd.DataFrame) and not lv.empty and lvl_helpers is not None:
+                vw = lv[lv["price"].notna()].copy().sort_values("anchor_ts")
+                # asof join: propager la dernière valeur connue
+                left = df[[price_col]].copy()
+                left["ts"] = df.index
+                joined = lvl_helpers.join_levels(
+                    left,
+                    vw.rename(columns={"price": "level_price"}),
+                    how="asof",
+                    on="ts",
+                )
+                if isinstance(joined, pd.DataFrame) and "level_price" in joined.columns:
+                    vwap_series = joined["level_price"].reindex(df.index)
+        except Exception:
+            vwap_series = None
+
+    if vwap_series is None:
+        vwap_series = _compute_intraday_vwap(df, price_col=price_col, volume_col=volume_col)
+
+    return ((price >= vwap_series) if side == "above" else (price <= vwap_series)).fillna(False)
+
+
+def poc_distance_filter(
+    df: pd.DataFrame,
+    max_distance: float,
+    unit: Literal["abs", "pct"] = "abs",
+    symbol: Optional[str] = None,
+    level_type: str = "POC",
+) -> pd.Series:
+    """
+    True si la distance à un POC 'actif' le plus proche est <= max_distance.
+    - Lit les POC depuis marketdata.levels si possible, sinon False (pas de fallback fiable).
+    - unit='abs' : distance en prix ; unit='pct' : |close-POC|/close
+    """
+    if lvl_repo is None or lvl_helpers is None or symbol is None:
+        return pd.Series(False, index=df.index)
+
+    try:
+        lv = lvl_repo.select_levels(
+            engine=None, table_fqn=None,
+            symbol=symbol, level_types=[level_type],
+            active_only=True,
+            start=df.index.min().isoformat(),
+            end=df.index.max().isoformat(),
+            limit=100000
+        )
+        if not isinstance(lv, pd.DataFrame) or lv.empty:
+            return pd.Series(False, index=df.index)
+
+        price_series = df["close"].astype(float)
+        # Tente helper distance_to, sinon asof local
+        try:
+            dist = lvl_helpers.distance_to(df, lv.copy(), level_type=level_type, side="mid")
+        except Exception:
+            lv_ = lv.sort_values("anchor_ts")["anchor_ts"].to_frame().join(lv[["price"]])
+            lv_ = lv_.dropna()
+            lv_ = lv_.rename(columns={"anchor_ts": "ts", "price": "lvl"})
+            lv_ = lv_.set_index(pd.to_datetime(lv_["ts"], utc=True))["lvl"].reindex(df.index, method="ffill")
+            dist = (price_series - lv_).abs()
+
+        if unit == "pct":
+            dist = dist / price_series.replace(0, np.nan)
+
+        return (dist <= max_distance).fillna(False)
+    except Exception:
+        return pd.Series(False, index=df.index)

--- a/tests/test_filters_volume_profile_smoke.py
+++ b/tests/test_filters_volume_profile_smoke.py
@@ -1,0 +1,87 @@
+"""Smoke tests for volume & market profile filters."""
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from quant_engine.filters.volume_profile import (
+    volume_surge_filter,
+    vwap_side_filter,
+    poc_distance_filter,
+)
+
+
+def _make_df(n: int = 200) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=n, freq="1min", tz="UTC")
+    base_price = 1.10 + np.cumsum(np.random.normal(0, 0.0001, size=n))
+    df = pd.DataFrame(
+        {
+            "open": base_price + np.random.normal(0, 0.00005, size=n),
+            "high": base_price + np.abs(np.random.normal(0, 0.0001, size=n)),
+            "low": base_price - np.abs(np.random.normal(0, 0.0001, size=n)),
+            "close": base_price,
+            "volume": np.random.randint(100, 200, size=n).astype(float),
+        },
+        index=idx,
+    )
+    return df
+
+
+def test_volume_surge_filter_smoke():
+    df = _make_df()
+    result = volume_surge_filter(df, window=10, mode="z", z_thresh=1.0)
+    assert isinstance(result, pd.Series)
+    assert result.index.equals(df.index)
+    assert result.dtype == bool
+    assert result.any() or (~result).any()
+
+
+def test_vwap_side_filter_local_fallback():
+    df = _make_df()
+    result = vwap_side_filter(df, from_levels=False)
+    assert isinstance(result, pd.Series)
+    assert result.index.equals(df.index)
+    assert result.dtype == bool
+
+
+def test_poc_distance_filter_with_and_without_levels(monkeypatch):
+    df = _make_df()
+
+    # Without symbol or repo -> False everywhere
+    result = poc_distance_filter(df, max_distance=0.0005, symbol=None)
+    assert isinstance(result, pd.Series)
+    assert not result.any()
+
+    # Mock levels repo/helpers
+    class DummyRepo:
+        def select_levels(self, **kwargs):
+            ts = pd.date_range(df.index.min(), periods=5, freq="30min")
+            return pd.DataFrame(
+                {
+                    "anchor_ts": ts,
+                    "price": np.linspace(df["close"].min(), df["close"].max(), len(ts)),
+                }
+            )
+
+    class DummyHelpers:
+        @staticmethod
+        def distance_to(df_local, levels_df, level_type="POC", side="mid"):
+            prices = levels_df["price"].to_numpy()
+            anchored = pd.Series(prices[-1], index=df_local.index)
+            return (df_local["close"] - anchored).abs()
+
+    monkeypatch.setattr(
+        "quant_engine.filters.volume_profile.lvl_repo",
+        DummyRepo(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "quant_engine.filters.volume_profile.lvl_helpers",
+        DummyHelpers,
+        raising=False,
+    )
+
+    result = poc_distance_filter(df, max_distance=0.01, symbol="EURUSD")
+    assert result.any()
+    assert result.index.equals(df.index)
+    assert result.dtype == bool


### PR DESCRIPTION
## Summary
- add volume profile filters with VWAP and POC integrations and expose them through the registry and API
- provide an example specification and smoke tests covering the new filters
- document volume/profile filters and update getting started guidance

## Testing
- pytest tests/test_filters_volume_profile_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e0719d7a848323b96694a92844636e