### PR TITLE
Standardize stress test metric naming

### DIFF
--- a/src/quant_engine/performance/stress_tests.py
+++ b/src/quant_engine/performance/stress_tests.py
@@ -21,6 +21,67 @@ from .models import CompletedTrade
 TimeSeries = Union[Sequence[float], Mapping[datetime, float]]
 MultiAssetReturns = Mapping[str, TimeSeries]
 
+METRIC_NAME_MAP = {
+    "maxDrawdown": "max_drawdown",
+    "max_drawdown": "max_drawdown",
+    "maxDrawdownPct": "max_drawdown_pct",
+    "max_drawdown_pct": "max_drawdown_pct",
+    "cagr": "cagr",
+    "cagr_pct": "cagr",
+    "ruinProbability": "ruin_probability",
+    "ruin_probability": "ruin_probability",
+    "time_to_recovery": "time_to_recovery_days",
+    "time_to_recovery_days": "time_to_recovery_days",
+}
+
+EXPECTED_STRESS_TEST_METRICS: Dict[str, Dict[str, List[str]]] = {
+    "monte_carlo": {
+        "summary": ["max_drawdown", "max_drawdown_pct", "cagr", "ruin_probability", "time_to_recovery_days"],
+        "level1": [
+            "final_capital",
+            "return_pct",
+            "max_drawdown",
+            "max_drawdown_pct",
+            "volatility_pct",
+            "sharpe",
+            "sortino",
+            "winrate_pct",
+            "total_return",
+            "average_trade",
+            "win_count",
+            "loss_count",
+        ],
+    },
+    "scenarios": {
+        "level1": [
+            "final_capital",
+            "return_pct",
+            "max_drawdown",
+            "max_drawdown_pct",
+            "volatility_pct",
+            "sharpe",
+            "sortino",
+            "winrate_pct",
+            "total_return",
+            "average_trade",
+            "win_count",
+            "loss_count",
+        ]
+    },
+}
+
+
+def _normalize_metric_names(metrics: Mapping[str, Any]) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = {}
+    for key, value in metrics.items():
+        target = METRIC_NAME_MAP.get(key, key)
+        normalized[target] = value
+    return normalized
+
+
+def _normalize_scenario_metrics(metrics_map: Mapping[str, Any]) -> Dict[str, Any]:
+    return {name: _normalize_metric_names(metrics) for name, metrics in metrics_map.items()}
+
 
 class StressTestResult(TypedDict, total=False):
     """Standardized output keys for stress tests.
@@ -424,7 +485,9 @@ def apply_scenarios_to_returns(
             for symbol, values in per_asset.items():
                 adjusted = _apply_scenario_to_returns(values, scenario, initial_capital=initial_capital)
                 adjusted_assets[symbol] = adjusted
-                metrics = _compute_level1_metrics(adjusted, _build_equity_curve(adjusted, initial_capital), initial_capital)
+                metrics = _normalize_metric_names(
+                    _compute_level1_metrics(adjusted, _build_equity_curve(adjusted, initial_capital), initial_capital)
+                )
                 per_asset_results[symbol] = {
                     "returns": adjusted,
                     "timestamps": timestamps.get(symbol),
@@ -432,8 +495,10 @@ def apply_scenarios_to_returns(
                 }
 
             portfolio_returns, portfolio_ts = _aggregate_multi_asset_returns(adjusted_assets, timestamps)
-            portfolio_metrics = _compute_level1_metrics(
-                portfolio_returns, _build_equity_curve(portfolio_returns, initial_capital), initial_capital
+            portfolio_metrics = _normalize_metric_names(
+                _compute_level1_metrics(
+                    portfolio_returns, _build_equity_curve(portfolio_returns, initial_capital), initial_capital
+                )
             )
             scenario_results[name] = {
                 "metrics": portfolio_metrics,
@@ -450,7 +515,9 @@ def apply_scenarios_to_returns(
         for scenario in scenarios:
             name = str(scenario.get("name", "scenario"))
             adjusted = _apply_scenario_to_returns(values, scenario, initial_capital=initial_capital)
-            metrics = _compute_level1_metrics(adjusted, _build_equity_curve(adjusted, initial_capital), initial_capital)
+            metrics = _normalize_metric_names(
+                _compute_level1_metrics(adjusted, _build_equity_curve(adjusted, initial_capital), initial_capital)
+            )
             scenario_results[name] = {
                 "metrics": metrics,
                 "returns": adjusted,
@@ -460,7 +527,7 @@ def apply_scenarios_to_returns(
             scenario_metrics[name] = metrics
 
     return {
-        "metrics": {"scenarios": scenario_metrics},
+        "metrics": {"scenarios": _normalize_scenario_metrics(scenario_metrics)},
         "distributions": {"scenarios": scenario_results},
         "parameters": {"initial_capital": initial_capital, "scenarios": list(scenarios)},
         "warnings": warnings,
@@ -733,13 +800,16 @@ def _monte_carlo_bootstrap(
     for key, values in level1_metrics.items():
         metrics[key] = _summary_stats(values)
 
+    metrics = _normalize_metric_names(metrics)
+    normalized_level1 = _normalize_metric_names(level1_metrics)
+
     distributions = {
         "max_drawdown": max_drawdowns,
         "cagr": cagrs,
         "time_to_recovery_days": time_to_recovery,
         "equity_curves": equity_curves,
         "ruin": ruin_flags,
-        "level1": level1_metrics,
+        "level1": normalized_level1,
     }
 
     return {


### PR DESCRIPTION
### Motivation
- Provide a single, consistent metric naming convention for Monte Carlo and deterministic scenario stress tests (e.g. `max_drawdown`, `cagr`, `ruin_probability`, `time_to_recovery_days`).
- Tolerate legacy or alternate metric keys from existing outputs by mapping them to the canonical names.
- Formalize the set of expected level-1 and summary metrics for Monte Carlo and scenario runs so consumers can rely on a stable schema.

### Description
- Added a `METRIC_NAME_MAP` mapping and `EXPECTED_STRESS_TEST_METRICS` dictionary in `src/quant_engine/performance/stress_tests.py` to declare canonical keys and expected metric lists.
- Implemented `_normalize_metric_names` and `_normalize_scenario_metrics` helper functions and applied them to normalize metrics produced by `apply_scenarios_to_returns` and the Monte Carlo bootstrap outputs.
- Normalized per-asset metrics, portfolio-level metrics, the Monte Carlo summary `metrics` and the `distributions["level1"]` payload to use canonical keys.
- Kept existing computed metric values and distributions intact while ensuring keys are translated to the unified naming convention.

### Testing
- No automated tests were executed against these changes during this update.
- The change was committed to the repository and the modified file is `src/quant_engine/performance/stress_tests.py`.
- Existing unit tests in the tree reference various metric keys but were not run as part of this PR.
- Consumers of the stress-test outputs should validate integration with downstream code paths that read keys like `run_metrics` or API schemas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949eefd66bc832399f86c96b6a3fdbe)