### PR TITLE
Add structure & ICT filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ poetry run quant-engine stats run --spec specs/filters_volatility_trend_example.
 
 > Consulte la [référence des filtres](docs/filters.md) pour le détail des paramètres ADX/ATR/EMA slope et des autres filtres disponibles.
 
+### Structure & ICT
+
+```bash
+poetry run quant-engine stats run --spec specs/filters_structure_ict_example.json
+```
+
 ## Configuration `.env`
 Copier `.env.example` vers `.env` et ajuster :
 ```env

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -38,3 +38,28 @@ Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés d
 - **Paramètres** : `max_distance` (float), `unit` = `"abs"` \| `"pct"`, `symbol`, `level_type="POC"`.
 - **Retour** : `True` si la distance au **POC actif** le plus proche ≤ seuil.
 - **Notes** : nécessite des **POC** en DB (`marketdata.levels`). Sans POC: renvoie `False`.
+
+## Structure & ICT filters
+
+### `liquidity_sweep`
+- **Idée** : mèche qui “prend” la liquidité d’un extrême récent (EQH/EQL local).  
+- **Paramètres** :  
+  - `side` = `"high"` \| `"low"`  
+  - `lookback` (barres)  
+  - `require_close_back_in` (bool, par défaut True)  
+  - `tolerance_ticks`, `price_increment` (pour marge)  
+- **Retour** : `True` quand la barre réalise un sweep (prise + close-back-in si demandé).  
+- **Source** : pure OHLC (pas besoin de DB).
+
+### `bos`
+- **Idée** : cassure du dernier swing high/low → Break Of Structure.  
+- **Paramètres** :  
+  - `direction` = `"up"` \| `"down"`  
+  - `left`, `right` (fractals)  
+  - `use_levels` (True par défaut) + `symbol` → si SWING_H/L présents en DB, les utiliser ; sinon fallback fractals.  
+- **Retour** : `True` sur la barre qui casse.  
+
+### `mss`
+- **Idée** : “flip” de structure : cassure dans un sens, puis cassure opposée dans `window` barres.  
+- **Paramètres** : `left`, `right`, `window`, `use_levels`, `symbol`.  
+- **Retour** : `True` sur la barre qui réalise la deuxième cassure.  

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,3 +44,13 @@ poetry run qe stats run --spec specs/filters_volume_profile_example.json
 ```
 
 Le résultat présente les lifts calculés après application des filtres `volume_surge`, `vwap_side` et `poc_distance`. Lorsque la base `marketdata.levels` n'est pas accessible, les filtres reviennent automatiquement sur leurs fallbacks (ou renvoient `False`).
+
+## Essayer les filtres Structure/ICT
+
+Les filtres structurels et ICT disposent d'un exemple dédié dans `specs/filters_structure_ict_example.json`.
+
+```bash
+poetry run qe YOUR_COMMAND --spec specs/filters_structure_ict_example.json
+```
+
+Remplace `YOUR_COMMAND` par la commande de backtest/statistiques adaptée à ton workflow (ex. `stats run`).

--- a/specs/filters_structure_ict_example.json
+++ b/specs/filters_structure_ict_example.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume",
+      "timeframe_col": null
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-05T00:00:00Z",
+    "end": "2025-01-10T23:59:00Z"
+  },
+  "filters": [
+    { "type": "liquidity_sweep", "params": { "side": "high", "lookback": 50, "require_close_back_in": true, "tolerance_ticks": 1, "price_increment": 0.0001 } },
+    { "type": "bos", "params": { "direction": "up", "left": 2, "right": 2, "use_levels": true, "symbol": "EURUSD" } },
+    { "type": "mss", "params": { "left": 2, "right": 2, "window": 30, "use_levels": true, "symbol": "EURUSD" } }
+  ]
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -94,6 +94,9 @@ class FilterConditionSpec(BaseModel):
         "volume_surge",
         "vwap_side",
         "poc_distance",
+        "liquidity_sweep",
+        "bos",
+        "mss",
     ]
     params: Dict[str, Any] = Field(default_factory=dict)
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .volatility_trend import adx_filter, atr_filter, ema_slope_filter
 from .volume_profile import volume_surge_filter, vwap_side_filter, poc_distance_filter
+from .structure_ict import liquidity_sweep_filter, bos_filter, mss_filter
 
 __all__ = [
     "adx_filter",
@@ -11,6 +12,9 @@ __all__ = [
     "volume_surge_filter",
     "vwap_side_filter",
     "poc_distance_filter",
+    "liquidity_sweep_filter",
+    "bos_filter",
+    "mss_filter",
     "filters_registry",
     "list_filter_types",
 ]
@@ -22,6 +26,9 @@ filters_registry = {
     "volume_surge": volume_surge_filter,
     "vwap_side": vwap_side_filter,
     "poc_distance": poc_distance_filter,
+    "liquidity_sweep": liquidity_sweep_filter,
+    "bos": bos_filter,
+    "mss": mss_filter,
 }
 
 

--- a/src/quant_engine/filters/structure_ict.py
+++ b/src/quant_engine/filters/structure_ict.py
@@ -1,0 +1,171 @@
+import numpy as np
+import pandas as pd
+from typing import Optional, Literal
+
+try:
+    from quant_engine.levels import repo as lvl_repo
+    from quant_engine.levels import helpers as lvl_helpers
+except Exception:
+    lvl_repo = None
+    lvl_helpers = None
+
+
+def _recent_extreme(series: pd.Series, window: int, side: str) -> pd.Series:
+    """
+    Retourne la série du plus haut/bas récent sur 'window' barres (rolling).
+    side='high' -> rolling_max ; 'low' -> rolling_min
+    Décale d'1 barre pour éviter le lookahead.
+    """
+    if side == "high":
+        return series.rolling(window=window, min_periods=1).max().shift(1)
+    else:
+        return series.rolling(window=window, min_periods=1).min().shift(1)
+
+
+def liquidity_sweep_filter(
+    df: pd.DataFrame,
+    side: Literal["high", "low"] = "high",
+    lookback: int = 50,
+    require_close_back_in: bool = True,
+    tolerance_ticks: int = 0,
+    price_increment: Optional[float] = None,
+) -> pd.Series:
+    """
+    True si la barre actuelle 'prend la liquidité' d’un extrême récent :
+      - side='high' : high[t] dépasse le plus haut des 'lookback' barres précédentes (décalées d’1),
+      - side='low'  : low[t]  casse le plus bas des 'lookback' barres précédentes.
+    Options :
+      - require_close_back_in=True : close revient dans le range (mèche de sweep) => filtre plus strict.
+      - tolerance_ticks : marge de tolérance (ticks * price_increment si fourni).
+    Sans dépendre de la DB (pure OHLC). Idempotent, sans lookahead.
+    """
+    hi, lo, cl = df["high"].astype(float), df["low"].astype(float), df["close"].astype(float)
+    tol = (tolerance_ticks or 0) * (price_increment or 1.0)
+
+    if side == "high":
+        ref = _recent_extreme(hi, lookback, "high")
+        took = (hi >= (ref + tol))
+        back_in = cl <= ref if require_close_back_in else pd.Series(True, index=df.index)
+        out = took & back_in
+    else:
+        ref = _recent_extreme(lo, lookback, "low")
+        took = (lo <= (ref - tol))
+        back_in = cl >= ref if require_close_back_in else pd.Series(True, index=df.index)
+        out = took & back_in
+
+    return out.fillna(False)
+
+
+def _fractals(df: pd.DataFrame, left: int = 2, right: int = 2):
+    """
+    Fractals n-bar (fallback local si pas de levels) :
+    - Swing High si high[t] > max(high[t-left...t-1]) et > max(high[t+1...t+right])
+    - Swing Low idem sur low
+    Retourne deux Series bool (is_swing_high, is_swing_low).
+    """
+    hi = df["high"].to_numpy(dtype=float)
+    lo = df["low"].to_numpy(dtype=float)
+    n = len(df)
+    sh = np.zeros(n, dtype=bool)
+    sl = np.zeros(n, dtype=bool)
+    for t in range(left, n - right):
+        if hi[t] > hi[t-left:t].max() and hi[t] > hi[t+1:t+1+right].max():
+            sh[t] = True
+        if lo[t] < lo[t-left:t].min() and lo[t] < lo[t+1:t+1+right].min():
+            sl[t] = True
+    return pd.Series(sh, index=df.index), pd.Series(sl, index=df.index)
+
+
+def bos_filter(
+    df: pd.DataFrame,
+    direction: Literal["up", "down"] = "up",
+    left: int = 2,
+    right: int = 2,
+    use_levels: bool = True,
+    symbol: Optional[str] = None,
+) -> pd.Series:
+    """
+    True si cassure de structure dans le sens demandé :
+      - direction='up'   : close casse le dernier swing high (résistance)
+      - direction='down' : close casse le dernier swing low (support)
+    Stratégie :
+      - si use_levels et SWING_H/L dispo dans marketdata.levels -> utiliser helpers/join_levels pour dernier swing.
+      - sinon fallback fractals local (_fractals).
+    """
+    cl = df["close"].astype(float)
+
+    if use_levels and lvl_repo is not None and lvl_helpers is not None and symbol is not None:
+        try:
+            lv = lvl_repo.select_levels(
+                engine=None, table_fqn=None,
+                symbol=symbol, level_types=["SWING_H","SWING_L"],
+                active_only=False,
+                start=df.index.min().isoformat(),
+                end=df.index.max().isoformat(),
+                limit=200000
+            )
+            if isinstance(lv, pd.DataFrame) and not lv.empty:
+                swings = lv[lv["level_type"].isin(["SWING_H","SWING_L"])].copy()
+                swings = swings.sort_values("anchor_ts")
+                # asof-join pour récupérer le dernier swing connu
+                base = df[["close"]].copy()
+                base["ts"] = base.index
+                j = lvl_helpers.join_levels(
+                    base,
+                    swings.rename(columns={"price": "level_price"}),
+                    how="asof",
+                    on="ts",
+                    by=None,
+                )
+                j.index = df.index
+                ref = j["level_price"].reindex(df.index)
+                if direction == "up":
+                    # dernier swing high seulement
+                    mask = j["level_type"].fillna("") == "SWING_H"
+                    ref_up = ref.where(mask)  # NaN si dernier level était swing low
+                    ref_up = ref_up.ffill()   # propage le dernier swing high observé
+                    return (cl > ref_up).fillna(False)
+                else:
+                    mask = j["level_type"].fillna("") == "SWING_L"
+                    ref_dn = ref.where(mask)
+                    ref_dn = ref_dn.ffill()
+                    return (cl < ref_dn).fillna(False)
+        except Exception:
+            pass
+
+    # Fallback local avec fractals
+    is_sh, is_sl = _fractals(df, left=left, right=right)
+    # construire la référence "dernier swing" au fil de l’eau
+    ref_up = df["high"].where(is_sh).ffill()
+    ref_dn = df["low"].where(is_sl).ffill()
+
+    if direction == "up":
+        return (cl > ref_up).fillna(False)
+    else:
+        return (cl < ref_dn).fillna(False)
+
+
+def mss_filter(
+    df: pd.DataFrame,
+    left: int = 2,
+    right: int = 2,
+    window: int = 50,
+    use_levels: bool = True,
+    symbol: Optional[str] = None,
+) -> pd.Series:
+    """
+    Market Structure Shift : détection d’un 'flip' de structure :
+      - on observe une cassure haussière (BOS up), suivie dans 'window' barres d’une cassure baissière (BOS down)
+        OU l’inverse (down -> up). Retourne True sur la barre qui réalise le 2e break.
+    Implémentation MVP :
+      - construire deux Series bool : bos_up, bos_down (via bos_filter)
+      - MSS = (bos_up & bos_down.rolling(window).max().shift(1)) OR (bos_down & bos_up.rolling(window).max().shift(1))
+    """
+    bos_up = bos_filter(df, direction="up", left=left, right=right, use_levels=use_levels, symbol=symbol)
+    bos_dn = bos_filter(df, direction="down", left=left, right=right, use_levels=use_levels, symbol=symbol)
+
+    prev_up = bos_up.rolling(window, min_periods=1).max().shift(1).fillna(0).astype(bool)
+    prev_dn = bos_dn.rolling(window, min_periods=1).max().shift(1).fillna(0).astype(bool)
+
+    mss = (bos_up & prev_dn) | (bos_dn & prev_up)
+    return mss.fillna(False)

--- a/tests/test_filters_structure_ict_smoke.py
+++ b/tests/test_filters_structure_ict_smoke.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pandas as pd
+
+from quant_engine.filters import (
+    bos_filter,
+    liquidity_sweep_filter,
+    mss_filter,
+)
+
+
+def _make_structure_df(rows: int = 240) -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=rows, freq="1min", tz="UTC")
+    pattern = np.array([0.0, 0.01, 0.02, 0.035, 0.015, -0.005, -0.025, -0.015, 0.005, 0.025, 0.0, -0.03])
+    cycles = rows // len(pattern)
+    close_values = []
+    level = 1.05
+    for cycle in range(cycles + 1):
+        scale = 1 + 0.15 * cycle
+        cycle_vals = level + scale * pattern
+        close_values.extend(cycle_vals)
+        level += 0.01 * scale
+    close = np.array(close_values[:rows])
+    high = close + 0.003
+    low = close - 0.003
+    df = pd.DataFrame({"open": close, "high": high, "low": low, "close": close}, index=index)
+
+    lookback = 30
+    ref_high = df["high"].rolling(window=lookback, min_periods=1).max().shift(1)
+    ref_low = df["low"].rolling(window=lookback, min_periods=1).min().shift(1)
+
+    for idx in (40, 80, 120, 160, 200):
+        ref = float(ref_high.iloc[idx])
+        if np.isnan(ref):
+            continue
+        df.iloc[idx, df.columns.get_loc("high")] = ref + 0.004
+        df.iloc[idx, df.columns.get_loc("close")] = ref - 0.001
+        df.iloc[idx, df.columns.get_loc("open")] = ref - 0.0015
+
+    for idx in (55, 95, 135, 175, 215):
+        ref = float(ref_low.iloc[idx])
+        if np.isnan(ref):
+            continue
+        df.iloc[idx, df.columns.get_loc("low")] = ref - 0.004
+        df.iloc[idx, df.columns.get_loc("close")] = ref + 0.001
+        df.iloc[idx, df.columns.get_loc("open")] = ref + 0.0015
+
+    return df
+
+
+def test_liquidity_sweep_filters_detect_events() -> None:
+    df = _make_structure_df()
+    series_high = liquidity_sweep_filter(df, side="high", lookback=30, require_close_back_in=True)
+    series_low = liquidity_sweep_filter(df, side="low", lookback=30, require_close_back_in=True)
+
+    assert isinstance(series_high, pd.Series)
+    assert isinstance(series_low, pd.Series)
+    assert series_high.index.equals(df.index)
+    assert series_low.index.equals(df.index)
+    assert series_high.dtype == bool
+    assert series_low.dtype == bool
+    assert series_high.sum() > 0
+    assert series_low.sum() > 0
+
+
+def test_bos_filters_return_boolean_series() -> None:
+    df = _make_structure_df()
+    bos_up = bos_filter(df, direction="up", use_levels=False, left=2, right=2)
+    bos_down = bos_filter(df, direction="down", use_levels=False, left=2, right=2)
+
+    assert isinstance(bos_up, pd.Series)
+    assert isinstance(bos_down, pd.Series)
+    assert bos_up.index.equals(df.index)
+    assert bos_down.index.equals(df.index)
+    assert bos_up.dtype == bool
+    assert bos_down.dtype == bool
+    assert bos_up.sum() > 0
+    assert bos_down.sum() > 0
+
+
+def test_mss_filter_detects_structure_shift() -> None:
+    df = _make_structure_df()
+    mss = mss_filter(df, use_levels=False, window=50, left=2, right=2)
+
+    assert isinstance(mss, pd.Series)
+    assert mss.index.equals(df.index)
+    assert mss.dtype == bool
+    assert mss.sum() > 0


### PR DESCRIPTION
## Summary
- add ICT-oriented filters (liquidity_sweep, bos, mss) with level-aware fallbacks
- expose the new filters through the registry, API schemas, sample spec, and smoke tests
- document Structure & ICT filters across README and getting started guide

## Testing
- poetry run pytest tests/test_filters_structure_ict_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e0742079408323a3e24158c1a63939