### PR TITLE
Add validation splitter unit tests

### DIFF
--- a/tests/test_validation_splitter.py
+++ b/tests/test_validation_splitter.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+
+from quant_engine.validate.splitter import generate_folds
+
+
+def _build_dataset(start: datetime, days: int, tz: timezone | None = None) -> list[dict]:
+    rows = []
+    current = start
+    for _ in range(days):
+        if tz is not None:
+            current = current.replace(tzinfo=tz)
+        rows.append({"timestamp": current.isoformat()})
+        current = (current + timedelta(days=1)).replace(tzinfo=None)
+    return rows
+
+
+def test_empty_dataset_returns_empty_list() -> None:
+    assert generate_folds([], train_months=1, test_months=1, folds=2, embargo_days=0) == []
+
+
+def test_timezone_aware_conversion_is_neutral() -> None:
+    start = datetime(2020, 1, 1, 0, 30)
+    tz = timezone(timedelta(hours=2))
+    dataset_tz = _build_dataset(start, days=40, tz=tz)
+    dataset_naive = _build_dataset(start, days=40, tz=None)
+
+    folds_tz = generate_folds(
+        dataset_tz, train_months=1, test_months=1, folds=1, embargo_days=0
+    )
+    folds_naive = generate_folds(
+        dataset_naive, train_months=1, test_months=1, folds=1, embargo_days=0
+    )
+
+    assert [row["timestamp"] for row in folds_tz[0]["train"]] == [
+        row["timestamp"] for row in folds_naive[0]["train"]
+    ]
+    assert [row["timestamp"] for row in folds_tz[0]["test"]] == [
+        row["timestamp"] for row in folds_naive[0]["test"]
+    ]
+
+
+def test_embargo_days_is_applied() -> None:
+    dataset = _build_dataset(datetime(2020, 1, 1), days=70)
+    folds = generate_folds(dataset, train_months=1, test_months=1, folds=1, embargo_days=2)
+
+    test_rows = folds[0]["test"]
+    assert test_rows[0]["timestamp"].startswith("2020-02-03")
+    assert all(
+        not row["timestamp"].startswith(("2020-02-01", "2020-02-02"))
+        for row in test_rows
+    )
+
+
+def test_breaks_when_test_rows_empty() -> None:
+    dataset = _build_dataset(datetime(2020, 1, 1), days=15)
+    folds = generate_folds(dataset, train_months=1, test_months=1, folds=3, embargo_days=0)
+    assert folds == []


### PR DESCRIPTION
### Motivation

- Add unit tests for the walk-forward validation splitter to catch regressions and clarify expected behavior.
- Verify correct handling of timezone-aware vs naive ISO timestamps when building folds from a dataset.
- Ensure the `embargo_days` offset is applied to test windows to prevent leakage.
- Confirm the fold-generation loop terminates when there are no `test_rows` to include.

### Description

- Add `tests/test_validation_splitter.py` which provides a `_build_dataset` helper producing ISO timestamps for synthetic datasets.
- Add tests `test_empty_dataset_returns_empty_list`, `test_timezone_aware_conversion_is_neutral`, `test_embargo_days_is_applied`, and `test_breaks_when_test_rows_empty` that exercise `generate_folds`.
- Tests assert fold structure and timestamp boundaries, including that timezone-aware timestamps are normalized and embargo days shift the `test` window.
- Test inputs use deterministic daily increments and ISO-formatted `timestamp` strings to keep behavior reproducible.

### Testing

- No automated tests were executed during this rollout.
- The new tests are present and intended to be run by the project's test suite (e.g., via `pytest`) in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e01a73688323927177a3023947cc)