### PR TITLE
Wrap multi-asset scenario outputs in `portfolio_level` and `by_symbol`

### DIFF
--- a/src/quant_engine/performance/stress_tests.py
+++ b/src/quant_engine/performance/stress_tests.py
@@ -590,6 +590,7 @@ def apply_scenarios_to_returns(
                     "returns": adjusted,
                     "timestamps": timestamps.get(symbol),
                     "metrics": metrics,
+                    "parameters": scenario_data,
                 }
 
             portfolio_returns, portfolio_ts = _aggregate_multi_asset_returns(adjusted_assets, timestamps)
@@ -599,11 +600,13 @@ def apply_scenarios_to_returns(
                 )
             )
             scenario_results[name] = {
-                "metrics": portfolio_metrics,
-                "returns": portfolio_returns,
-                "timestamps": portfolio_ts,
-                "per_asset": per_asset_results,
-                "parameters": scenario_data,
+                "portfolio_level": {
+                    "metrics": portfolio_metrics,
+                    "returns": portfolio_returns,
+                    "timestamps": portfolio_ts,
+                    "parameters": scenario_data,
+                },
+                "by_symbol": per_asset_results,
             }
             scenario_metrics[name] = portfolio_metrics
     else:


### PR DESCRIPTION
### Motivation
- Make multi-asset scenario output follow the same schema as single-asset scenarios produced by `apply_scenarios_to_returns`.
- Expose per-symbol `parameters` so each symbol block contains the same keys as single-asset results.
- Provide an explicit portfolio-level block to separate aggregated metrics from per-symbol data.
- Ensure consumers of `scenario_results[name]` have a stable, uniform structure for both single- and multi-asset runs.

### Description
- Updated `apply_scenarios_to_returns` to include `"parameters"` inside each per-symbol result stored in `per_asset_results`.
- Replaced the previous top-level multi-asset keys with a nested structure so `scenario_results[name]` now contains `"portfolio_level"` (with `metrics`, `returns`, `timestamps`, `parameters`) and `"by_symbol"` (per-symbol blocks).
- Kept metric normalization and `scenario_metrics` population unchanged while adjusting the distribution shape to the new schema.
- No behavior changes were made for the single-asset branch; its output keys remain `metrics`, `returns`, `timestamps`, and `parameters`.

### Testing
- No automated tests were executed as part of this change.
- Static inspection and local edits were committed without running test suites.
- Consumers depending on the previous multi-asset shape should update to the new `portfolio_level`/`by_symbol` schema.
- Recommend running the repository test suite (`pytest`) and integration checks after pulling this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b372bb0a883239fc68899bc86e208)