### PR TITLE
Add persistence DB tests for SQLite behavior

### DIFF
--- a/tests/test_persistence_db.py
+++ b/tests/test_persistence_db.py
@@ -1,0 +1,55 @@
+import sqlite3
+
+import pytest
+
+from quant_engine.config import reset_settings_cache
+from quant_engine.persistence import db
+
+
+def test_init_db_creates_tables(monkeypatch):
+    monkeypatch.setenv("DB_DSN", "sqlite:///:memory:")
+    reset_settings_cache()
+    conn = db.connect()
+    try:
+        db.init_db(conn)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = {row[0] for row in rows}
+        expected_tables = {
+            "experiment_runs",
+            "run_metrics",
+            "trials",
+            "market_stats",
+            "seasonality_profiles",
+            "seasonality_runs",
+        }
+        assert expected_tables.issubset(table_names)
+    finally:
+        conn.close()
+
+
+def test_run_id_unique_constraint(monkeypatch):
+    monkeypatch.setenv("DB_DSN", "sqlite:///:memory:")
+    reset_settings_cache()
+    conn = db.connect()
+    try:
+        db.init_db(conn)
+        conn.execute(
+            "INSERT INTO experiment_runs (run_id, status) VALUES (?, ?)",
+            ("run-1", "started"),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO experiment_runs (run_id, status) VALUES (?, ?)",
+                ("run-1", "started"),
+            )
+    finally:
+        conn.close()
+
+
+def test_non_sqlite_dsn_raises(monkeypatch):
+    monkeypatch.setenv("DB_DSN", "mysql://localhost/db")
+    reset_settings_cache()
+    with pytest.raises(RuntimeError, match="Only sqlite DSNs are supported"):
+        db.connect()


### PR DESCRIPTION
### Motivation

- Ensure the lightweight SQLite persistence layer creates the expected schema when `init_db` is run.  
- Verify the unique constraint on `run_id` in the `experiment_runs` table to prevent duplicate runs.  
- Surface a clear error when a non-SQLite DSN (e.g. `mysql://...`) is supplied to the lightweight connector.  

### Description

- Add `tests/test_persistence_db.py` containing three tests that exercise the persistence layer using an in-memory SQLite DSN `sqlite:///:memory:`.  
- Test `init_db` creates tables including `experiment_runs`, `run_metrics`, `trials`, `market_stats`, `seasonality_profiles`, and `seasonality_runs`.  
- Test the `run_id` uniqueness by inserting duplicate `run_id` values and expecting a `sqlite3.IntegrityError`.  
- Test that a non-SQLite DSN (set via `DB_DSN`) causes `db.connect()` to raise `RuntimeError` with a message about SQLite-only DSNs.  

### Testing

- The new tests are located in `tests/test_persistence_db.py` and use `monkeypatch.setenv` and `reset_settings_cache()` to control `DB_DSN`.  
- The tests use `sqlite:///:memory:` for fast, isolated execution.  
- No automated test suite was executed as part of this change.  
- Manual review/commit completed; automated run of `pytest` was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e029340083238ea0a25f900ac273)