### PR TITLE
Document Python performance pipeline and DCA integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 ## Présentation
 Moteur d’optimisation et de backtest basé sur une spécification JSON, prenant en charge EMA/VWAP, TP/SL, Walk Forward Analysis, Optuna, MySQL et MLflow.
 
+### Vue d’ensemble du moteur Python
+- **Source de vérité métier** : le code Python produit les signaux (EMA/grid/DCA), reconstruit les trades, calcule les métriques de performance et garde la cohérence entre backtests et exécution live.
+- **Séparation des rôles** :
+  - *Signaux* (bas niveau, multi BUY par cycle),
+  - *Trades agrégés* (1 cycle DCA = 1 trade logique, clôturé sur le SELL take‑profit),
+  - *Run de stratégie* (métriques globales dérivées des trades).
+- **Persistance** : Python ne stocke pas durablement les résultats métiers ; il calcule et transmet un payload vers le backend Java Spring responsable de l’import et de la conservation des runs/trades.
+
 Affichage Markdown :  Ctrl + Shift + V
 ## Installation
 ```bash 
@@ -69,6 +77,13 @@ poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
   ```bash
   poetry run quant-engine runs show RUN_ID
   ```
+
+## Performance, DCA et intégration backend
+- **Module `quant_engine.performance`** : calcule les métriques côté Python et agrège les signaux DCA en `CompletedTrade` (1 cycle = 1 trade logique). Les BUY successifs d’un cycle sont consolidés ; la vente `take_profit` clôture le trade et porte les métadonnées du cycle.
+- **StrategyRunResult** : résumé d’un run (dates, ratios win/loss, drawdown, Sharpe/Sortino calculés en Python). Les champs capital/prix/qty peuvent rester des placeholders selon la stratégie ; les valeurs optionnelles sont envoyées dans `extra` pour compatibilité future.
+- **Flux de données** : `candles → signaux → trades → métriques → payload backend`. Les perfs sont calculées en Python pour garantir la cohérence entre backtest et live, éviter la duplication de logique et permettre la reproductibilité.
+- **Payload Java** : un seul endpoint d’import est appelé avec `{ "run": {..}, "trades": [...] }`. Le backend Spring ne recalcule pas les perfs ; il persiste simplement le run et les trades reçus.
+- **Conventions récentes** : `runId` est obligatoire et présent dans tous les objets envoyés. Les signaux sont des événements bas niveau ; les trades reflètent les cycles stratégiques ; le run agrège la performance globale. Certains champs prix/qty peuvent encore être complétés par la suite (TODO connus), mais la structure de payload est stable.
 
 ### High-level Strategies
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -11,6 +11,14 @@ Ce document résume l’état **actuel** du moteur lourd Python (après intégra
 - **Persistence** : SQLAlchemy/Alembic (MySQL cible, SQLite fallback), artefacts Parquet/JSON, logging MLflow (si configuré).
 - **Qualité & CI** : pytest, ruff, black, mypy, pré-commit, GitHub Actions.
 
+### Performance & DCA (source de vérité Python)
+- **Python calcule tout** : production des signaux, logique DCA/grid, reconstruction des trades agrégés et calcul des métriques de performance (Sharpe, Sortino, drawdown, win/loss…).
+- **Pas de persistance métier longue durée** : le moteur Python prépare un payload pour le backend Java qui se charge de stocker les résultats.
+- **Granularité** :
+  - *Signaux* : évènements bas niveau (plusieurs BUY par cycle possible, tags `cycle_id`, `grid_level`…),
+  - *Trades* : 1 cycle DCA = 1 `CompletedTrade` consolidé (BUY multiples → SELL take-profit qui clôture),
+  - *Run* : `StrategyRunResult` décrivant la performance globale d’une stratégie sur une période (backtest ou live).
+
 Arborescence (simplifiée) :
 
 src/quant_engine/ api/ (FastAPI, schémas Pydantic) cli/ (Typer CLI) core/ (spec, dataset, features) backtest/ (engine, metrics) tpsl/ (règles TP/SL) validate/ (splitter WFA) optimize/ (Optuna runner) stats/ (events, conditions, targets, estimators, runner) persistence/ (db, models, repo, migrations) io/ (artifacts, ids)
@@ -94,11 +102,21 @@ Ex. “Avec 2 bougies up en M1, HTF up, vol haute → P(up_next) ≈ 57% [54–6
 
 ## 6) Bonnes pratiques (rappel)
 
-- **No lookahead** : conditions calculables à t ; targets sur t+1..t+n.  
-- **n_min** : seuil d’échantillon (ex. 300) ; sous le seuil → `insufficient=true`.  
-- **WFA** : séparer train/test ; apprendre les bins sur train.  
-- **Contrôle FDR** : BH sur p-values si beaucoup de patterns.  
+- **No lookahead** : conditions calculables à t ; targets sur t+1..t+n.
+- **n_min** : seuil d’échantillon (ex. 300) ; sous le seuil → `insufficient=true`.
+- **WFA** : séparer train/test ; apprendre les bins sur train.
+- **Contrôle FDR** : BH sur p-values si beaucoup de patterns.
 - **Traçabilité** : stocker `spec_id`, `dataset_id`, dates `start/end` dans chaque sortie.
+
+## 7) Module performance & intégration backend Java
+
+- **`quant_engine.performance`** :
+  - `StrategyRunResult` = résumé d’un run (timestamps UTC, ratios de victoire/défaite, drawdown, retours cumulés, Sharpe/Sortino calculés côté Python).
+  - `CompletedTrade` = trade agrégé par cycle DCA (plusieurs BUY successifs consolidés, SELL take-profit comme fermeture, `cycle_id` obligatoire pour relier les signaux).
+  - Les champs prix/quantité peuvent rester approximatifs sur certaines stratégies (placeholders) ; les valeurs complémentaires partent dans `extra/meta` pour compatibilité future.
+- **Pipeline de données** : `candles → signaux → trades → métriques → payload backend`. Les perfs sont calculées dans Python pour garantir une logique unique entre backtest et live et éviter toute divergence avec le backend.
+- **Payload envoyé au backend Spring** : structure `{ "run": {…}, "trades": [...] }` générée via `to_backend_payload` ou `build_backend_payload_for_java`. Un seul endpoint d’import est appelé ; Java ne recalculera jamais les performances reçues.
+- **Règles et conventions récentes** : `runId` propagé partout, séparation nette signaux/trades/run, champs encore en TODO (ex. certaines valeurs de prix/qty) mais format stabilisé. Les SELL non take-profit ne ferment pas un trade DCA ; seul le SELL taggé `take_profit` termine le cycle.
 
 ---
 

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -1,3 +1,12 @@
+"""Construction des trades DCA et du payload backend.
+
+À partir des signaux bas niveau (BUY/SELL taggés `cycle_id`), le module
+reconstruit des `CompletedTrade` (1 cycle = 1 trade logique), calcule les
+métriques agrégées (`StrategyRunResult`) et produit le payload `{run, trades}`
+envoyé au backend Java. Les performances sont donc calculées dans Python pour
+rester cohérentes entre backtests et exécution live.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/quant_engine/performance/models.py
+++ b/src/quant_engine/performance/models.py
@@ -1,3 +1,13 @@
+"""Dataclasses représentant un run de stratégie et les trades agrégés.
+
+Le module sert de contrat interne pour le calcul des performances côté Python et
+la génération du payload envoyé au backend Java. `StrategyRunResult` décrit la
+vue synthétique d’un run (dates, ratios, drawdown, métriques de risque), tandis
+que `CompletedTrade` capture un cycle DCA consolidé (BUY multiples → SELL
+take-profit). Les champs optionnels permettent de transporter des placeholders
+ou des compléments dans `extra/meta` sans casser le format du payload.
+"""
+
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field


### PR DESCRIPTION
## Summary
- expand README with the Python-centric performance overview and backend integration workflow
- document DCA trade aggregation, StrategyRunResult, and payload expectations in architecture overview
- clarify performance module intent through module-level docstrings

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693caf534bd483239998b4c45b32fe3f)