### PR TITLE
Add seasonality time filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ poetry run quant-engine stats run --spec specs/filters_volatility_trend_example.
 poetry run quant-engine stats run --spec specs/filters_structure_ict_example.json
 ```
 
+### Seasonality & Time
+
+```bash
+poetry run quant-engine stats run --spec specs/filters_time_seasonality_example.json
+```
+
 ## Configuration `.env`
 Copier `.env.example` vers `.env` et ajuster :
 ```env

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -60,6 +60,35 @@ Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés d
 - **Retour** : `True` sur la barre qui casse.  
 
 ### `mss`
-- **Idée** : “flip” de structure : cassure dans un sens, puis cassure opposée dans `window` barres.  
-- **Paramètres** : `left`, `right`, `window`, `use_levels`, `symbol`.  
-- **Retour** : `True` sur la barre qui réalise la deuxième cassure.  
+- **Idée** : “flip” de structure : cassure dans un sens, puis cassure opposée dans `window` barres.
+- **Paramètres** : `left`, `right`, `window`, `use_levels`, `symbol`.
+- **Retour** : `True` sur la barre qui réalise la deuxième cassure.
+
+## Seasonality & Time filters
+
+### `session_time`
+- **Sessions pré-définies (UTC)** :
+  - Asia : 23:00–07:00
+  - London : 07:00–15:00
+  - NewYork : 13:00–21:00
+- **Paramètres** : `session` (`"asia"`, `"london"`, `"newyork"`), `tz` (timezone de référence).
+- **Retour** : `True` si la barre tombe dans la session choisie.
+
+### `day_of_week`
+- **Paramètres** : `allowed_days` (liste d'entiers 0–6) ou `blocked_days`.
+- **Retour** : `True` si le jour de semaine est autorisé.
+- **Exemple** : exclure lundi (0) et vendredi (4) → `blocked_days=[0,4]`.
+
+### `day_of_month`
+- **Paramètres** : `mode="first"|"last"`, `n` (entier > 0).
+- **Retour** : `True` si la barre se situe dans les `n` premiers ou derniers jours du mois.
+
+### `month_of_year`
+- **Paramètres** : `allowed_months` ou `blocked_months` (1–12).
+- **Retour** : `True` si le mois est autorisé (ou non bloqué).
+- **Exemple** : éviter août (8) et décembre (12) → `blocked_months=[8,12]`.
+
+### `intraday_time`
+- **Paramètres** : `start`, `end` (format `"HH:MM"`), `tz`.
+- **Retour** : `True` si la barre tombe dans la fenêtre `[start, end)`.
+- **Exemple** : ne garder que 09:00–12:00 UTC.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,3 +54,13 @@ poetry run qe YOUR_COMMAND --spec specs/filters_structure_ict_example.json
 ```
 
 Remplace `YOUR_COMMAND` par la commande de backtest/statistiques adaptée à ton workflow (ex. `stats run`).
+
+## Essayer les filtres Seasonality/Time
+
+Les filtres basés sur l'heure et la saisonnalité disposent d'un exemple dans `specs/filters_time_seasonality_example.json`.
+
+```bash
+poetry run qe YOUR_COMMAND --spec specs/filters_time_seasonality_example.json
+```
+
+Comme pour les autres exemples, remplace `YOUR_COMMAND` par la commande souhaitée (`stats run`, etc.).

--- a/specs/filters_time_seasonality_example.json
+++ b/specs/filters_time_seasonality_example.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume"
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-07T23:59:00Z"
+  },
+  "filters": [
+    { "type": "session_time", "params": { "session": "london", "tz": "UTC" } },
+    { "type": "day_of_week", "params": { "allowed_days": [1, 2, 3, 4] } },
+    { "type": "day_of_month", "params": { "mode": "last", "n": 2 } },
+    { "type": "month_of_year", "params": { "blocked_months": [8, 12] } },
+    { "type": "intraday_time", "params": { "start": "09:00", "end": "12:00", "tz": "UTC" } }
+  ]
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -97,6 +97,11 @@ class FilterConditionSpec(BaseModel):
         "liquidity_sweep",
         "bos",
         "mss",
+        "session_time",
+        "day_of_week",
+        "day_of_month",
+        "month_of_year",
+        "intraday_time",
     ]
     params: Dict[str, Any] = Field(default_factory=dict)
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 from .volatility_trend import adx_filter, atr_filter, ema_slope_filter
 from .volume_profile import volume_surge_filter, vwap_side_filter, poc_distance_filter
 from .structure_ict import liquidity_sweep_filter, bos_filter, mss_filter
+from .time_seasonality import (
+    session_time_filter,
+    day_of_week_filter,
+    day_of_month_filter,
+    month_of_year_filter,
+    intraday_time_filter,
+)
 
 __all__ = [
     "adx_filter",
@@ -15,6 +22,11 @@ __all__ = [
     "liquidity_sweep_filter",
     "bos_filter",
     "mss_filter",
+    "session_time_filter",
+    "day_of_week_filter",
+    "day_of_month_filter",
+    "month_of_year_filter",
+    "intraday_time_filter",
     "filters_registry",
     "list_filter_types",
 ]
@@ -29,6 +41,11 @@ filters_registry = {
     "liquidity_sweep": liquidity_sweep_filter,
     "bos": bos_filter,
     "mss": mss_filter,
+    "session_time": session_time_filter,
+    "day_of_week": day_of_week_filter,
+    "day_of_month": day_of_month_filter,
+    "month_of_year": month_of_year_filter,
+    "intraday_time": intraday_time_filter,
 }
 
 

--- a/src/quant_engine/filters/time_seasonality.py
+++ b/src/quant_engine/filters/time_seasonality.py
@@ -1,0 +1,117 @@
+"""Seasonality and time-based filters.
+
+These filters operate solely on the time index of the input dataframe and
+return boolean series aligned with the source index.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Literal, Optional
+
+import pandas as pd
+
+SessionName = Literal["asia", "london", "newyork"]
+
+
+def _ensure_datetime_index(df: pd.DataFrame) -> pd.DatetimeIndex:
+    """Return a timezone-aware DatetimeIndex for computations."""
+
+    if not isinstance(df.index, pd.DatetimeIndex):  # pragma: no cover - defensive
+        raise TypeError("DataFrame index must be a DatetimeIndex")
+    idx = df.index
+    if idx.tz is None:
+        idx = idx.tz_localize("UTC")
+    return idx
+def session_time_filter(
+    df: pd.DataFrame,
+    session: SessionName = "london",
+    tz: str = "UTC",
+) -> pd.Series:
+    """Return ``True`` when timestamps fall within the configured session."""
+
+    idx = _ensure_datetime_index(df).tz_convert(tz)
+    hours = idx.hour
+    if session == "asia":
+        mask = (hours >= 23) | (hours < 7)
+    elif session == "london":
+        mask = (hours >= 7) & (hours < 15)
+    else:  # "newyork"
+        mask = (hours >= 13) & (hours < 21)
+    return pd.Series(mask, index=df.index)
+
+
+def day_of_week_filter(
+    df: pd.DataFrame,
+    allowed_days: Optional[Iterable[int]] = None,
+    blocked_days: Optional[Iterable[int]] = None,
+) -> pd.Series:
+    """Return ``True`` for timestamps occurring on allowed weekdays."""
+
+    idx = _ensure_datetime_index(df)
+    weekdays = pd.Series(idx.dayofweek, index=df.index)
+    if allowed_days is not None and blocked_days is not None:
+        raise ValueError("Specify either allowed_days or blocked_days, not both")
+    if allowed_days is not None:
+        return weekdays.isin(list(allowed_days))
+    if blocked_days is not None:
+        return ~weekdays.isin(list(blocked_days))
+    return pd.Series(True, index=df.index)
+
+
+def day_of_month_filter(
+    df: pd.DataFrame,
+    mode: Literal["first", "last"] = "first",
+    n: int = 1,
+) -> pd.Series:
+    """Return ``True`` for timestamps within the first/last ``n`` days of a month."""
+
+    if n <= 0:
+        raise ValueError("n must be a positive integer")
+    idx = _ensure_datetime_index(df)
+    days = pd.Series(idx.day, index=df.index)
+    if mode == "first":
+        return days <= n
+    if mode == "last":
+        month_lengths = pd.Series(idx.days_in_month, index=df.index)
+        return (month_lengths - days + 1) <= n
+    raise ValueError("mode must be either 'first' or 'last'")
+
+
+def month_of_year_filter(
+    df: pd.DataFrame,
+    allowed_months: Optional[Iterable[int]] = None,
+    blocked_months: Optional[Iterable[int]] = None,
+) -> pd.Series:
+    """Return ``True`` for timestamps occurring in allowed months."""
+
+    idx = _ensure_datetime_index(df)
+    months = pd.Series(idx.month, index=df.index)
+    if allowed_months is not None and blocked_months is not None:
+        raise ValueError("Specify either allowed_months or blocked_months, not both")
+    if allowed_months is not None:
+        return months.isin(list(allowed_months))
+    if blocked_months is not None:
+        return ~months.isin(list(blocked_months))
+    return pd.Series(True, index=df.index)
+
+
+def intraday_time_filter(
+    df: pd.DataFrame,
+    start: str = "09:00",
+    end: str = "12:00",
+    tz: str = "UTC",
+) -> pd.Series:
+    """Return ``True`` for timestamps within the half-open intraday window."""
+
+    idx = _ensure_datetime_index(df).tz_convert(tz)
+    times = idx.hour * 60 + idx.minute
+    try:
+        start_hour, start_minute = map(int, start.split(":"))
+        end_hour, end_minute = map(int, end.split(":"))
+    except ValueError as exc:  # pragma: no cover - defensive validation
+        raise ValueError("start and end must be formatted as 'HH:MM'") from exc
+    start_total = start_hour * 60 + start_minute
+    end_total = end_hour * 60 + end_minute
+    if end_total < start_total:
+        raise ValueError("end time must be after start time within the same day")
+    mask = (times >= start_total) & (times < end_total)
+    return pd.Series(mask, index=df.index)

--- a/tests/test_filters_time_seasonality_smoke.py
+++ b/tests/test_filters_time_seasonality_smoke.py
@@ -1,0 +1,80 @@
+"""Smoke tests for time seasonality filters."""
+from __future__ import annotations
+
+import pandas as pd
+
+from quant_engine.filters.time_seasonality import (
+    day_of_month_filter,
+    day_of_week_filter,
+    intraday_time_filter,
+    month_of_year_filter,
+    session_time_filter,
+)
+
+
+def _make_df(start: str, periods: int, freq: str = "min") -> pd.DataFrame:
+    index = pd.date_range(start=start, periods=periods, freq=freq, tz="UTC")
+    return pd.DataFrame(index=index)
+
+
+def test_session_time_filter_london_window() -> None:
+    df = _make_df("2025-01-01", periods=3 * 24 * 60)
+    mask = session_time_filter(df, session="london")
+
+    assert isinstance(mask, pd.Series)
+    assert mask.index.equals(df.index)
+    assert mask.dtype == bool
+
+    selected_hours = df.index[mask]
+    if not selected_hours.empty:
+        hours = selected_hours.to_series().dt.hour
+        assert ((hours >= 7) & (hours < 15)).all()
+
+    outside_hours = df.index[~mask]
+    if not outside_hours.empty:
+        hours = outside_hours.to_series().dt.hour
+        assert ((hours < 7) | (hours >= 15)).all()
+
+
+def test_day_of_week_filter_blocks_weekend() -> None:
+    df = _make_df("2025-01-01", periods=10 * 24 * 60)
+    mask = day_of_week_filter(df, blocked_days=[5, 6])
+
+    weekdays = df.index.to_series().dt.dayofweek
+    assert mask.dtype == bool
+    assert mask.index.equals(df.index)
+    assert mask[weekdays < 5].all()
+    assert (~mask)[weekdays >= 5].all()
+
+
+def test_day_of_month_filter_first_three_days() -> None:
+    df = _make_df("2025-01-01", periods=10 * 24 * 60)
+    mask = day_of_month_filter(df, mode="first", n=3)
+
+    days = df.index.to_series().dt.day
+    assert mask.dtype == bool
+    assert mask.index.equals(df.index)
+    assert mask[days <= 3].all()
+    assert (~mask)[days > 3].all()
+
+
+def test_month_of_year_filter_only_january() -> None:
+    df = _make_df("2024-12-30", periods=7 * 24, freq="h")
+    mask = month_of_year_filter(df, allowed_months=[1])
+
+    months = df.index.to_series().dt.month
+    assert mask.dtype == bool
+    assert mask.index.equals(df.index)
+    assert mask[months == 1].all()
+    assert (~mask)[months != 1].all()
+
+
+def test_intraday_time_filter_window() -> None:
+    df = _make_df("2025-01-01", periods=2 * 24 * 60)
+    mask = intraday_time_filter(df, start="09:00", end="12:00")
+
+    minutes_of_day = df.index.to_series().dt.hour * 60 + df.index.to_series().dt.minute
+    assert mask.dtype == bool
+    assert mask.index.equals(df.index)
+    assert mask[(minutes_of_day >= 9 * 60) & (minutes_of_day < 12 * 60)].all()
+    assert (~mask)[(minutes_of_day < 9 * 60) | (minutes_of_day >= 12 * 60)].all()


### PR DESCRIPTION
## Summary
- add session, weekday, monthly and intraday time filters with registry wiring
- expose the new filters through the API and document usage with an example spec
- cover the filters with smoke tests and refresh the user documentation

## Testing
- poetry run pytest tests/test_filters_time_seasonality_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e11bef9d8c8323ac488001972b80e0