### PR TITLE
Include aggregation and weights metadata in stress scenario outputs

### DIFF
--- a/src/quant_engine/performance/stress_tests.py
+++ b/src/quant_engine/performance/stress_tests.py
@@ -602,6 +602,7 @@ def apply_scenarios_to_returns(
     warnings: List[str] = []
     aggregation = str(params.get("aggregation", "equal_weight")).lower()
     raw_weights = params.get("weights")
+    weights_source = params.get("weights_source")
     weights_used: Optional[Dict[str, float]] = None
 
     scenario_results: Dict[str, Any] = {}
@@ -635,6 +636,12 @@ def apply_scenarios_to_returns(
             name = str(scenario_data.get("name", "scenario"))
             per_asset_results: Dict[str, Any] = {}
             adjusted_assets: Dict[str, List[float]] = {}
+            scenario_parameters = {
+                **scenario_data,
+                "aggregation": aggregation,
+                "weights": weights_used,
+                "weights_source": weights_source,
+            }
             for symbol, values in per_asset.items():
                 adjusted = _apply_scenario_to_returns(values, scenario_data, initial_capital=initial_capital)
                 adjusted_assets[symbol] = adjusted
@@ -645,7 +652,7 @@ def apply_scenarios_to_returns(
                     "returns": adjusted,
                     "timestamps": timestamps.get(symbol),
                     "metrics": metrics,
-                    "parameters": scenario_data,
+                    "parameters": scenario_parameters,
                 }
 
             portfolio_returns, portfolio_ts = _aggregate_multi_asset_returns(
@@ -663,7 +670,7 @@ def apply_scenarios_to_returns(
                     "metrics": portfolio_metrics,
                     "returns": portfolio_returns,
                     "timestamps": portfolio_ts,
-                    "parameters": scenario_data,
+                    "parameters": scenario_parameters,
                 },
                 "by_symbol": per_asset_results,
             }
@@ -679,11 +686,17 @@ def apply_scenarios_to_returns(
             metrics = _normalize_metric_names(
                 _compute_level1_metrics(adjusted, _build_equity_curve(adjusted, initial_capital), initial_capital)
             )
+            scenario_parameters = {
+                **scenario_data,
+                "aggregation": None,
+                "weights": None,
+                "weights_source": None,
+            }
             scenario_results[name] = {
                 "metrics": metrics,
                 "returns": adjusted,
                 "timestamps": timestamps,
-                "parameters": scenario_data,
+                "parameters": scenario_parameters,
             }
             scenario_metrics[name] = metrics
 


### PR DESCRIPTION
### Motivation
- Ensure scenario outputs include aggregation and weight information so downstream consumers know how portfolio-level returns were constructed.
- Preserve an explicit `weights_source` when provided to indicate the origin of weights used in aggregation.
- Provide consistent metadata keys in both `portfolio_level` and `by_symbol` outputs for easier parsing and display.
- Maintain compatibility with single-asset inputs by emitting the same parameter keys with null values when not applicable.

### Description
- Extract `weights_source` from `parameters` and compute `weights_used` as before in `apply_scenarios_to_returns` in `src/quant_engine/performance/stress_tests.py`.
- Build a `scenario_parameters` dict that merges the scenario definition with `aggregation`, `weights`, and `weights_source` and attach it to each per-symbol result under `by_symbol` and to the `portfolio_level` result.
- For the single-asset branch, include `aggregation`, `weights`, and `weights_source` keys set to `None` so single-asset outputs have the same parameter shape.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b38b5af8c83239ee3129a68ccbe84)