### PR TITLE
Add estimator tests for edge cases and numerical stability

### DIFF
--- a/tests/test_stats_estimators.py
+++ b/tests/test_stats_estimators.py
@@ -1,0 +1,23 @@
+from quant_engine.stats import estimators
+
+
+def test_freq_with_wilson_zero_case():
+    assert estimators.freq_with_wilson(0, 0) == (0.0, 0.0, 0.0)
+
+
+def test_benjamini_hochberg_fixed_set():
+    pvals = [0.01, 0.04, 0.03, 0.002]
+    qvals = estimators.benjamini_hochberg(pvals)
+    assert qvals == [0.02, 0.04, 0.04, 0.008]
+
+
+def test_beta_hdi_bounds():
+    low, high = estimators.beta_hdi(2.5, 3.5)
+    assert 0.0 <= low <= 1.0
+    assert 0.0 <= high <= 1.0
+    assert low < high
+
+
+def test_freq_with_wilson_large_n_stability():
+    p, low, high = estimators.freq_with_wilson(500_000, 1_000_000)
+    assert 0.0 <= low <= p <= high <= 1.0


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for statistical estimator helpers to catch edge cases and numerical regressions.
- Ensure `freq_with_wilson` handles zero-trial and large-`n` cases without producing invalid intervals.
- Verify deterministic behavior of `benjamini_hochberg` on a fixed set of p-values.
- Confirm `beta_hdi` returns bounds within the valid probability range [0,1].

### Description
- Add new test file `tests/test_stats_estimators.py` that imports `estimators` from `quant_engine.stats`.
- Add `test_freq_with_wilson_zero_case` to assert `freq_with_wilson(0, 0) == (0.0, 0.0, 0.0)`.
- Add `test_benjamini_hochberg_fixed_set` to validate `benjamini_hochberg` returns expected q-values for a fixed p-value list.
- Add `test_beta_hdi_bounds` and `test_freq_with_wilson_large_n_stability` to check HDI bounds are in [0,1] and Wilson interval stability for large `n` respectively.

### Testing
- New unit tests are contained in `tests/test_stats_estimators.py` and include four test cases targeting `freq_with_wilson`, `benjamini_hochberg`, and `beta_hdi`.
- No automated test run was performed as part of this change (tests were added but not executed).
- Existing CI/test matrix was not modified by this PR.
- The change is limited to test code and does not alter library implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e022b8b88323a1fb8a263bbb4922)