### PR TITLE
Add spec parsing coverage

### DIFF
--- a/tests/test_spec_parsing.py
+++ b/tests/test_spec_parsing.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quant_engine.core import spec as spec_module
+
+
+SPEC_PATH = Path(__file__).parent / "data" / "spec_example.json"
+
+
+def _load_base_spec() -> dict:
+    return json.loads(SPEC_PATH.read_text())
+
+
+@pytest.mark.parametrize("missing_field", ["start", "end"])
+def test_parse_spec_requires_start_end(missing_field: str) -> None:
+    payload = _load_base_spec()
+    payload["data"].pop(missing_field, None)
+
+    with pytest.raises(ValueError, match="data.start and data.end are required"):
+        spec_module.spec_from_dict(payload)
+
+
+def test_parse_spec_requires_dataset_or_mysql() -> None:
+    payload = _load_base_spec()
+    payload["data"].pop("path", None)
+    payload["data"].pop("dataset_path", None)
+
+    with pytest.raises(ValueError, match="dataset_path/path or mysql"):
+        spec_module.spec_from_dict(payload)
+
+
+def test_parse_spec_rejects_non_iterable_search_space() -> None:
+    payload = _load_base_spec()
+    payload["strategy"]["search_space"]["ema_fast"] = 5
+
+    with pytest.raises(TypeError):
+        spec_module.spec_from_dict(payload)
+
+
+def test_parse_spec_casts_mysql_chunk_minutes_to_int() -> None:
+    payload = _load_base_spec()
+    payload["data"].pop("path", None)
+    payload["data"].pop("dataset_path", None)
+    payload["data"]["mysql"] = {"chunk_minutes": "15"}
+
+    parsed = spec_module.spec_from_dict(payload)
+
+    assert parsed.data.mysql is not None
+    assert parsed.data.mysql.chunk_minutes == 15
+    assert isinstance(parsed.data.mysql.chunk_minutes, int)


### PR DESCRIPTION
### Motivation
- Add unit tests to verify the JSON spec parsing enforces required fields and input types.
- Ensure the parser errors when `data.start` or `data.end` are missing and when no data source is provided.
- Prevent silent acceptance of non-iterable `search_space` values by asserting a failure.
- Verify dataclass fields are properly typed (e.g. `mysql.chunk_minutes` is cast to `int`).

### Description
- Add `tests/test_spec_parsing.py` containing four tests that exercise `spec_module.spec_from_dict` using the base spec at `tests/data/spec_example.json`.
- Test that missing `data.start` or `data.end` raises `ValueError` with the expected message.
- Test that removing both `path`/`dataset_path` and not providing `mysql` raises `ValueError` about `dataset_path/path or mysql`.
- Test that non-iterable `search_space` entries raise `TypeError` and that `mysql.chunk_minutes` passed as a string is cast to an `int`.

### Testing
- No automated test runner was executed as part of this change.
- The new tests exercise `spec_module.spec_from_dict` and are ready to be run with `pytest tests/test_spec_parsing.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e011d72c8323a38db4c806fff37e)