### PR TITLE
Add tests for backtest metrics and binary estimators

### DIFF
--- a/tests/test_backtest_metrics.py
+++ b/tests/test_backtest_metrics.py
@@ -27,6 +27,20 @@ def test_simple_drawdown():
     assert metrics.max_drawdown(equity) == 1.0
 
 
+def test_known_trades_metrics():
+    trades = [
+        {"pnl": -1.0, "r_multiple": -1.0},
+        {"pnl": 2.0, "r_multiple": 2.0},
+        {"pnl": 2.0, "r_multiple": 2.0},
+    ]
+    equity = [0.0, -1.0, 1.0, 3.0, 2.0, 4.0, 1.0]
+    result = metrics.compute(trades, equity)
+
+    assert result["sharpe"] == pytest.approx((3 ** 0.5) / (2 ** 0.5))
+    assert result["sortino"] == pytest.approx(3.0)
+    assert result["max_drawdown"] == pytest.approx(3.0)
+
+
 def test_hit_rate_and_avg_r():
     trades = [
         {"pnl": 1.0, "r_multiple": 2.0},

--- a/tests/test_stats_estimators.py
+++ b/tests/test_stats_estimators.py
@@ -1,3 +1,6 @@
+import pandas as pd
+import pytest
+
 from quant_engine.stats import estimators
 
 
@@ -21,3 +24,39 @@ def test_beta_hdi_bounds():
 def test_freq_with_wilson_large_n_stability():
     p, low, high = estimators.freq_with_wilson(500_000, 1_000_000)
     assert 0.0 <= low <= p <= high <= 1.0
+
+
+def test_binary_wilson_and_bayes():
+    outcomes = pd.Series([1, 0, 1, 1, 0])
+    summary = estimators.aggregate_binary(outcomes)
+
+    assert summary["n"] == 5
+    assert summary["successes"] == 3
+    assert summary["p_hat"] == pytest.approx(0.6)
+    assert 0.0 <= summary["ci_low"] <= summary["p_hat"] <= summary["ci_high"] <= 1.0
+
+    bayes = estimators.aggregate_binary_bayes(summary["successes"], summary["n"])
+    assert bayes["alpha_post"] == pytest.approx(3.5)
+    assert bayes["beta_post"] == pytest.approx(2.5)
+    assert bayes["p_mean"] == pytest.approx(3.5 / 6.0)
+    assert bayes["p_map"] == pytest.approx(0.625)
+    assert 0.0 <= bayes["hdi_low"] < bayes["hdi_high"] <= 1.0
+
+
+def test_binary_zero_stability():
+    outcomes = pd.Series([], dtype=float)
+    summary = estimators.aggregate_binary(outcomes)
+    assert summary == {
+        "n": 0,
+        "successes": 0,
+        "p_hat": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+    }
+
+    bayes = estimators.aggregate_binary_bayes(0, 0)
+    assert bayes["alpha_post"] == pytest.approx(0.5)
+    assert bayes["beta_post"] == pytest.approx(0.5)
+    assert bayes["p_mean"] == pytest.approx(0.5)
+    assert bayes["p_map"] == pytest.approx(0.5)
+    assert 0.0 <= bayes["hdi_low"] < bayes["hdi_high"] <= 1.0


### PR DESCRIPTION
### Motivation
- Validate backtest metric calculations (Sharpe, Sortino, max drawdown) on a simple, known trade sequence.
- Verify binary outcome aggregation using Wilson score intervals and a Beta-Binomial Bayesian posterior.
- Ensure numerical stability for edge cases such as zero trials and zero variance.

### Description
- Added `test_known_trades_metrics` in `tests/test_backtest_metrics.py` to assert Sharpe, Sortino and max drawdown for a hand-crafted trade/equity series.
- Added `test_binary_wilson_and_bayes` in `tests/test_stats_estimators.py` to check `aggregate_binary` and `aggregate_binary_bayes` outputs and expected posterior parameters.
- Added `test_binary_zero_stability` to assert stable outputs for zero trials and empty outcome series, and imported `pytest`/`pandas` where needed.
- Modified only test files: `tests/test_backtest_metrics.py` and `tests/test_stats_estimators.py` with new assertions and example data.

### Testing
- Ran `pytest tests/test_backtest_metrics.py tests/test_stats_estimators.py` to execute the new tests.
- All collected tests passed: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3b99eaac8323a8193c7eb184e887)