### PR TITLE
Add risk management filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ poetry run quant-engine stats run --spec specs/filters_time_seasonality_example.
 poetry run quant-engine stats run --spec specs/filters_stat_prob_example.json
 ```
 
+### Risk & Money Management
+
+```bash
+poetry run quant-engine stats run --spec specs/filters_risk_mgmt_example.json
+```
+
 ## Configuration `.env`
 Copier `.env.example` vers `.env` et ajuster :
 ```env

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -115,3 +115,33 @@ Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés d
 - **Idée** : mesurer la “randomness” directionnelle locale.
 - **Paramètres** : `window`, `max_entropy` et/ou `min_entropy`, `use_body`.
 - **Retour** : `True` si l’entropie respecte le(s) seuil(s).
+
+## Risk & Money Management filters
+
+Ces filtres visent à plafonner les pertes, limiter le nombre d’entrées et adapter le risque aux conditions de marché.
+
+### `daily_loss_cap`
+- **Idée** : couper les signaux quand la perte journalière dépasse un plafond.
+- **Paramètres** : `loss_cap` (float, en devise), `mode` = `"pnl"` \| `"equity"` \| `"ret_notional"`, `pnl_col` / `equity_col` / `ret_col` (+ `notional`).
+- **Comportement** : renvoie `False` (lock) pour le reste de la journée dès que la perte cumulée ≤ `-loss_cap`.
+- **Tolérance** : si les colonnes requises sont absentes, le filtre renvoie `True` partout (no-op).
+
+### `daily_trades_cap`
+- **Idée** : limiter le nombre d’entrées par jour.
+- **Paramètres** : `signal_col` (bool), `max_trades_per_day` (int).
+- **Notes** : nécessite que `signal_col` existe déjà (par exemple le résultat d’un bloc de règles). Après avoir atteint la limite, le filtre reste `False` jusqu’à la fin de la journée.
+
+### `cooldown_bars`
+- **Idée** : imposer un cooldown après un signal.
+- **Paramètres** : `signal_col` (bool), `cooldown_bars` (int).
+- **Retour** : `True` uniquement si au moins `cooldown_bars` barres se sont écoulées depuis le dernier `True`.
+
+### `atr_risk_gate`
+- **Idée** : bloquer si la volatilité relative (ATR/close) est trop élevée.
+- **Paramètres** : `atr_window`, `max_atr_pct`.
+- **Utilité** : conserver un sizing cohérent et un ratio rendement/risque praticable. Si les colonnes OHLC sont absentes, le filtre devient un no-op (`True`).
+
+### `equity_dd_lockout`
+- **Idée** : lockout si le drawdown de l’equity dépasse un seuil.
+- **Paramètres** : `equity_col`, `max_dd_pct`.
+- **Notes** : nécessite une colonne equity ; sinon le filtre renvoie `True` (no-op).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -74,3 +74,13 @@ poetry run qe YOUR_COMMAND --spec specs/filters_stat_prob_example.json
 ```
 
 Adapte `YOUR_COMMAND` au workflow visé (par exemple `stats run`).
+
+## Essayer les filtres Risk & Money Management
+
+Les filtres de gestion du risque disposent d'un exemple complet dans `specs/filters_risk_mgmt_example.json`.
+
+```bash
+poetry run qe YOUR_COMMAND --spec specs/filters_risk_mgmt_example.json
+```
+
+Comme pour les autres scénarios, remplace `YOUR_COMMAND` par la commande correspondant à ton pipeline (`stats run`, backtest, etc.).

--- a/specs/filters_risk_mgmt_example.json
+++ b/specs/filters_risk_mgmt_example.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "mysql": {
+      "env_var": "QE_MARKETDATA_MYSQL_URL",
+      "schema": "marketdata",
+      "table": "ohlcv_m1",
+      "symbol_col": "symbol",
+      "ts_col": "ts_utc",
+      "open_col": "open",
+      "high_col": "high",
+      "low_col": "low",
+      "close_col": "close",
+      "volume_col": "volume"
+    },
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-07T23:59:00Z"
+  },
+  "filters": [
+    { "type": "daily_loss_cap",   "params": { "loss_cap": 500.0, "mode": "pnl",    "pnl_col": "pnl" } },
+    { "type": "equity_dd_lockout","params": { "max_dd_pct": 0.15, "equity_col": "equity" } },
+    { "type": "atr_risk_gate",    "params": { "atr_window": 14, "max_atr_pct": 0.02 } },
+    { "type": "daily_trades_cap", "params": { "signal_col": "entry_signal", "max_trades_per_day": 3 } },
+    { "type": "cooldown_bars",    "params": { "signal_col": "entry_signal", "cooldown_bars": 20 } }
+  ]
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -106,6 +106,11 @@ class FilterConditionSpec(BaseModel):
         "seasonality_bin",
         "hurst_regime",
         "entropy_window",
+        "daily_loss_cap",
+        "daily_trades_cap",
+        "cooldown_bars",
+        "atr_risk_gate",
+        "equity_dd_lockout",
     ]
     params: Dict[str, Any] = Field(default_factory=dict)
 

--- a/src/quant_engine/filters/__init__.py
+++ b/src/quant_engine/filters/__init__.py
@@ -17,6 +17,13 @@ from .stat_prob import (
     hurst_regime_filter,
     entropy_window_filter,
 )
+from .risk_mgmt import (
+    daily_loss_cap_filter,
+    daily_trades_cap_filter,
+    cooldown_bars_filter,
+    atr_risk_gate_filter,
+    equity_dd_lockout_filter,
+)
 
 __all__ = [
     "adx_filter",
@@ -39,6 +46,11 @@ __all__ = [
     "entropy_window_filter",
     "filters_registry",
     "list_filter_types",
+    "daily_loss_cap_filter",
+    "daily_trades_cap_filter",
+    "cooldown_bars_filter",
+    "atr_risk_gate_filter",
+    "equity_dd_lockout_filter",
 ]
 
 filters_registry = {
@@ -60,6 +72,11 @@ filters_registry = {
     "seasonality_bin": seasonality_bin_filter,
     "hurst_regime": hurst_regime_filter,
     "entropy_window": entropy_window_filter,
+    "daily_loss_cap": daily_loss_cap_filter,
+    "daily_trades_cap": daily_trades_cap_filter,
+    "cooldown_bars": cooldown_bars_filter,
+    "atr_risk_gate": atr_risk_gate_filter,
+    "equity_dd_lockout": equity_dd_lockout_filter,
 }
 
 

--- a/src/quant_engine/filters/risk_mgmt.py
+++ b/src/quant_engine/filters/risk_mgmt.py
@@ -1,0 +1,184 @@
+"""Risk and money management oriented filters."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+import numpy as np
+import pandas as pd
+
+
+def _daily_groups(idx: pd.DatetimeIndex) -> pd.Index:
+    """Return a normalized UTC date index suitable for grouping by day."""
+
+    if not isinstance(idx, pd.DatetimeIndex):
+        raise TypeError("Index must be a DatetimeIndex")
+
+    if idx.tz is None:
+        utc_idx = idx.tz_localize("UTC")
+    else:
+        utc_idx = idx.tz_convert("UTC")
+    return utc_idx.normalize()
+
+
+def daily_loss_cap_filter(
+    df: pd.DataFrame,
+    loss_cap: float,
+    mode: Literal["pnl", "equity", "ret_notional"] = "pnl",
+    pnl_col: str = "pnl",
+    equity_col: str = "equity",
+    ret_col: str = "ret",
+    notional: Optional[float] = None,
+) -> pd.Series:
+    """Return ``False`` once the cumulative daily loss reaches the cap.
+
+    Lockout is triggered when the cumulative PnL for the current UTC day is
+    less than or equal to ``-loss_cap``. The filter returns ``True`` elsewhere.
+
+    Missing inputs (columns or ``notional`` when required) result in a no-op
+    filter that returns ``True`` everywhere.
+    """
+
+    if loss_cap <= 0:
+        raise ValueError("loss_cap must be positive")
+
+    try:
+        groups = _daily_groups(df.index)
+    except Exception:
+        return pd.Series(True, index=df.index)
+
+    try:
+        if mode == "pnl" and pnl_col in df.columns:
+            pnl = df[pnl_col].astype(float)
+        elif mode == "equity" and equity_col in df.columns:
+            pnl = df[equity_col].astype(float).diff()
+        elif (
+            mode == "ret_notional"
+            and ret_col in df.columns
+            and notional is not None
+        ):
+            pnl = df[ret_col].astype(float) * float(notional)
+        else:
+            return pd.Series(True, index=df.index)
+
+        daily_cum = pnl.groupby(groups).cumsum()
+        breached = daily_cum <= -abs(float(loss_cap))
+        lock = breached.groupby(groups).cummax()
+        return (~lock).fillna(True)
+    except Exception:
+        return pd.Series(True, index=df.index)
+
+
+def daily_trades_cap_filter(
+    df: pd.DataFrame,
+    signal_col: str,
+    max_trades_per_day: int = 3,
+) -> pd.Series:
+    """Allow at most ``max_trades_per_day`` True signals per UTC day.
+
+    Missing ``signal_col`` results in a no-op returning ``True`` everywhere.
+    """
+
+    if signal_col not in df.columns:
+        return pd.Series(True, index=df.index)
+
+    if max_trades_per_day < 1:
+        raise ValueError("max_trades_per_day must be >= 1")
+
+    try:
+        groups = _daily_groups(df.index)
+    except Exception:
+        return pd.Series(True, index=df.index)
+
+    sig = df[signal_col].fillna(False).astype(bool)
+    count = sig.groupby(groups).cumsum()
+    allowed = count <= int(max_trades_per_day)
+    return allowed.reindex(df.index, fill_value=True)
+
+
+def cooldown_bars_filter(
+    df: pd.DataFrame,
+    signal_col: str,
+    cooldown_bars: int = 10,
+) -> pd.Series:
+    """Impose a cooldown of ``cooldown_bars`` bars after a True signal.
+
+    Missing ``signal_col`` returns ``True`` everywhere.
+    """
+
+    if signal_col not in df.columns:
+        return pd.Series(True, index=df.index)
+
+    if cooldown_bars < 0:
+        raise ValueError("cooldown_bars must be >= 0")
+
+    sig = df[signal_col].fillna(False).astype(bool)
+    if cooldown_bars == 0:
+        return pd.Series(True, index=df.index)
+
+    positions = pd.Series(np.arange(len(df)), index=df.index, dtype=float)
+    true_positions = positions.where(sig)
+    last_true_before = true_positions.shift().ffill()
+    distance = positions - last_true_before
+    allowed = last_true_before.isna() | (distance > cooldown_bars)
+    return allowed.fillna(True)
+
+
+def atr_risk_gate_filter(
+    df: pd.DataFrame,
+    atr_window: int = 14,
+    max_atr_pct: float = 0.02,
+    high_col: str = "high",
+    low_col: str = "low",
+    close_col: str = "close",
+) -> pd.Series:
+    """Block when ATR to close ratio exceeds ``max_atr_pct``.
+
+    Missing OHLC columns results in a no-op returning ``True`` everywhere.
+    """
+
+    required = {high_col, low_col, close_col}
+    if not required.issubset(df.columns):
+        return pd.Series(True, index=df.index)
+
+    if atr_window <= 0:
+        raise ValueError("atr_window must be positive")
+    if max_atr_pct <= 0:
+        raise ValueError("max_atr_pct must be positive")
+
+    h = df[high_col].astype(float)
+    l = df[low_col].astype(float)
+    c = df[close_col].astype(float)
+
+    prev_close = c.shift(1)
+    tr_components = pd.concat(
+        [(h - l).abs(), (h - prev_close).abs(), (l - prev_close).abs()], axis=1
+    )
+    tr = tr_components.max(axis=1)
+
+    atr = tr.ewm(alpha=1.0 / float(atr_window), adjust=False).mean()
+    atr_pct = atr / c.replace(0.0, np.nan)
+    allowed = atr_pct <= float(max_atr_pct)
+    return allowed.fillna(True)
+
+
+def equity_dd_lockout_filter(
+    df: pd.DataFrame,
+    equity_col: str = "equity",
+    max_dd_pct: float = 0.1,
+) -> pd.Series:
+    """Lock out once the equity drawdown exceeds ``max_dd_pct``.
+
+    Missing ``equity_col`` returns ``True`` everywhere.
+    """
+
+    if equity_col not in df.columns:
+        return pd.Series(True, index=df.index)
+
+    if max_dd_pct < 0:
+        raise ValueError("max_dd_pct must be non-negative")
+
+    eq = df[equity_col].astype(float)
+    peak = eq.cummax()
+    drawdown = (peak - eq) / peak.replace(0.0, np.nan)
+    allowed = drawdown <= float(max_dd_pct)
+    return allowed.fillna(True)

--- a/tests/test_filters_risk_mgmt_smoke.py
+++ b/tests/test_filters_risk_mgmt_smoke.py
@@ -1,0 +1,136 @@
+import datetime as dt
+
+import numpy as np
+import pandas as pd
+
+from quant_engine.filters.risk_mgmt import (
+    atr_risk_gate_filter,
+    cooldown_bars_filter,
+    daily_loss_cap_filter,
+    daily_trades_cap_filter,
+    equity_dd_lockout_filter,
+)
+
+
+def _make_sample_df() -> pd.DataFrame:
+    rng = np.random.default_rng(123)
+    idx = pd.date_range("2025-01-01", periods=2 * 24 * 60, freq="min", tz="UTC")
+    n = len(idx)
+
+    close = 100 + np.cumsum(rng.normal(0, 0.3, size=n))
+    open_ = close + rng.normal(0, 0.05, size=n)
+    span = 0.5 + rng.random(n)
+    high = np.maximum(open_, close) + span
+    low = np.minimum(open_, close) - span
+
+    pnl = rng.normal(0, 5.0, size=n)
+    first_day_mask = idx < pd.Timestamp("2025-01-02", tz="UTC")
+    pnl[first_day_mask] = rng.normal(5.0, 1.5, size=first_day_mask.sum())
+    loss_window = (idx >= pd.Timestamp("2025-01-02 00:00:00", tz="UTC")) & (
+        idx < pd.Timestamp("2025-01-02 00:30:00", tz="UTC")
+    )
+    pnl[loss_window] = -50.0
+    big_drop_ts = pd.Timestamp("2025-01-02 01:00:00", tz="UTC")
+    pnl[idx.get_loc(big_drop_ts)] = -15000.0
+
+    equity = 100_000 + pnl.cumsum()
+
+    entry_signal = np.zeros(n, dtype=bool)
+    for ts in (
+        "2025-01-01 08:00:00",
+        "2025-01-01 09:00:00",
+        "2025-01-01 10:00:00",
+        "2025-01-02 05:00:00",
+        "2025-01-02 05:12:00",
+        "2025-01-02 05:25:00",
+    ):
+        entry_signal[idx.get_loc(pd.Timestamp(ts, tz="UTC"))] = True
+
+    df = pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "pnl": pnl,
+            "equity": equity,
+            "entry_signal": entry_signal,
+        },
+        index=idx,
+    )
+
+    volatile_ts = pd.Timestamp("2025-01-02 02:00:00", tz="UTC")
+    df.loc[volatile_ts, "high"] = df.loc[volatile_ts, "close"] + 12.0
+    df.loc[volatile_ts, "low"] = df.loc[volatile_ts, "close"] - 12.0
+
+    return df
+
+
+def test_daily_loss_cap_filter_blocks_after_threshold():
+    df = _make_sample_df()
+    flt = daily_loss_cap_filter(df, loss_cap=100.0, mode="pnl", pnl_col="pnl")
+
+    first_day = df.index.normalize() == pd.Timestamp("2025-01-01", tz="UTC")
+    assert flt[first_day].all()
+
+    second_day = df.index.normalize() == pd.Timestamp("2025-01-02", tz="UTC")
+    breached_idx = flt[second_day][~flt[second_day]].index[0]
+    assert breached_idx >= pd.Timestamp("2025-01-02 00:00:00+00:00")
+    assert not flt.loc[breached_idx]
+    post_breach = flt[second_day].loc[breached_idx:]
+    assert (~post_breach).all()
+
+
+def test_equity_dd_lockout_filter_triggers_on_drawdown():
+    df = _make_sample_df()
+    flt = equity_dd_lockout_filter(df, equity_col="equity", max_dd_pct=0.1)
+
+    breach_points = flt[~flt]
+    assert not breach_points.empty
+    first_breach = breach_points.index[0]
+    assert first_breach >= pd.Timestamp("2025-01-02 01:00:00+00:00")
+    assert not flt.loc[first_breach]
+    assert flt.loc[pd.Timestamp("2025-01-01 12:00:00", tz="UTC")]
+
+
+def test_atr_risk_gate_filter_has_expected_behavior():
+    df = _make_sample_df()
+    flt = atr_risk_gate_filter(df, atr_window=5, max_atr_pct=0.02)
+
+    assert flt.dtype == bool
+    assert flt.any()
+    assert (~flt).any()
+
+
+def test_daily_trades_cap_filter_limits_entries():
+    df = _make_sample_df()
+    flt = daily_trades_cap_filter(df, signal_col="entry_signal", max_trades_per_day=2)
+
+    first_signals = [
+        pd.Timestamp("2025-01-01 08:00:00", tz="UTC"),
+        pd.Timestamp("2025-01-01 09:00:00", tz="UTC"),
+        pd.Timestamp("2025-01-01 10:00:00", tz="UTC"),
+    ]
+    assert flt.loc[first_signals[0]]
+    assert flt.loc[first_signals[1]]
+    assert not flt.loc[first_signals[2]]
+    assert not flt.loc[pd.Timestamp("2025-01-01 15:00:00", tz="UTC")]
+
+
+def test_cooldown_bars_filter_enforces_gap():
+    df = _make_sample_df()
+    flt = cooldown_bars_filter(df, signal_col="entry_signal", cooldown_bars=10)
+
+    ts = pd.Timestamp("2025-01-02 05:00:00", tz="UTC")
+    assert flt.loc[ts]
+    for minutes in range(1, 11):
+        check_ts = ts + pd.Timedelta(minutes=minutes)
+        assert not flt.loc[check_ts]
+    assert flt.loc[ts + pd.Timedelta(minutes=11)]
+    second_signal = ts + pd.Timedelta(minutes=12)
+    assert flt.loc[second_signal]
+    for minutes in range(13, 23):
+        check_ts = ts + pd.Timedelta(minutes=minutes)
+        assert not flt.loc[check_ts]
+    assert flt.loc[ts + pd.Timedelta(minutes=23)]
+    assert flt.loc[ts + pd.Timedelta(minutes=25)]


### PR DESCRIPTION
## Summary
- add daily loss cap, daily trade cap, cooldown, ATR gate, and equity drawdown filters with registry and API support
- document the new risk & money management filters and provide an example specification
- add smoke tests covering the new filters

## Testing
- poetry run pytest tests/test_filters_risk_mgmt_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68e1299fc788832393ebf1ed0ad0a0ab