### PR TITLE
Add Telegram notifications for live trading signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ MLFLOW_TRACKING_URI=http://localhost:5000
 Pour les tests rapides, la persistance locale utilise SQLite (`.db/quant.db`). Configure les accès MySQL via `QE_MARKETDATA_MYSQL_URL` lorsque tu veux lire les OHLCV depuis ton instance Spring.
 
 
+## Activer les alertes Telegram
+Configure les variables d'environnement suivantes avant de lancer le runner live :
+
+```bash
+export ENABLE_TELEGRAM_ALERTS=true
+export TELEGRAM_BOT_TOKEN="123456789:ABCDEF..."
+export TELEGRAM_CHAT_ID="123456789"
+```
+
+Mets `ENABLE_TELEGRAM_ALERTS` à `false` (ou supprime la variable) pour désactiver les notifications. Si les variables sont absentes ou incomplètes, le moteur continue de fonctionner sans envoyer d'alerte et logue un avertissement.
+
+
 ## Docker Compose
 ```bash
 docker compose up -d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ alembic = "^1.12"
 tenacity = "^8.2"
 pymysql = "^1.1"
 pydantic-settings = "^2.1"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/src/quant_engine/live/runner.py
+++ b/src/quant_engine/live/runner.py
@@ -13,7 +13,14 @@ from sqlalchemy import create_engine
 
 from ..api.schemas import LiveSpec
 from ..filters import filters_registry
-from .emitter import build_trade, emit_to_java, ensure_trades_live_table, write_trade
+from .emitter import (
+    TradePayload,
+    build_trade,
+    emit_to_java,
+    ensure_trades_live_table,
+    write_trade,
+)
+from ..notify.telegram_notify import send_telegram_message
 from .feed import FeedColumns, MySQLPollFeed
 from .state import LiveState
 
@@ -324,6 +331,7 @@ class LiveRunner:
                 emit_to_java(payload, url_env=self.emit_java_env, path=self.emit_java_path)
             except Exception as exc:  # pragma: no cover - network failure
                 LOGGER.warning("Java emission raised: %s", exc)
+        self._notify_telegram(state, trade)
         state.emitted_hashes.add(trade.uniq_hash)
         self._emitted += 1
         LOGGER.info(
@@ -333,6 +341,32 @@ class LiveRunner:
             ts.isoformat(),
             entry_price,
         )
+
+    def _notify_telegram(self, state: LiveState, trade: TradePayload) -> None:
+        """Send a Telegram alert for the emitted trade without blocking the main flow."""
+
+        try:
+            msg_lines = [
+                "🚨 *Signal de trading détecté*",
+                f"• Stratégie : `{trade.strategy_id}`",
+                f"• Symbole : `{state.symbol}`",
+                f"• Timeframe : `{state.timeframe}`",
+                f"• Direction : *{trade.side}*",
+                f"• Prix d'entrée : `{trade.entry_price}`",
+                f"• Timestamp : `{trade.ts_open}`",
+            ]
+            if trade.expected_rr is not None:
+                msg_lines.append(f"• RR attendu : `{trade.expected_rr}`")
+            if trade.signal_payload and "details" in trade.signal_payload:
+                details = trade.signal_payload["details"]
+                if isinstance(details, dict) and details:
+                    formatted = ", ".join(
+                        f"{key}={value}" for key, value in details.items()
+                    )
+                    msg_lines.append(f"• Détails : `{formatted}`")
+            send_telegram_message("\n".join(msg_lines))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.error("Erreur lors de la préparation/envoi de l'alerte Telegram: %s", exc)
 
 
 __all__ = ["LiveRunner"]

--- a/src/quant_engine/notify/__init__.py
+++ b/src/quant_engine/notify/__init__.py
@@ -1,0 +1,5 @@
+"""Notification helpers for external alerting channels."""
+
+from .telegram_notify import send_telegram_message, is_configured
+
+__all__ = ["send_telegram_message", "is_configured"]

--- a/src/quant_engine/notify/telegram_notify.py
+++ b/src/quant_engine/notify/telegram_notify.py
@@ -1,0 +1,63 @@
+"""Telegram notification helper."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+TELEGRAM_ENABLED = os.getenv("ENABLE_TELEGRAM_ALERTS", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+
+
+def is_configured() -> bool:
+    """Return ``True`` if Telegram notifications are fully configured."""
+
+    return TELEGRAM_ENABLED and bool(TELEGRAM_BOT_TOKEN) and bool(TELEGRAM_CHAT_ID)
+
+
+def send_telegram_message(text: str, *, parse_mode: Optional[str] = "Markdown") -> None:
+    """Send ``text`` to the configured Telegram chat.
+
+    Environment variables required:
+    - ``TELEGRAM_BOT_TOKEN`` : Token du bot Telegram.
+    - ``TELEGRAM_CHAT_ID`` : Identifiant du chat (utilisateur ou groupe).
+    - ``ENABLE_TELEGRAM_ALERTS`` : (optionnel) ``true`` par défaut, mettre à ``false`` pour désactiver.
+
+    Les erreurs sont loggées sans interrompre le flux principal.
+    """
+
+    if not TELEGRAM_ENABLED:
+        logger.debug("[Telegram] Alerts disabled via ENABLE_TELEGRAM_ALERTS")
+        return
+
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        logger.warning(
+            "[Telegram] Configuration incomplète (TELEGRAM_BOT_TOKEN ou TELEGRAM_CHAT_ID manquant)."
+        )
+        return
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    payload = {
+        "chat_id": TELEGRAM_CHAT_ID,
+        "text": text,
+    }
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+
+    try:
+        resp = requests.post(url, json=payload, timeout=3)
+        if resp.status_code != 200:
+            logger.error("[Telegram] Échec envoi message (%s): %s", resp.status_code, resp.text)
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.error("[Telegram] Exception lors de l'envoi du message: %s", exc)
+


### PR DESCRIPTION
## Summary
- add a Telegram notification helper module that reads configuration from environment variables
- hook live signal emission to send Telegram alerts alongside existing Java emission
- document the Telegram environment variables and add the requests dependency

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8c86c23c832393b00e1a14575b6f)