### PR TITLE
Add CLI error handling tests for submit and run-local

### DIFF
--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -26,6 +26,26 @@ def test_submit_connection_error(monkeypatch) -> None:
     assert "Connection error: Service down" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    [
+        (400, "Bad Request"),
+        (500, "Server Error"),
+    ],
+)
+def test_submit_http_error(monkeypatch, status, reason) -> None:
+    def raise_urlopen(*_args, **_kwargs):
+        raise error.HTTPError("http://127.0.0.1:8000/submit", status, reason, None, None)
+
+    monkeypatch.setattr(cli_main.request, "urlopen", raise_urlopen)
+    runner = CliRunner()
+
+    result = runner.invoke(cli_main.app, ["submit", "--spec", str(SPEC_PATH)])
+
+    assert result.exit_code == 1
+    assert f"HTTP {status}: {reason}" in result.stdout
+
+
 def test_run_local_outputs_json() -> None:
     runner = CliRunner()
 
@@ -38,3 +58,30 @@ def test_run_local_outputs_json() -> None:
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert isinstance(payload, dict)
+
+
+def test_run_local_outputs_minimal_payload(monkeypatch) -> None:
+    class DummyJobManager:
+        @staticmethod
+        def submit(_spec, synchronous=True):
+            return {
+                "best": {"metrics": {"sharpe": 1.2}, "params": {"foo": 1}, "extra": 2},
+                "ignored": True,
+            }
+
+    monkeypatch.setattr(cli_main, "JobManager", DummyJobManager)
+    runner = CliRunner()
+
+    result = runner.invoke(cli_main.app, ["run-local", "--spec", str(SPEC_PATH)])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"metrics": {"sharpe": 1.2}, "params": {"foo": 1}}
+
+
+def test_run_local_missing_spec() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli_main.app, ["run-local", "--spec", "missing.json"])
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--spec'" in result.output


### PR DESCRIPTION
### Motivation

- Improve CLI test coverage for HTTP error handling when calling the API via `submit`.
- Ensure `run-local` prints a minimal JSON payload containing only `metrics` and `params` when a job result contains extra fields.
- Validate the CLI fails cleanly when an invalid `--spec` path is provided.

### Description

- Updated `tests/test_cli_errors.py` to add a parametrized `test_submit_http_error` that mocks `request.urlopen` to raise `HTTPError` for 400 and 500 statuses.
- Added `test_submit_connection_error` already present which mocks `URLError` to verify the error message and exit code remain correct.
- Added `test_run_local_outputs_minimal_payload` that monkeypatches `JobManager` with a `DummyJobManager` and asserts `run-local` returns only the `metrics` and `params` fields.
- Added `test_run_local_missing_spec` that asserts `run-local` with a missing spec path fails with an `Invalid value for '--spec'` message.

### Testing

- No automated test suite was executed as part of this rollout.
- The change adds the following tests: `test_submit_http_error`, `test_run_local_outputs_minimal_payload`, and `test_run_local_missing_spec` in `tests/test_cli_errors.py`.
- Existing `test_submit_connection_error` and `test_run_local_outputs_json` remain and are unchanged in behavior.
- These tests use `typer.testing.CliRunner` and `monkeypatch` to simulate HTTP errors and a dummy `JobManager`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3ba2732483238a5dd842f80b1a10)