### PR TITLE
Add stress test API contract to performance package

### DIFF
--- a/src/quant_engine/performance/__init__.py
+++ b/src/quant_engine/performance/__init__.py
@@ -1,4 +1,13 @@
 from .models import CompletedTrade, StrategyRunResult, to_backend_payload
+from .stress_tests import (
+    StressTestResult,
+    run_monte_carlo_on_equity_curve,
+    run_monte_carlo_on_returns,
+    run_monte_carlo_on_trades,
+    run_scenarios_on_equity_curve,
+    run_scenarios_on_returns,
+    run_scenarios_on_trades,
+)
 from .dca_builder import build_backend_payload_for_java, build_dca_performance_from_signals
 
 __all__ = [
@@ -7,4 +16,11 @@ __all__ = [
     "to_backend_payload",
     "build_dca_performance_from_signals",
     "build_backend_payload_for_java",
+    "StressTestResult",
+    "run_monte_carlo_on_equity_curve",
+    "run_monte_carlo_on_returns",
+    "run_monte_carlo_on_trades",
+    "run_scenarios_on_equity_curve",
+    "run_scenarios_on_returns",
+    "run_scenarios_on_trades",
 ]

--- a/src/quant_engine/performance/stress_tests.py
+++ b/src/quant_engine/performance/stress_tests.py
@@ -1,0 +1,199 @@
+"""API contract for strategy stress tests.
+
+This module defines a unified interface for running stress tests and returning
+results that can be stored in ``StrategyRunResult.extra``. Implementations can
+plug into the placeholders to provide Monte Carlo or deterministic scenario
+analysis while keeping a consistent payload schema.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Sequence, TypedDict, Union
+
+from .models import CompletedTrade
+
+
+TimeSeries = Union[Sequence[float], Mapping[datetime, float]]
+
+
+class StressTestResult(TypedDict, total=False):
+    """Standardized output keys for stress tests.
+
+    Keys
+    ----
+    metrics:
+        Aggregated figures such as percentiles, worst-case loss, or VaR.
+    distributions:
+        Raw distributions or arrays produced by the stress test (e.g. Monte Carlo
+        returns, scenario PnL paths).
+    parameters:
+        Parameters actually used for the run (sample size, scenario shocks,
+        random seed, horizon, etc.).
+    warnings:
+        Human-readable warnings for data quality or configuration issues.
+    """
+
+    metrics: Dict[str, Any]
+    distributions: Dict[str, Any]
+    parameters: Dict[str, Any]
+    warnings: List[str]
+
+
+def run_monte_carlo_on_trades(
+    trades: Sequence[CompletedTrade],
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run Monte Carlo stress tests using the completed trades.
+
+    Parameters
+    ----------
+    trades:
+        Sequence of ``CompletedTrade`` describing the run.
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional configuration for the Monte Carlo run (sample size, horizon,
+        random seed, bootstrap method, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Monte Carlo stress tests on trades are not implemented.")
+
+
+def run_monte_carlo_on_returns(
+    returns: TimeSeries,
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run Monte Carlo stress tests using the returns series.
+
+    Parameters
+    ----------
+    returns:
+        Sequence or mapping of returns (chronological order if sequence).
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional configuration for the Monte Carlo run (sample size, horizon,
+        random seed, bootstrap method, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Monte Carlo stress tests on returns are not implemented.")
+
+
+def run_monte_carlo_on_equity_curve(
+    equity_curve: TimeSeries,
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run Monte Carlo stress tests using the equity curve.
+
+    Parameters
+    ----------
+    equity_curve:
+        Sequence or mapping of equity values (chronological order if sequence).
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional configuration for the Monte Carlo run (sample size, horizon,
+        random seed, bootstrap method, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Monte Carlo stress tests on equity curve are not implemented.")
+
+
+def run_scenarios_on_trades(
+    trades: Sequence[CompletedTrade],
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run deterministic scenario stress tests using the completed trades.
+
+    Parameters
+    ----------
+    trades:
+        Sequence of ``CompletedTrade`` describing the run.
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional scenario definitions (shock size, volatility spike, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Scenario stress tests on trades are not implemented.")
+
+
+def run_scenarios_on_returns(
+    returns: TimeSeries,
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run deterministic scenario stress tests using the returns series.
+
+    Parameters
+    ----------
+    returns:
+        Sequence or mapping of returns (chronological order if sequence).
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional scenario definitions (shock size, volatility spike, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Scenario stress tests on returns are not implemented.")
+
+
+def run_scenarios_on_equity_curve(
+    equity_curve: TimeSeries,
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    parameters: Optional[Mapping[str, Any]] = None,
+) -> StressTestResult:
+    """Run deterministic scenario stress tests using the equity curve.
+
+    Parameters
+    ----------
+    equity_curve:
+        Sequence or mapping of equity values (chronological order if sequence).
+    metadata:
+        Optional contextual metadata (strategy id, asset class, etc.).
+    parameters:
+        Optional scenario definitions (shock size, volatility spike, etc.).
+
+    Returns
+    -------
+    StressTestResult
+        Dict compatible with ``StrategyRunResult.extra``.
+    """
+
+    raise NotImplementedError("Scenario stress tests on equity curve are not implemented.")


### PR DESCRIPTION
### Motivation
- Provide a unified API surface for running stress tests (Monte Carlo and deterministic scenarios) over trades, returns or equity curves.
- Standardize the output format so stress-test results can be stored in `StrategyRunResult.extra` with consistent keys.
- Separate the contract from implementations so different backends or algorithms can be plugged in later.

### Description
- Add a new module `src/quant_engine/performance/stress_tests.py` that defines `TimeSeries`, `StressTestResult`, and the API functions `run_monte_carlo_on_trades`, `run_monte_carlo_on_returns`, `run_monte_carlo_on_equity_curve`, `run_scenarios_on_trades`, `run_scenarios_on_returns`, and `run_scenarios_on_equity_curve` which currently raise `NotImplementedError` as placeholders.
- Define `StressTestResult` as a `TypedDict` with standard keys `metrics`, `distributions`, `parameters` and `warnings` to document the expected output schema.
- Export the new types and functions from the `performance` package via `src/quant_engine/performance/__init__.py` so they are available to callers.
- Ensure the contract explicitly documents inputs (`CompletedTrade`, returns/equity `TimeSeries`, `metadata`, `parameters`) and compatibility with `StrategyRunResult.extra`.

### Testing
- No automated tests were run for this API-only change.
- The repository changes were committed and the new module was added without running the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e76fe59883239fb042220ca017f9)