### PR TITLE
Add CLI error handling tests

### DIFF
--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from urllib import error
+
+import pytest
+
+pytest.importorskip("typer")
+
+from typer.testing import CliRunner
+
+from quant_engine.cli import main as cli_main
+
+SPEC_PATH = Path(__file__).parent / "data" / "spec_example.json"
+
+
+def test_submit_connection_error(monkeypatch) -> None:
+    def raise_urlopen(*_args, **_kwargs):
+        raise error.URLError("Service down")
+
+    monkeypatch.setattr(cli_main.request, "urlopen", raise_urlopen)
+    runner = CliRunner()
+
+    result = runner.invoke(cli_main.app, ["submit", "--spec", str(SPEC_PATH)])
+
+    assert result.exit_code == 1
+    assert "Connection error: Service down" in result.stdout
+
+
+def test_run_local_outputs_json() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main.app,
+        ["run-local", "--spec", str(SPEC_PATH)],
+        env={"DB_DSN": "sqlite:///:memory:"},
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict)


### PR DESCRIPTION
### Motivation

- Add tests to cover CLI behaviour when HTTP endpoints are unavailable and ensure exit codes and error messages are correct.
- Verify CLI success output is valid JSON for commands that run locally.
- Make tests resilient in environments where optional CLI dependency `typer` is not installed.

### Description

- Add `tests/test_cli_errors.py` which contains two tests exercising the CLI via `CliRunner`.
- Simulate an unavailable endpoint by mocking `cli_main.request.urlopen` to raise `urllib.error.URLError` and assert exit code and error message.
- Add `pytest.importorskip("typer")` at module import time to skip the tests when `typer` is missing.
- Add a test that runs the `run-local` command and asserts the stdout is parseable JSON and yields a dictionary.

### Testing

- Ran `pytest -q tests/test_cli_errors.py` initially which failed during collection due to missing `typer` (ModuleNotFoundError).
- After adding `pytest.importorskip("typer")`, re-ran `pytest -q tests/test_cli_errors.py` which completed with the test module skipped (1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e032486483238fd9b61e5e8940d4)