### PR TITLE
Add tests for backtest metrics edge cases

### DIFF
--- a/tests/test_backtest_metrics.py
+++ b/tests/test_backtest_metrics.py
@@ -1,0 +1,37 @@
+import pytest
+
+from quant_engine.backtest import metrics
+
+
+def test_empty_series_metrics_zero():
+    result = metrics.compute([], [])
+    assert result == {
+        "sharpe": 0.0,
+        "sortino": 0.0,
+        "max_drawdown": 0.0,
+        "cagr": 0.0,
+        "hit_rate": 0.0,
+        "avg_R": 0.0,
+        "trades": 0.0,
+    }
+
+
+def test_constant_series_sharpe_sortino_zero():
+    returns = [1.0, 1.0, 1.0]
+    assert metrics.sharpe_ratio(returns) == 0.0
+    assert metrics.sortino_ratio(returns) == 0.0
+
+
+def test_simple_drawdown():
+    equity = [0.0, 2.0, 1.0]
+    assert metrics.max_drawdown(equity) == 1.0
+
+
+def test_hit_rate_and_avg_r():
+    trades = [
+        {"pnl": 1.0, "r_multiple": 2.0},
+        {"pnl": -1.0, "r_multiple": -1.0},
+        {"pnl": 0.5, "r_multiple": 1.5},
+    ]
+    assert metrics.hit_rate(trades) == pytest.approx(2 / 3)
+    assert metrics.avg_r(trades) == pytest.approx(2.5 / 3)


### PR DESCRIPTION
### Motivation
- Add coverage for edge cases in the backtest metrics to ensure stable behaviour on empty or degenerate inputs.
- Verify that statistical ratios handle constant returns without division errors and return sensible values.
- Ensure drawdown calculation is correct for simple equity sequences.
- Confirm trade-based metrics `hit_rate` and `avg_r` compute expected values on basic trade lists.

### Description
- Add a new test file `tests/test_backtest_metrics.py` containing unit tests for the metrics module.
- Test `metrics.compute` on empty `trades` and `equity` to assert all reported metrics are zero.
- Add assertions for `metrics.sharpe_ratio` and `metrics.sortino_ratio` on constant returns to be zero and for `metrics.max_drawdown` on a simple equity series to equal `1.0`.
- Add a test verifying `metrics.hit_rate` and `metrics.avg_r` against a small sample list of trades.

### Testing
- No automated tests were executed as part of this change.
- The new tests are standard `pytest` unit tests located at `tests/test_backtest_metrics.py` and can be run with `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e01fe0d88323a46734ce406ad36f)