### PR TITLE
Add no-lookahead backtest entry/exit test

### DIFF
--- a/tests/test_backtest_engine_no_lookahead.py
+++ b/tests/test_backtest_engine_no_lookahead.py
@@ -1,0 +1,36 @@
+from quant_engine.backtest import engine
+
+
+def test_backtest_engine_uses_next_open_for_entry_and_exit():
+    dataset = [
+        {
+            "timestamp": "2020-01-01",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 102.0,
+        },
+        {
+            "timestamp": "2020-01-02",
+            "open": 110.0,
+            "high": 112.0,
+            "low": 108.0,
+            "close": 111.0,
+        },
+        {
+            "timestamp": "2020-01-03",
+            "open": 120.0,
+            "high": 125.0,
+            "low": 115.0,
+            "close": 122.0,
+        },
+    ]
+    signals = [1, 0, 0]
+    atr_values = [1.0, 1.0, 1.0]
+
+    trades, _, _ = engine.run(dataset, signals, atr_values, atr_mult=1.0, r_mult=1.0)
+
+    assert len(trades) == 1
+    trade = trades[0]
+    assert trade["price_entry"] == dataset[1]["open"]
+    assert trade["price_exit"] == dataset[2]["open"]


### PR DESCRIPTION
### Motivation

- Ensure the backtest engine executes entries and exits on the next bar open rather than using current-bar intrabar prices.
- Prevent lookahead bugs by providing a focused, minimal scenario that would expose incorrect fill timing.
- Provide a small reproducible unit test that documents expected engine behavior.

### Description

- Add `tests/test_backtest_engine_no_lookahead.py` containing a focused unit test. 
- Construct a 3-bar `dataset` with distinct prices and use `signals = [1, 0, 0]` and constant `atr_values` to simplify expectations. 
- Call `engine.run(dataset, signals, atr_values, atr_mult=1.0, r_mult=1.0)` and assert a single trade is produced. 
- Assert that `price_entry` equals the next bar's `open` and `price_exit` equals the following bar's `open` to verify no lookahead is used.

### Testing

- The change adds the unit test `tests/test_backtest_engine_no_lookahead.py` and no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509db0924c8323b037be83dac3cb60)