### PR TITLE
feat: add live trading runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ export $(grep -v '^#' .env | xargs)
 - [Getting started](docs/getting_started.md)
 - [Filtres pré-trade](docs/filters.md)
 - [Seasonality – Dimensions & Métriques](docs/seasonality_reference.md)
+- [Live Trading Runner](docs/live.md)
 
 ## Lancer l'API
 ```bash

--- a/docs/live.md
+++ b/docs/live.md
@@ -1,0 +1,44 @@
+# Live Trading Runner
+
+La boucle live exécute les stratégies en mode *on-bar-close*. Chaque itération :
+
+1. Lit la dernière barre clôturée depuis MySQL (`marketdata`), sans regarder l'avenir.
+2. Passe la fenêtre `(warmup + nouvelles barres)` dans la pipeline `filters → rules → risk gates`.
+3. Construit un trade idempotent (1 trade max par barre/stratégie/side) et l'émet vers les destinations configurées.
+
+## Architecture
+
+```
+marketdata (MySQL) ──► feed (poll) ──► runner (filters/rules/risk) ──► emitter ──┬─► Java REST
+                                                                                └─► quant.trades_live (MySQL)
+```
+
+## Variables d'environnement
+
+- `QE_MARKETDATA_MYSQL_URL` : connexion READ (`marketdata.*`).
+- `QE_WRITE_MYSQL_URL` : connexion WRITE (`quant.trades_live`).
+- `QE_JAVA_LIVE_URL` : endpoint REST Java (ex: `http://localhost:8080`).
+
+## Lancer une stratégie live
+
+```bash
+poetry run qe live run --spec specs/live_example.json
+```
+
+Le runner charge `warmup_bars` (ex. 300 pour EMA/ADX) pour amorcer les indicateurs, puis boucle toutes `poll_interval_sec` secondes. Les timestamps sont gérés en UTC.
+
+## Idempotence et état
+
+- Cache mémoire par `(strategy_id, symbol, timeframe)` : historique, `last_ts_seen`, graines d'indicateurs.
+- Un hash (`uniq_hash`) garantit `1 trade` max par barre/stratégie/side côté base (`quant.trades_live`).
+- Redémarrage : le warm-up recharge les barres nécessaires avant de reprendre la boucle.
+
+## Gestion du risque
+
+Les risk gates (`daily_loss_cap`, `equity_dd_lockout`, `atr_risk_gate`, etc.) s'appliquent après les règles. En absence de colonnes requises (`equity`, `pnl`...), les gates deviennent no-op (`True`).
+
+## Latence & extensions
+
+- Mode actuel : `on-bar-close` (latence = clôture barre + poll interval).
+- Intra-bar / tick feed et mise à jour incrémentale EMA/ATR sont laissés en TODO.
+- Les erreurs REST Java sont journalisées mais non bloquantes.

--- a/specs/live_example.json
+++ b/specs/live_example.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "mysql_read_env": "QE_MARKETDATA_MYSQL_URL",
+    "schema": "marketdata",
+    "table": "ohlcv_m1",
+    "symbol_col": "symbol",
+    "ts_col": "ts_utc",
+    "open_col": "open",
+    "high_col": "high",
+    "low_col": "low",
+    "close_col": "close",
+    "volume_col": "volume",
+    "symbols": ["EURUSD"],
+    "timeframe": "M1",
+    "warmup_bars": 300,
+    "poll_interval_sec": 5
+  },
+  "strategy": {
+    "strategy_id": "EMA_ADX_M1_v1",
+    "filters": [
+      { "type": "adx", "params": { "window": 14, "thresh": 20 } },
+      { "type": "atr", "params": { "window": 14, "min_mult": 0.0005, "max_mult": 0.02 } },
+      { "type": "ema_slope", "params": { "window": 50, "slope_thresh": 0.0 } },
+      { "type": "vwap_side", "params": { "anchor": "day", "side": "above", "from_levels": true, "symbol": "EURUSD" } }
+    ],
+    "rules": [
+      { "type": "cross_over", "params": { "fast_ema": 20, "slow_ema": 50, "side": "LONG" } }
+    ],
+    "risk_gates": [
+      { "type": "daily_loss_cap", "params": { "loss_cap": 300.0, "mode": "equity", "equity_col": "equity" } },
+      { "type": "equity_dd_lockout", "params": { "max_dd_pct": 0.15, "equity_col": "equity" } }
+    ],
+    "tp_sl_mgmt": {
+      "type": "fixed_rr",
+      "params": { "rr": 2.0, "sl_mode": "atr", "atr_window": 14, "atr_mult": 1.5 }
+    }
+  },
+  "destinations": {
+    "write_db": { "mysql_write_env": "QE_WRITE_MYSQL_URL", "schema": "quant", "table": "trades_live" },
+    "emit_java": { "enabled": true, "url_env": "QE_JAVA_LIVE_URL", "path": "/live/signal" }
+  }
+}

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -200,6 +200,89 @@ class PersistenceSpec(BaseModel):
     dataset_id: str | None = None
 
 
+class LiveDataSpec(BaseModel):
+    """Specification of the live data feed for on-bar-close execution."""
+
+    model_config = ConfigDict(protected_namespaces=(), populate_by_name=True)
+
+    mysql_read_env: str = "QE_MARKETDATA_MYSQL_URL"
+    schema_: str = Field("marketdata", alias="schema")
+    table: str = "ohlcv"
+    symbol_col: str = "symbol"
+    ts_col: str = "ts"
+    open_col: str = "open"
+    high_col: str = "high"
+    low_col: str = "low"
+    close_col: str = "close"
+    volume_col: str = "volume"
+    symbols: List[str]
+    timeframe: str
+    warmup_bars: int = 300
+    poll_interval_sec: int = 5
+    timeframe_col: str | None = None
+
+    @property
+    def schema(self) -> str:
+        return self.schema_
+
+
+class LiveFilterSpec(BaseModel):
+    type: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveRuleSpec(BaseModel):
+    type: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveRiskGateSpec(BaseModel):
+    type: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveTPSLMgmtSpec(BaseModel):
+    type: str
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveStrategySpec(BaseModel):
+    strategy_id: str
+    filters: List[LiveFilterSpec] = Field(default_factory=list)
+    rules: List[LiveRuleSpec] = Field(default_factory=list)
+    risk_gates: List[LiveRiskGateSpec] = Field(default_factory=list)
+    tp_sl_mgmt: LiveTPSLMgmtSpec | None = None
+
+
+class LiveWriteDBSpec(BaseModel):
+    model_config = ConfigDict(protected_namespaces=(), populate_by_name=True)
+
+    mysql_write_env: str = "QE_WRITE_MYSQL_URL"
+    schema_: str = Field("quant", alias="schema")
+    table: str = "trades_live"
+
+    @property
+    def schema(self) -> str:
+        return self.schema_
+
+
+class LiveJavaEmitSpec(BaseModel):
+    enabled: bool = False
+    url_env: str = "QE_JAVA_LIVE_URL"
+    path: str = "/live/signal"
+
+
+class LiveDestinationsSpec(BaseModel):
+    write_db: LiveWriteDBSpec | None = None
+    emit_java: LiveJavaEmitSpec | None = None
+
+
+class LiveSpec(BaseModel):
+    data: LiveDataSpec
+    strategy: LiveStrategySpec
+    destinations: LiveDestinationsSpec | None = None
+
+
 class SeasonalityDataSpec(DataInputSpec):
     pass
 

--- a/src/quant_engine/cli/main.py
+++ b/src/quant_engine/cli/main.py
@@ -21,10 +21,12 @@ runs_app = typer.Typer()
 stats_app = typer.Typer()
 seasonality_app = typer.Typer()
 levels_app = typer.Typer()
+live_app = typer.Typer()
 app.add_typer(runs_app, name="runs")
 app.add_typer(stats_app, name="stats")
 app.add_typer(seasonality_app, name="seasonality")
 app.add_typer(levels_app, name="levels")
+app.add_typer(live_app, name="live")
 
 
 class RunStatus(str, Enum):
@@ -442,6 +444,21 @@ def levels_build(
     spec_model = LevelsBuildSpec.model_validate_json(Path(spec).read_text())
     result = run_levels_build(spec_model)
     typer.echo(json.dumps(result, separators=(",", ":")))
+
+
+@live_app.command("run")
+def live_run(
+    spec: Path = typer.Option(..., "--spec", exists=True, file_okay=True, dir_okay=False)
+) -> None:
+    """Run a live trading specification locally."""
+
+    from ..api.schemas import LiveSpec
+    from ..live.runner import LiveRunner
+
+    payload = json.loads(Path(spec).read_text())
+    live_spec = LiveSpec.model_validate(payload)
+    runner = LiveRunner(live_spec)
+    runner.run_forever()
 
 
 if __name__ == "__main__":

--- a/src/quant_engine/live/__init__.py
+++ b/src/quant_engine/live/__init__.py
@@ -1,0 +1,21 @@
+"""Live trading runtime components."""
+
+from .feed import MySQLPollFeed
+from .state import LiveState
+from .emitter import (
+    ensure_trades_live_table,
+    emit_to_java,
+    write_trade,
+    build_trade,
+)
+from .runner import LiveRunner
+
+__all__ = [
+    "MySQLPollFeed",
+    "LiveState",
+    "ensure_trades_live_table",
+    "emit_to_java",
+    "write_trade",
+    "build_trade",
+    "LiveRunner",
+]

--- a/src/quant_engine/live/emitter.py
+++ b/src/quant_engine/live/emitter.py
@@ -1,0 +1,200 @@
+"""Signal emission helpers for the live runner."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib import request, error
+
+from sqlalchemy import Engine, text
+
+LOGGER = logging.getLogger(__name__)
+
+
+def ensure_trades_live_table(engine: Engine, fqn: str = "quant.trades_live") -> None:
+    """Create the ``quant.trades_live`` table if it does not exist."""
+
+    ddl = (
+        "CREATE TABLE IF NOT EXISTS {table} ("
+        " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+        " strategy_id VARCHAR(64) NOT NULL,"
+        " symbol VARCHAR(32) NOT NULL,"
+        " timeframe VARCHAR(8) NOT NULL,"
+        " ts_open DATETIME(6) NOT NULL,"
+        " side ENUM('LONG','SHORT') NOT NULL,"
+        " entry_price DOUBLE NOT NULL,"
+        " sl DOUBLE NULL,"
+        " tp DOUBLE NULL,"
+        " expected_rr DOUBLE NULL,"
+        " signal_payload JSON NULL,"
+        " uniq_hash CHAR(64) NOT NULL,"
+        " created_at TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),"
+        " UNIQUE KEY ux_trades_live_uniq (uniq_hash),"
+        " KEY idx_trades_live_sym_tf_ts (symbol, timeframe, ts_open),"
+        " KEY idx_trades_live_strategy (strategy_id)"
+        ")"
+    ).format(table=fqn)
+    alt_table = fqn.replace(".", "_")
+    with engine.begin() as conn:
+        try:
+            conn.exec_driver_sql(ddl)
+        except Exception:  # pragma: no cover - fallback for non-MySQL engines
+            conn.exec_driver_sql(ddl.replace(fqn, alt_table))
+
+
+@dataclass
+class TradePayload:
+    strategy_id: str
+    symbol: str
+    timeframe: str
+    ts_open: str
+    side: str
+    entry_price: float
+    sl: Optional[float] = None
+    tp: Optional[float] = None
+    expected_rr: Optional[float] = None
+    signal_payload: Optional[Dict[str, Any]] = None
+    uniq_hash: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        data = {
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "ts_open": self.ts_open,
+            "side": self.side,
+            "entry_price": float(self.entry_price),
+            "sl": self.sl,
+            "tp": self.tp,
+            "expected_rr": self.expected_rr,
+            "signal_payload": self.signal_payload,
+        }
+        if self.uniq_hash:
+            data["uniq_hash"] = self.uniq_hash
+        return data
+
+
+def _round_for_hash(value: Optional[float]) -> str:
+    if value is None:
+        return ""
+    return f"{float(value):.10f}"
+
+
+def compute_trade_hash(payload: TradePayload) -> str:
+    """Compute the deterministic uniq_hash for a trade."""
+
+    parts = [
+        payload.strategy_id,
+        payload.symbol,
+        payload.timeframe,
+        payload.ts_open,
+        payload.side,
+        _round_for_hash(payload.entry_price),
+        _round_for_hash(payload.sl),
+        _round_for_hash(payload.tp),
+    ]
+    digest = hashlib.sha256("|".join(parts).encode()).hexdigest()
+    return digest
+
+
+def build_trade(
+    strategy_id: str,
+    symbol: str,
+    timeframe: str,
+    ts_open: str,
+    side: str,
+    entry_price: float,
+    sl: Optional[float],
+    tp: Optional[float],
+    expected_rr: Optional[float],
+    payload: Optional[Dict[str, Any]] = None,
+) -> TradePayload:
+    """Construct a trade payload enriched with ``uniq_hash``."""
+
+    trade = TradePayload(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        timeframe=timeframe,
+        ts_open=ts_open,
+        side=side.upper(),
+        entry_price=float(entry_price),
+        sl=float(sl) if sl is not None else None,
+        tp=float(tp) if tp is not None else None,
+        expected_rr=float(expected_rr) if expected_rr is not None else None,
+        signal_payload=payload,
+    )
+    trade.uniq_hash = compute_trade_hash(trade)
+    return trade
+
+
+def emit_to_java(
+    signal_dict: Dict[str, Any],
+    url_env: str = "QE_JAVA_LIVE_URL",
+    path: str = "/live/signal",
+    timeout: float = 3.0,
+) -> bool:
+    """POST the signal to the downstream Java service."""
+
+    base = os.environ.get(url_env)
+    if not base:
+        LOGGER.debug("Java emission skipped - env %s not set", url_env)
+        return False
+    url = base.rstrip("/") + path
+    data = json.dumps(signal_dict).encode()
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            if resp.status != 200:
+                LOGGER.warning("Java emit failed: HTTP %s %s", resp.status, resp.reason)
+                return False
+            payload = json.loads(resp.read().decode() or "{}")
+    except error.URLError as exc:
+        LOGGER.warning("Java emit error: %s", exc)
+        return False
+    ok = bool(payload.get("ok", True))
+    if not ok:
+        LOGGER.warning("Java emit returned non-ok payload: %s", payload)
+    return ok
+
+
+def write_trade(engine: Engine, table_fqn: str, trade: TradePayload) -> bool:
+    """Persist the trade payload into ``quant.trades_live`` with idempotence."""
+
+    data = trade.as_dict()
+    if "uniq_hash" not in data or not data["uniq_hash"]:
+        data["uniq_hash"] = compute_trade_hash(trade)
+    insert_cols = (
+        "strategy_id, symbol, timeframe, ts_open, side, entry_price, sl, tp,"
+        " expected_rr, signal_payload, uniq_hash"
+    )
+    values = (
+        ":strategy_id, :symbol, :timeframe, :ts_open, :side, :entry_price, :sl, :tp,"
+        " :expected_rr, :signal_payload, :uniq_hash"
+    )
+    mysql_sql = text(
+        f"INSERT INTO {table_fqn} ({insert_cols}) VALUES ({values}) "
+        "ON DUPLICATE KEY UPDATE signal_payload = VALUES(signal_payload)"
+    )
+    sqlite_table = table_fqn.replace(".", "_")
+    sqlite_sql = text(
+        f"INSERT OR IGNORE INTO {sqlite_table} ({insert_cols}) VALUES ({values})"
+    )
+    with engine.begin() as conn:
+        try:
+            conn.execute(mysql_sql, data)
+            return True
+        except Exception:
+            conn.execute(sqlite_sql, data)
+            return True
+
+
+__all__ = [
+    "TradePayload",
+    "build_trade",
+    "emit_to_java",
+    "ensure_trades_live_table",
+    "write_trade",
+]

--- a/src/quant_engine/live/feed.py
+++ b/src/quant_engine/live/feed.py
@@ -1,0 +1,116 @@
+"""Live data feed adapters."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+from sqlalchemy import Engine, text
+
+
+@dataclass
+class FeedColumns:
+    """Mapping of OHLCV column names in the source table."""
+
+    ts: str
+    open: str
+    high: str
+    low: str
+    close: str
+    volume: str
+    symbol: str
+
+
+class MySQLPollFeed:
+    """Poll-based OHLCV reader for MySQL backends."""
+
+    def __init__(
+        self,
+        engine: Engine,
+        table: str,
+        symbol: str,
+        timeframe: str,
+        columns: FeedColumns,
+        warmup_bars: int,
+        schema: Optional[str] = None,
+        timeframe_col: Optional[str] = None,
+    ) -> None:
+        self.engine = engine
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.columns = columns
+        self.warmup_bars = int(max(warmup_bars, 1))
+        self.schema = schema
+        self.timeframe_col = timeframe_col
+        self._qualified_table = self._qualify_table(table, schema)
+
+    @staticmethod
+    def _qualify_table(table: str, schema: Optional[str]) -> str:
+        if "." in table:
+            return table
+        if schema:
+            return f"{schema}.{table}"
+        return table
+
+    def _base_select(self) -> str:
+        cols = self.columns
+        return (
+            f"SELECT {cols.ts} AS ts, {cols.open} AS open, {cols.high} AS high, "
+            f"{cols.low} AS low, {cols.close} AS close, {cols.volume} AS volume, "
+            f"{cols.symbol} AS symbol "
+            f"FROM {self._qualified_table} "
+            f"WHERE {cols.symbol} = :symbol"
+        )
+
+    def bootstrap(self) -> pd.DataFrame:
+        """Load the warm-up window of bars in ascending order."""
+
+        limit = self.warmup_bars
+        base = self._base_select()
+        if self.timeframe_col:
+            base += f" AND {self.timeframe_col} = :timeframe"
+        base += f" ORDER BY {self.columns.ts} DESC LIMIT {limit}"
+        params: Dict[str, object] = {"symbol": self.symbol}
+        if self.timeframe_col:
+            params["timeframe"] = self.timeframe
+        with self.engine.connect() as conn:
+            df = pd.read_sql(text(base), conn, params=params)
+        if df.empty:
+            return df
+        df["ts"] = pd.to_datetime(df["ts"], utc=True)
+        df = df.sort_values("ts").reset_index(drop=True)
+        return df
+
+    def poll_last_bar(self, last_ts_seen: Optional[pd.Timestamp]) -> pd.DataFrame:
+        """Fetch the most recent completed bar strictly after ``last_ts_seen``."""
+
+        params: Dict[str, object] = {"symbol": self.symbol}
+        base = self._base_select()
+        if self.timeframe_col:
+            base += f" AND {self.timeframe_col} = :timeframe"
+            params["timeframe"] = self.timeframe
+        if last_ts_seen is None:
+            constraint = ""
+        else:
+            last_ts = pd.Timestamp(last_ts_seen)
+            if last_ts.tzinfo is None:
+                last_ts = last_ts.tz_localize("UTC")
+            else:
+                last_ts = last_ts.tz_convert("UTC")
+            constraint = f" AND {self.columns.ts} > :last_ts"
+            params["last_ts"] = last_ts.isoformat()
+        query = (
+            f"SELECT * FROM ("
+            f"{base}{constraint} ORDER BY {self.columns.ts} DESC LIMIT 1"
+            f") AS latest ORDER BY ts ASC"
+        )
+        with self.engine.connect() as conn:
+            df = pd.read_sql(text(query), conn, params=params)
+        if df.empty:
+            return df
+        df["ts"] = pd.to_datetime(df["ts"], utc=True)
+        df = df.sort_values("ts").reset_index(drop=True)
+        return df
+
+
+__all__ = ["FeedColumns", "MySQLPollFeed"]

--- a/src/quant_engine/live/runner.py
+++ b/src/quant_engine/live/runner.py
@@ -1,0 +1,338 @@
+"""Live runner orchestrating feed, strategy evaluation and emission."""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pandas as pd
+from sqlalchemy import create_engine
+
+from ..api.schemas import LiveSpec
+from ..filters import filters_registry
+from .emitter import build_trade, emit_to_java, ensure_trades_live_table, write_trade
+from .feed import FeedColumns, MySQLPollFeed
+from .state import LiveState
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RuleResult:
+    side: str
+    details: Dict[str, float]
+
+
+class LiveRunner:
+    """Main loop driving the live trading pipeline."""
+
+    def __init__(self, spec: LiveSpec) -> None:
+        self.spec = spec
+        self.poll_interval = max(int(spec.data.poll_interval_sec), 1)
+        read_url = os.environ.get(spec.data.mysql_read_env)
+        if not read_url:
+            raise RuntimeError(
+                f"Missing MySQL read URL in environment: {spec.data.mysql_read_env}"
+            )
+        self.read_engine = create_engine(read_url)
+        self.write_engine = None
+        self.write_table = None
+        self.emit_java_enabled = False
+        self.emit_java_path = "/live/signal"
+        destinations = spec.destinations
+        if destinations and destinations.write_db:
+            write_env = destinations.write_db.mysql_write_env
+            write_url = os.environ.get(write_env) if write_env else None
+            if write_url:
+                self.write_engine = create_engine(write_url)
+                schema = destinations.write_db.schema
+                table = destinations.write_db.table
+                self.write_table = f"{schema}.{table}" if schema else table
+                ensure_trades_live_table(self.write_engine, self.write_table)
+            else:
+                LOGGER.warning("MySQL write URL env %s not set", write_env)
+        if destinations and destinations.emit_java and destinations.emit_java.enabled:
+            self.emit_java_enabled = True
+            self.emit_java_path = destinations.emit_java.path or "/live/signal"
+            self.emit_java_env = destinations.emit_java.url_env
+        else:
+            self.emit_java_env = "QE_JAVA_LIVE_URL"
+        self.strategy_id = spec.strategy.strategy_id
+        self.timeframe = spec.data.timeframe
+        self._feeds: Dict[str, MySQLPollFeed] = {}
+        self._states: Dict[str, LiveState] = {}
+        self._stop = threading.Event()
+        self._emitted = 0
+        columns = FeedColumns(
+            ts=spec.data.ts_col,
+            open=spec.data.open_col,
+            high=spec.data.high_col,
+            low=spec.data.low_col,
+            close=spec.data.close_col,
+            volume=spec.data.volume_col,
+            symbol=spec.data.symbol_col,
+        )
+        for symbol in spec.data.symbols:
+            feed = MySQLPollFeed(
+                engine=self.read_engine,
+                table=spec.data.table,
+                symbol=symbol,
+                timeframe=self.timeframe,
+                columns=columns,
+                warmup_bars=spec.data.warmup_bars,
+                schema=spec.data.schema,
+                timeframe_col=spec.data.timeframe_col,
+            )
+            self._feeds[symbol] = feed
+            self._states[symbol] = LiveState(
+                strategy_id=self.strategy_id, symbol=symbol, timeframe=self.timeframe
+            )
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def status(self) -> Dict[str, object]:
+        last_ts = {
+            sym: (
+                state.last_ts_seen.isoformat() if state.last_ts_seen is not None else None
+            )
+            for sym, state in self._states.items()
+        }
+        return {
+            "running": not self._stop.is_set(),
+            "last_ts_seen": last_ts,
+            "emitted_trades": self._emitted,
+        }
+
+    def run_forever(self) -> None:
+        LOGGER.info("Starting LiveRunner for strategy %s", self.strategy_id)
+        try:
+            while not self._stop.is_set():
+                self._run_cycle()
+                time.sleep(self.poll_interval)
+        except KeyboardInterrupt:  # pragma: no cover - manual stop
+            LOGGER.info("LiveRunner interrupted by user")
+        finally:
+            LOGGER.info("LiveRunner stopped")
+
+    def _run_cycle(self) -> None:
+        for symbol, feed in self._feeds.items():
+            state = self._states[symbol]
+            if not state.warm:
+                history = feed.bootstrap()
+                if history.empty:
+                    LOGGER.debug("Warm-up empty for %s", symbol)
+                    continue
+                state.append_history(history)
+                state.mark_processed(history["ts"].iloc[-1])
+                state.warm = True
+                LOGGER.info("Warm-up loaded %s bars for %s", len(history), symbol)
+                continue
+            last_ts = state.last_ts_seen
+            latest = feed.poll_last_bar(last_ts)
+            if latest.empty:
+                continue
+            bar_ts = latest["ts"].iloc[-1]
+            if not state.should_process(bar_ts):
+                continue
+            state.append_history(latest)
+            decision = self._evaluate_symbol(state)
+            if decision is not None:
+                self._emit_signal(state, decision, latest)
+            state.mark_processed(bar_ts)
+
+    def _evaluate_symbol(self, state: LiveState) -> Optional[RuleResult]:
+        df = state.history.copy()
+        if df.empty:
+            return None
+        df["ts"] = pd.to_datetime(df["ts"], utc=True)
+        df = df.set_index("ts")
+        filters_ok = self._apply_filters(df)
+        if not filters_ok:
+            return None
+        rule = self._apply_rules(df)
+        if rule is None:
+            return None
+        if not self._apply_risk_gates(df):
+            return None
+        return rule
+
+    def _apply_filters(self, df: pd.DataFrame) -> bool:
+        specs = self.spec.strategy.filters
+        if not specs:
+            return True
+        results: List[bool] = []
+        for flt in specs:
+            fn = filters_registry.get(flt.type)
+            if fn is None:
+                LOGGER.warning("Unknown filter %s", flt.type)
+                continue
+            series = fn(df, **flt.params)
+            results.append(self._latest_bool(series))
+        return all(results) if results else True
+
+    def _apply_risk_gates(self, df: pd.DataFrame) -> bool:
+        gates = self.spec.strategy.risk_gates
+        if not gates:
+            return True
+        results: List[bool] = []
+        for gate in gates:
+            fn = filters_registry.get(gate.type)
+            if fn is None:
+                LOGGER.warning("Unknown risk gate %s", gate.type)
+                continue
+            series = fn(df, **gate.params)
+            results.append(self._latest_bool(series))
+        return all(results) if results else True
+
+    def _apply_rules(self, df: pd.DataFrame) -> Optional[RuleResult]:
+        rules = self.spec.strategy.rules
+        for rule in rules:
+            if rule.type == "cross_over":
+                res = self._rule_cross_over(df, **rule.params)
+                if res is not None:
+                    return res
+            else:
+                LOGGER.warning("Unsupported rule type %s", rule.type)
+        return None
+
+    @staticmethod
+    def _latest_bool(series: pd.Series) -> bool:
+        if series.empty:
+            return False
+        value = series.iloc[-1]
+        if isinstance(value, (bool, int)):
+            return bool(value)
+        if pd.isna(value):
+            return False
+        return bool(value)
+
+    def _rule_cross_over(
+        self,
+        df: pd.DataFrame,
+        fast_ema: int,
+        slow_ema: int,
+        side: str = "LONG",
+    ) -> Optional[RuleResult]:
+        if "close" not in df.columns:
+            return None
+        close = df["close"].astype(float)
+        fast = close.ewm(span=int(fast_ema), adjust=False).mean()
+        slow = close.ewm(span=int(slow_ema), adjust=False).mean()
+        if len(close) < max(fast_ema, slow_ema) // 2:
+            return None
+        side = side.upper()
+        if side == "LONG":
+            cond = (fast > slow) & (fast.shift(1) <= slow.shift(1))
+            if cond.iloc[-1]:
+                return RuleResult(side="LONG", details={"fast": fast.iloc[-1], "slow": slow.iloc[-1]})
+        elif side == "SHORT":
+            cond = (fast < slow) & (fast.shift(1) >= slow.shift(1))
+            if cond.iloc[-1]:
+                return RuleResult(side="SHORT", details={"fast": fast.iloc[-1], "slow": slow.iloc[-1]})
+        else:
+            LOGGER.warning("Unsupported side %s for crossover", side)
+        return None
+
+    def _compute_tp_sl(
+        self,
+        df: pd.DataFrame,
+        side: str,
+    ) -> Dict[str, Optional[float]]:
+        cfg = self.spec.strategy.tp_sl_mgmt
+        if cfg is None or cfg.type != "fixed_rr":
+            return {"sl": None, "tp": None, "rr": None}
+        params = cfg.params
+        rr = params.get("rr")
+        if rr is None:
+            return {"sl": None, "tp": None, "rr": None}
+        sl_mode = params.get("sl_mode", "atr")
+        close = float(df["close"].iloc[-1])
+        if sl_mode == "atr":
+            atr_window = int(params.get("atr_window", 14))
+            atr_mult = float(params.get("atr_mult", 1.0))
+            atr = self._atr(df, window=atr_window)
+            if atr is None:
+                return {"sl": None, "tp": None, "rr": rr}
+            if side == "LONG":
+                sl = close - atr_mult * atr
+                tp = close + (close - sl) * float(rr)
+            else:
+                sl = close + atr_mult * atr
+                tp = close - (sl - close) * float(rr)
+            return {"sl": sl, "tp": tp, "rr": rr}
+        return {"sl": None, "tp": None, "rr": rr}
+
+    @staticmethod
+    def _atr(df: pd.DataFrame, window: int) -> Optional[float]:
+        required = {"high", "low", "close"}
+        if not required.issubset(df.columns):
+            return None
+        high = df["high"].astype(float)
+        low = df["low"].astype(float)
+        close = df["close"].astype(float)
+        prev_close = close.shift(1)
+        tr = pd.concat([(high - low).abs(), (high - prev_close).abs(), (low - prev_close).abs()], axis=1)
+        atr = tr.max(axis=1).ewm(alpha=1.0 / float(window), adjust=False).mean()
+        value = atr.iloc[-1]
+        return None if pd.isna(value) else float(value)
+
+    def _emit_signal(
+        self,
+        state: LiveState,
+        rule: RuleResult,
+        latest: pd.DataFrame,
+    ) -> None:
+        ts_raw = latest["ts"].iloc[-1]
+        ts = pd.Timestamp(ts_raw)
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        else:
+            ts = ts.tz_convert("UTC")
+        entry_price = float(latest["close"].iloc[-1])
+        history = state.history.copy()
+        history["ts"] = pd.to_datetime(history["ts"], utc=True)
+        history = history.set_index("ts")
+        tpsl = self._compute_tp_sl(history, rule.side)
+        trade = build_trade(
+            strategy_id=self.strategy_id,
+            symbol=state.symbol,
+            timeframe=state.timeframe,
+            ts_open=ts.isoformat(),
+            side=rule.side,
+            entry_price=entry_price,
+            sl=tpsl["sl"],
+            tp=tpsl["tp"],
+            expected_rr=tpsl["rr"],
+            payload={"rule": "cross_over", "details": rule.details},
+        )
+        if trade.uniq_hash in state.emitted_hashes:
+            LOGGER.debug("Duplicate trade hash %s skipped", trade.uniq_hash)
+            return
+        if self.write_engine is not None and self.write_table is not None:
+            try:
+                write_trade(self.write_engine, self.write_table, trade)
+            except Exception as exc:
+                LOGGER.exception("Failed to persist trade: %s", exc)
+        if self.emit_java_enabled:
+            payload = trade.as_dict()
+            payload.pop("uniq_hash", None)
+            try:
+                emit_to_java(payload, url_env=self.emit_java_env, path=self.emit_java_path)
+            except Exception as exc:  # pragma: no cover - network failure
+                LOGGER.warning("Java emission raised: %s", exc)
+        state.emitted_hashes.add(trade.uniq_hash)
+        self._emitted += 1
+        LOGGER.info(
+            "Emitted trade %s %s at %s (entry %.5f)",
+            rule.side,
+            state.symbol,
+            ts.isoformat(),
+            entry_price,
+        )
+
+
+__all__ = ["LiveRunner"]

--- a/src/quant_engine/live/state.py
+++ b/src/quant_engine/live/state.py
@@ -1,0 +1,73 @@
+"""Runtime state cache for live trading."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Set
+
+import pandas as pd
+
+
+@dataclass
+class LiveState:
+    """Hold per-strategy symbol state between polling cycles."""
+
+    strategy_id: str
+    symbol: str
+    timeframe: str
+    history: pd.DataFrame = field(default_factory=lambda: pd.DataFrame(columns=["ts"]))
+    last_ts_seen: Optional[pd.Timestamp] = None
+    warm: bool = False
+    indicator_ctx: Dict[str, object] = field(default_factory=dict)
+    position_state: Dict[str, object] = field(default_factory=dict)
+    emitted_hashes: Set[str] = field(default_factory=set)
+
+    def should_process(self, ts: pd.Timestamp) -> bool:
+        """Return ``True`` if the provided timestamp is new for this state."""
+
+        if ts is None:
+            return False
+        cur = pd.Timestamp(ts)
+        if cur.tzinfo is None:
+            cur = cur.tz_localize("UTC")
+        else:
+            cur = cur.tz_convert("UTC")
+        if self.last_ts_seen is None:
+            return True
+        prev = self.last_ts_seen
+        if prev.tzinfo is None:
+            prev = prev.tz_localize("UTC")
+        else:
+            prev = prev.tz_convert("UTC")
+        return cur > prev
+
+    def mark_processed(self, ts: pd.Timestamp) -> None:
+        """Persist the timestamp of the last processed bar."""
+
+        cur = pd.Timestamp(ts)
+        if cur.tzinfo is None:
+            cur = cur.tz_localize("UTC")
+        else:
+            cur = cur.tz_convert("UTC")
+        self.last_ts_seen = cur
+
+    def append_history(self, df: pd.DataFrame) -> None:
+        """Append fresh bars to the in-memory history buffer."""
+
+        if df.empty:
+            return
+        df = df.copy()
+        df["ts"] = pd.to_datetime(df["ts"], utc=True)
+        if "ts" not in self.history.columns:
+            self.history = df
+        elif self.history.empty:
+            self.history = df
+        else:
+            self.history = (
+                pd.concat([self.history, df], ignore_index=True)
+                .drop_duplicates(subset=["ts"], keep="last")
+                .sort_values("ts")
+                .reset_index(drop=True)
+            )
+
+
+__all__ = ["LiveState"]

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1,0 +1,131 @@
+"""Smoke tests for the live runner pipeline."""
+from __future__ import annotations
+
+import os
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+from quant_engine.api.schemas import LiveSpec
+from quant_engine.live.runner import LiveRunner
+
+
+def _make_rows(start: pd.Timestamp, count: int, close: float) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for i in range(count):
+        ts = start + pd.Timedelta(minutes=i)
+        rows.append(
+            {
+                "symbol": "EURUSD",
+                "ts_utc": ts.isoformat(),
+                "open": close,
+                "high": close + 0.1,
+                "low": close - 0.1,
+                "close": close,
+                "volume": 1000.0,
+            }
+        )
+    return rows
+
+
+def test_live_runner_emits_once(tmp_path, monkeypatch):
+    db_path = tmp_path / "marketdata.db"
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE ohlcv_m1 (
+                    symbol TEXT,
+                    ts_utc TEXT,
+                    open REAL,
+                    high REAL,
+                    low REAL,
+                    close REAL,
+                    volume REAL
+                )
+                """
+            )
+        )
+        start = pd.Timestamp("2024-01-01 00:00:00+00:00")
+        warm_rows = _make_rows(start, 300, close=1.0)
+        conn.execute(
+            text(
+                """
+                INSERT INTO ohlcv_m1 (symbol, ts_utc, open, high, low, close, volume)
+                VALUES (:symbol, :ts_utc, :open, :high, :low, :close, :volume)
+                """
+            ),
+            warm_rows,
+        )
+    read_env = "QE_LIVE_TEST_READ_URL"
+    monkeypatch.setenv(read_env, url)
+    spec_dict = {
+        "data": {
+            "mysql_read_env": read_env,
+            "schema": "",
+            "table": "ohlcv_m1",
+            "symbol_col": "symbol",
+            "ts_col": "ts_utc",
+            "open_col": "open",
+            "high_col": "high",
+            "low_col": "low",
+            "close_col": "close",
+            "volume_col": "volume",
+            "symbols": ["EURUSD"],
+            "timeframe": "M1",
+            "warmup_bars": 300,
+            "poll_interval_sec": 1,
+            "timeframe_col": None,
+        },
+        "strategy": {
+            "strategy_id": "TEST_STRAT",
+            "filters": [],
+            "rules": [
+                {"type": "cross_over", "params": {"fast_ema": 20, "slow_ema": 50, "side": "LONG"}}
+            ],
+            "risk_gates": [],
+            "tp_sl_mgmt": {"type": "fixed_rr", "params": {"rr": 2.0, "sl_mode": "atr", "atr_window": 14, "atr_mult": 1.0}},
+        },
+        "destinations": {"write_db": None, "emit_java": {"enabled": False}},
+    }
+    spec = LiveSpec.model_validate(spec_dict)
+    runner = LiveRunner(spec)
+    state = runner._states["EURUSD"]
+    assert not state.warm
+    runner._run_cycle()
+    assert state.warm
+    assert len(state.history) == 300
+    last_ts = pd.Timestamp(state.history["ts"].iloc[-1])
+    if last_ts.tzinfo is None:
+        expected_ts = last_ts.tz_localize("UTC")
+    else:
+        expected_ts = last_ts.tz_convert("UTC")
+    assert state.last_ts_seen == expected_ts
+    next_bar = {
+        "symbol": "EURUSD",
+        "ts_utc": (start + pd.Timedelta(minutes=300)).isoformat(),
+        "open": 10.0,
+        "high": 10.2,
+        "low": 9.8,
+        "close": 10.0,
+        "volume": 1200.0,
+    }
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO ohlcv_m1 (symbol, ts_utc, open, high, low, close, volume)
+                VALUES (:symbol, :ts_utc, :open, :high, :low, :close, :volume)
+                """
+            ),
+            [next_bar],
+        )
+    runner._run_cycle()
+    assert runner._emitted == 1
+    assert len(state.history) == 301
+    assert len(state.emitted_hashes) == 1
+    emitted_hashes = set(state.emitted_hashes)
+    runner._run_cycle()
+    assert runner._emitted == 1
+    assert state.emitted_hashes == emitted_hashes


### PR DESCRIPTION
## Summary
- add live data feed, emitter, state cache, and runner to orchestrate on-bar-close execution
- extend API schemas and CLI to parse live specs and document the workflow with a sample JSON spec
- cover the flow with a smoke test verifying warm-up and idempotent emission

## Testing
- poetry run pytest tests/test_live_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_69055e62cc00832390b11ed9ac92bf85