### PR TITLE
docs: document trend volatility filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
   poetry run quant-engine runs show RUN_ID
   ```
 
+## Exemples de filtres
+
+### Volatilité & tendance
+
+```bash
+poetry run quant-engine stats run --spec specs/filters_volatility_trend_example.json
+```
+
+> Consulte la [référence des filtres](docs/filters.md) pour le détail des paramètres ADX/ATR/EMA slope et des autres filtres disponibles.
+
 ## Configuration `.env`
 Copier `.env.example` vers `.env` et ajuster :
 ```env

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -2,13 +2,24 @@
 
 This document provides a concise reference for the pre-trade filters available in the Quant Engine.
 
-## Core volatility & trend filters
+## Trend & Volatility filters
 
-These filters rely on volatility or trend metrics computed directly from the OHLCV stream. Refer to the individual function docstrings for the latest parameter details.
+Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés directement à partir du flux OHLCV.
 
-- `adx`
-- `atr`
-- `ema_slope`
+### `adx`
+- **Paramètres** : `window` (int), `thresh` (float).
+- **Retour** : `True` si `ADX(window) > thresh`.
+- **Utilité** : confirme qu'une tendance est suffisamment forte pour éviter les phases de range.
+
+### `atr`
+- **Paramètres** : `window` (int), `min_mult` (float), `max_mult` (float).
+- **Retour** : `True` si `ATR(window) / close` appartient à l'intervalle `[min_mult, max_mult]`.
+- **Utilité** : filtre les marchés trop calmes ou, à l'inverse, trop explosifs.
+
+### `ema_slope`
+- **Paramètres** : `window` (int), `slope_thresh` (float).
+- **Retour** : `True` si la pente de `EMA(window)` est `> slope_thresh` (tendance haussière) ou `< -slope_thresh` (tendance baissière).
+- **Utilité** : valide que la tendance présente une pente marquée plutôt qu'une moyenne mobile plate.
 
 ## Volume & Market Profile filters
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,6 +25,16 @@ Les commandes Typer sont exposées sous l'alias `qe` :
 poetry run qe --help
 ```
 
+## Essayer les filtres Volatilité/Tendance
+
+Un exemple prêt à l'emploi est fourni dans `specs/filters_volatility_trend_example.json`.
+
+```bash
+poetry run qe stats run --spec specs/filters_volatility_trend_example.json
+```
+
+Ce scénario combine `adx`, `atr` et `ema_slope` pour illustrer les filtres de tendance et de volatilité.
+
 ## Essayer les filtres Volume/Profile
 
 Les filtres pré-trade peuvent être évalués dans les workflows de statistiques. Un exemple complet est fourni dans `specs/filters_volume_profile_example.json`.


### PR DESCRIPTION
## Summary
- document ADX, ATR, and EMA slope behaviour in the filter reference
- link the filter reference from the README and add a volatility/trend CLI example
- add a getting started example spec for volatility and trend filters

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e073025fe48323ade52b3a999f8fc9