### PR TITLE
Add contract tests for API schemas

### DIFF
--- a/tests/test_api_schemas_contract.py
+++ b/tests/test_api_schemas_contract.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+
+from quant_engine.api.schemas import DataInputSpec, MySQLDataSpec, StatsPersistenceSpec
+
+
+def test_mysql_data_spec_schema_alias_and_property() -> None:
+    spec = MySQLDataSpec(schema="foo")
+
+    assert spec.schema_ == "foo"
+    assert spec.schema == "foo"
+
+
+def test_stats_persistence_spec_enabled_from_legacy_flag() -> None:
+    spec = StatsPersistenceSpec(store_stats_in_db=True)
+
+    assert spec.enabled is True
+
+
+@pytest.mark.parametrize(
+    "payload,missing_field",
+    [
+        ({"timeframe": "M1", "start": "2024-01-01", "end": "2024-01-02"}, "symbols"),
+        ({"symbols": ["EURUSD"], "start": "2024-01-01", "end": "2024-01-02"}, "timeframe"),
+        ({"symbols": ["EURUSD"], "timeframe": "M1", "end": "2024-01-02"}, "start"),
+        ({"symbols": ["EURUSD"], "timeframe": "M1", "start": "2024-01-01"}, "end"),
+    ],
+)
+def test_data_input_spec_requires_fields(payload, missing_field) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        DataInputSpec(**payload)
+
+    assert missing_field in str(excinfo.value)


### PR DESCRIPTION
### Motivation

- Ensure API schema models maintain compatibility and expected behavior regarding field aliases and legacy flags.
- Verify that `MySQLDataSpec` exposes the `schema` alias and the backing `schema_` property consistently.
- Ensure `StatsPersistenceSpec` derives `enabled` from the legacy `store_stats_in_db` flag.
- Validate that `DataInputSpec` enforces required fields and raises a `ValidationError` when missing.

### Description

- Add `tests/test_api_schemas_contract.py` containing contract tests for API schema models.
- Add a test that constructing `MySQLDataSpec(schema="foo")` yields `schema_ == "foo"` and `schema == "foo"`.
- Add a test that `StatsPersistenceSpec(store_stats_in_db=True)` sets `enabled` to `True` via the post-validation resolver.
- Add a parameterized test that `DataInputSpec` raises `ValidationError` when any of the required fields `symbols`, `timeframe`, `start`, or `end` are missing.

### Testing

- No automated tests were executed as part of this change.
- The new tests are added under `tests/test_api_schemas_contract.py` for CI to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509db35e9483239684e69a3224427c)