### PR TITLE
Add statistical probabilistic filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ poetry run quant-engine stats run --spec specs/filters_structure_ict_example.jso
 poetry run quant-engine stats run --spec specs/filters_time_seasonality_example.json
 ```
 
+### Statistical & Probabilistic
+
+```bash
+poetry run quant-engine stats run --spec specs/filters_stat_prob_example.json
+```
+
 ## Configuration `.env`
 Copier `.env.example` vers `.env` et ajuster :
 ```env

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -92,3 +92,26 @@ Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés d
 - **Paramètres** : `start`, `end` (format `"HH:MM"`), `tz`.
 - **Retour** : `True` si la barre tombe dans la fenêtre `[start, end)`.
 - **Exemple** : ne garder que 09:00–12:00 UTC.
+
+## Statistical & Probabilistic filters
+
+### `k_consecutive`
+- **Idée** : éviter d’entrer après trop de bougies alignées, ou au contraire détecter une séquence momentum.
+- **Paramètres** : `k`, `direction` (`"up"`/`"down"`), `use_body`.
+- **Retour** : `True` si la fenêtre courante présente `k` bougies successives dans la direction souhaitée.
+
+### `seasonality_bin`
+- **Idée** : n’activer que certains bins temporels.
+- **Modes** : `hour` (0–23), `dow` (0–6), `dom` (1–31), `month` (1–12), `session` (0–3).
+- **Paramètres** : `allowed` / `blocked` ou `min_winrate` (+ `symbol`) pour utiliser `quant.seasonality_profiles`.
+- **Retour** : `True` si la barre est dans un bin “positif”.
+
+### `hurst_regime`
+- **Idée** : filtrer par régime (trend/mean-revert/noise).
+- **Paramètres** : `window`, `min_h`, `max_h`.
+- **Retour** : `True` si `H` appartient à l’intervalle `[min_h, max_h]`.
+
+### `entropy_window`
+- **Idée** : mesurer la “randomness” directionnelle locale.
+- **Paramètres** : `window`, `max_entropy` et/ou `min_entropy`, `use_body`.
+- **Retour** : `True` si l’entropie respecte le(s) seuil(s).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,3 +64,13 @@ poetry run qe YOUR_COMMAND --spec specs/filters_time_seasonality_example.json
 ```
 
 Comme pour les autres exemples, remplace `YOUR_COMMAND` par la commande souhaitée (`stats run`, etc.).
+
+## Essayer les filtres Statistiques/Probabilistes
+
+Un exemple combinant les filtres de cette famille est fourni dans `specs/filters_stat_prob_example.json`.
+
+```bash
+poetry run qe YOUR_COMMAND --spec specs/filters_stat_prob_example.json
+```
+
+Adapte `YOUR_COMMAND` au workflow visé (par exemple `stats run`).

--- a/specs/filters_stat_prob_example.json
+++ b/specs/filters_stat_prob_example.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume"
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-07T23:59:00Z"
+  },
+  "filters": [
+    { "type": "k_consecutive", "params": { "k": 3, "direction": "up", "use_body": true } },
+    { "type": "seasonality_bin", "params": { "mode": "hour", "allowed": [8, 9, 10, 11] } },
+    { "type": "hurst_regime", "params": { "window": 256, "min_h": 0.55, "max_h": 0.9 } },
+    { "type": "entropy_window", "params": { "window": 64, "max_entropy": 0.85, "use_body": false } }
+  ]
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -102,6 +102,10 @@ class FilterConditionSpec(BaseModel):
         "day_of_month",
         "month_of_year",
         "intraday_time",
+        "k_consecutive",
+        "seasonality_bin",
+        "hurst_regime",
+        "entropy_window",
     ]
     params: Dict[str, Any] = Field(default_factory=dict)
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -11,6 +11,12 @@ from .time_seasonality import (
     month_of_year_filter,
     intraday_time_filter,
 )
+from .stat_prob import (
+    k_consecutive_filter,
+    seasonality_bin_filter,
+    hurst_regime_filter,
+    entropy_window_filter,
+)
 
 __all__ = [
     "adx_filter",
@@ -27,6 +33,10 @@ __all__ = [
     "day_of_month_filter",
     "month_of_year_filter",
     "intraday_time_filter",
+    "k_consecutive_filter",
+    "seasonality_bin_filter",
+    "hurst_regime_filter",
+    "entropy_window_filter",
     "filters_registry",
     "list_filter_types",
 ]
@@ -46,6 +56,10 @@ filters_registry = {
     "day_of_month": day_of_month_filter,
     "month_of_year": month_of_year_filter,
     "intraday_time": intraday_time_filter,
+    "k_consecutive": k_consecutive_filter,
+    "seasonality_bin": seasonality_bin_filter,
+    "hurst_regime": hurst_regime_filter,
+    "entropy_window": entropy_window_filter,
 }
 
 

--- a/src/quant_engine/filters/stat_prob.py
+++ b/src/quant_engine/filters/stat_prob.py
@@ -1,0 +1,166 @@
+import numpy as np
+import pandas as pd
+from typing import List, Literal, Optional
+
+try:
+    # Optionnel : si un repo stats existe déjà pour lire quant.seasonality_profiles
+    from quant_engine.stats import repo as stats_repo
+except Exception:  # pragma: no cover - optional dependency for fallback
+    stats_repo = None
+
+
+def k_consecutive_filter(
+    df: pd.DataFrame,
+    k: int = 3,
+    direction: Literal["up", "down"] = "up",
+    use_body: bool = True,
+) -> pd.Series:
+    """Return ``True`` when the last *k* candles move in the same direction.
+
+    ``use_body`` toggles between comparing ``close`` vs ``open`` (True) or
+    ``close`` vs ``close.shift(1)`` (False).
+    """
+
+    if k <= 0:
+        raise ValueError("k must be strictly positive")
+
+    if use_body:
+        delta = df["close"].astype(float) - df["open"].astype(float)
+    else:
+        delta = df["close"].astype(float).diff()
+
+    sign = np.sign(delta)
+    cond = (sign > 0).astype(int) if direction == "up" else (sign < 0).astype(int)
+    run = cond.rolling(window=k, min_periods=k).sum()
+    return (run == k).reindex(df.index).fillna(False)
+
+
+def seasonality_bin_filter(
+    df: pd.DataFrame,
+    mode: Literal["hour", "dow", "dom", "month", "session"] = "hour",
+    allowed: Optional[List[int]] = None,
+    blocked: Optional[List[int]] = None,
+    min_winrate: Optional[float] = None,
+    symbol: Optional[str] = None,
+) -> pd.Series:
+    """Filter bars that fall within a seasonal bucket deemed positive."""
+
+    idx = df.index
+    if mode == "hour":
+        bins = pd.Series(idx.hour, index=idx)
+    elif mode == "dow":
+        bins = pd.Series(idx.dayofweek, index=idx)
+    elif mode == "dom":
+        bins = pd.Series(idx.day, index=idx)
+    elif mode == "month":
+        bins = pd.Series(idx.month, index=idx)
+    else:  # session buckets (Asia/London/Overlap/US)
+        hours = idx.hour
+        session_id = np.full(len(idx), -1)
+        session_id[(hours >= 0) & (hours < 8)] = 0       # Asia 00-07
+        session_id[(hours >= 8) & (hours < 13)] = 1      # London 08-12
+        session_id[(hours >= 13) & (hours < 17)] = 2     # Overlap 13-16
+        session_id[(hours >= 17) & (hours < 22)] = 3     # US 17-21
+        bins = pd.Series(session_id, index=idx)
+
+    if min_winrate is not None and stats_repo is not None:
+        try:
+            profile = stats_repo.select_seasonality_profile(
+                symbol=symbol,
+                dimension=mode,
+            )
+        except Exception:  # pragma: no cover - optional database call
+            profile = None
+
+        if isinstance(profile, pd.DataFrame) and {"bin", "winrate"}.issubset(profile.columns):
+            winners = profile.loc[profile["winrate"] >= float(min_winrate), "bin"].astype(int)
+            good = set(winners.tolist())
+            return bins.isin(good)
+
+    if allowed is not None:
+        return bins.isin(allowed)
+    if blocked is not None:
+        return ~bins.isin(blocked)
+
+    return pd.Series(True, index=idx)
+
+
+def _hurst_rs(price: pd.Series, window: int) -> pd.Series:
+    """Estimate the Hurst exponent via a rolling rescaled range calculation."""
+
+    log_price = np.log(price.astype(float))
+    returns = log_price.diff().dropna()
+    hurst = pd.Series(np.nan, index=price.index)
+
+    for end in range(window, len(returns) + 1):
+        segment = returns.iloc[end - window : end]
+        if segment.std(ddof=0) == 0:
+            h_value = np.nan
+        else:
+            cumulative = segment.cumsum() - segment.mean() * np.arange(1, window + 1)
+            r_val = cumulative.max() - cumulative.min()
+            s_val = segment.std(ddof=0)
+            if s_val == 0:
+                h_value = np.nan
+            else:
+                rs = r_val / s_val
+                h_value = np.log(rs) / np.log(window)
+        hurst.loc[segment.index[-1]] = h_value
+
+    return hurst.ffill()
+
+
+def hurst_regime_filter(
+    df: pd.DataFrame,
+    window: int = 256,
+    min_h: float = 0.45,
+    max_h: float = 0.65,
+    price_col: str = "close",
+) -> pd.Series:
+    """Keep bars whose Hurst exponent lies within ``[min_h, max_h]``."""
+
+    if window <= 1:
+        raise ValueError("window must be greater than 1 for Hurst calculation")
+
+    price = df[price_col].astype(float)
+    hurst = _hurst_rs(price, window)
+    mask = (hurst >= float(min_h)) & (hurst <= float(max_h))
+    return mask.reindex(df.index).fillna(False)
+
+
+def entropy_window_filter(
+    df: pd.DataFrame,
+    window: int = 64,
+    max_entropy: Optional[float] = None,
+    min_entropy: Optional[float] = None,
+    use_body: bool = False,
+) -> pd.Series:
+    """Filter bars according to the directional entropy over a rolling window."""
+
+    if window <= 1:
+        raise ValueError("window must be greater than 1")
+
+    if use_body:
+        direction = np.sign((df["close"] - df["open"]).astype(float))
+    else:
+        direction = np.sign(df["close"].astype(float).diff())
+
+    up_prob = (direction > 0).astype(int).rolling(window, min_periods=max(8, window // 4)).mean()
+    eps = 1e-12
+    entropy = -(up_prob * np.log2(up_prob + eps) + (1 - up_prob) * np.log2(1 - up_prob + eps))
+
+    cond = pd.Series(True, index=df.index)
+    if max_entropy is not None:
+        cond &= entropy <= float(max_entropy)
+    if min_entropy is not None:
+        cond &= entropy >= float(min_entropy)
+
+    return cond.fillna(False)
+
+
+__all__ = [
+    "k_consecutive_filter",
+    "seasonality_bin_filter",
+    "hurst_regime_filter",
+    "entropy_window_filter",
+]

--- a/tests/test_filters_stat_prob_smoke.py
+++ b/tests/test_filters_stat_prob_smoke.py
@@ -1,0 +1,84 @@
+"""Smoke tests for statistical & probabilistic filters."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from quant_engine.filters.stat_prob import (
+    entropy_window_filter,
+    hurst_regime_filter,
+    k_consecutive_filter,
+    seasonality_bin_filter,
+)
+
+
+def _make_ohlc(count: int = 720) -> pd.DataFrame:
+    rng = np.random.default_rng(1234)
+    index = pd.date_range("2024-01-01", periods=count, freq="min", tz="UTC")
+    close = 1.10 + rng.normal(scale=0.0005, size=count).cumsum()
+    open_ = close - rng.normal(scale=0.0002, size=count)
+    high = np.maximum(open_, close) + np.abs(rng.normal(scale=0.0003, size=count))
+    low = np.minimum(open_, close) - np.abs(rng.normal(scale=0.0003, size=count))
+    volume = rng.integers(1_000, 5_000, size=count)
+    df = pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+    return df
+
+
+def test_k_consecutive_filter_detects_sequences() -> None:
+    df = _make_ohlc()
+    seq_idx = df.index[50:53]
+    df.loc[seq_idx, "open"] = 1.0
+    df.loc[seq_idx, "close"] = [1.2, 1.3, 1.4]
+
+    result = k_consecutive_filter(df, k=3, direction="up", use_body=True)
+
+    assert result.index.equals(df.index)
+    assert result.dtype == bool
+    assert result.loc[seq_idx[-1]]
+
+
+def test_seasonality_bin_filter_hour_allowed_only() -> None:
+    df = _make_ohlc()
+    mask = seasonality_bin_filter(df, mode="hour", allowed=[8, 9])
+
+    assert mask.index.equals(df.index)
+    assert mask.dtype == bool
+    allowed_hours = set(df.index[mask].hour)
+    assert allowed_hours <= {8, 9}
+    blocked_hours = set(df.index[~mask].hour)
+    assert blocked_hours.intersection({8, 9}) == set()
+
+
+def test_hurst_regime_filter_returns_boolean_series() -> None:
+    df = _make_ohlc()
+    result = hurst_regime_filter(df, window=128, min_h=0.0, max_h=1.0)
+
+    assert result.index.equals(df.index)
+    assert result.dtype == bool
+    assert not result.isna().any()
+    assert result.iloc[200:400].all()  # windows fully populated should be True within wide range
+
+
+def test_entropy_window_filter_has_true_and_false() -> None:
+    df = _make_ohlc()
+    trend_idx = df.index[120:220]
+    df.loc[trend_idx, "open"] = 1.0
+    df.loc[trend_idx, "close"] = np.linspace(1.01, 1.20, len(trend_idx))
+
+    result = entropy_window_filter(df, window=64, max_entropy=0.9)
+
+    assert result.index.equals(df.index)
+    assert result.dtype == bool
+    unique_values = set(result.unique().tolist())
+    assert unique_values.issubset({True, False})
+    assert unique_values == {True, False}


### PR DESCRIPTION
## Summary
- add statistical/probabilistic filters (k consecutive, seasonality bin, hurst regime, entropy window)
- expose the new filters through the registry, API schema, example spec, and smoke tests
- document usage in the filters reference, getting started guide, and README

## Testing
- pytest tests/test_filters_stat_prob_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68e11f6c91148323858bf71079d9295e