### PR TITLE
Add stats integration test for summary output

### DIFF
--- a/tests/test_stats_integration.py
+++ b/tests/test_stats_integration.py
@@ -1,0 +1,59 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+
+from quant_engine.api import schemas
+from quant_engine.core.spec import ArtifactsSpec, ValidationSpec
+from quant_engine.stats import runner
+
+
+def test_run_stats_writes_summary(tmp_path: Path) -> None:
+    start = datetime(2020, 1, 1)
+    rows = []
+    for i in range(6):
+        ts = start + timedelta(days=i)
+        rows.append(
+            {
+                "timestamp": ts.isoformat(),
+                "symbol": "TST",
+                "open": i + 1,
+                "high": i + 2,
+                "low": i,
+                "close": i + 1.5,
+            }
+        )
+
+    dataset_path = tmp_path / "tiny.json"
+    dataset_path.write_text(json.dumps(rows))
+
+    out_dir = tmp_path / "artifacts"
+    spec = schemas.StatsSpec(
+        data=schemas.StatsDataSpec(
+            dataset_path=str(dataset_path),
+            symbols=["TST"],
+            timeframe="1d",
+            start="2020-01-01",
+            end="2020-01-06",
+        ),
+        events=[schemas.StatsEventSpec(name="k_consecutive", params={"k": 2, "direction": "up"})],
+        targets=[schemas.StatsTargetSpec(name="up_next_bar")],
+        validation=ValidationSpec(
+            min_trades=0,
+            train_months=0,
+            test_months=1,
+            folds=1,
+            embargo_days=0,
+        ),
+        artifacts=ArtifactsSpec(out_dir=str(out_dir)),
+    )
+
+    runner.run_stats(spec)
+
+    summary_path = out_dir / "stats_summary.parquet"
+    assert summary_path.exists()
+
+    summary = pd.read_parquet(summary_path)
+    for column in ["p_hat", "n", "successes"]:
+        assert column in summary.columns


### PR DESCRIPTION
### Motivation

- Ensure `run_stats` writes a stats summary artifact when run end-to-end on a small JSON dataset.
- Verify the persisted summary contains required aggregate columns used by downstream tooling.
- Provide a lightweight integration test that exercises event detection, target computation, validation splitting, and artifact writing.

### Description

- Add `tests/test_stats_integration.py` which generates a tiny JSON dataset in `tmp_path` and writes it to disk.
- Build a minimal `StatsSpec` including an event (`k_consecutive`), a target (`up_next_bar`), `ValidationSpec`, and `ArtifactsSpec` and invoke `runner.run_stats(spec)`.
- Assert that `stats_summary.parquet` is created in the configured `out_dir` and that the columns `p_hat`, `n`, and `successes` are present in the written file.

### Testing

- No automated test suite was executed as part of this change.
- The new test can be run with `pytest tests/test_stats_integration.py` and is expected to pass when the stats runner and IO layers are functioning correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e4fe458c8323a9137e476a0e2133)