### PR TITLE
Add golden backtest summary fixture and test

### DIFF
--- a/tests/data/golden/backtest_summary.json
+++ b/tests/data/golden/backtest_summary.json
@@ -1,0 +1,9 @@
+{
+  "avg_R": 1.0,
+  "cagr": 1485633833817312.0,
+  "hit_rate": 1.0,
+  "max_drawdown": 0.0,
+  "sharpe": 0.0,
+  "sortino": 0.0,
+  "trades": 1.0
+}

--- a/tests/test_backtest_summary_golden.py
+++ b/tests/test_backtest_summary_golden.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quant_engine.backtest import engine
+
+
+DATASET = [
+    {
+        "timestamp": "2020-01-01T00:00:00Z",
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.0,
+    },
+    {
+        "timestamp": "2020-01-02T00:00:00Z",
+        "open": 101.0,
+        "high": 103.0,
+        "low": 100.0,
+        "close": 102.0,
+    },
+    {
+        "timestamp": "2020-01-03T00:00:00Z",
+        "open": 102.0,
+        "high": 104.0,
+        "low": 101.0,
+        "close": 103.0,
+    },
+    {
+        "timestamp": "2020-01-04T00:00:00Z",
+        "open": 103.0,
+        "high": 105.0,
+        "low": 102.0,
+        "close": 104.0,
+    },
+    {
+        "timestamp": "2020-01-05T00:00:00Z",
+        "open": 104.0,
+        "high": 106.0,
+        "low": 103.0,
+        "close": 105.0,
+    },
+]
+
+SIGNALS = [1, 1, 0, 0, 0]
+ATR_VALUES = [1.0] * len(DATASET)
+
+
+def test_backtest_summary_matches_golden(tmp_path):
+    _, _, summary = engine.run(DATASET, SIGNALS, ATR_VALUES, 1.0, 2.0)
+
+    output_path = tmp_path / "summary.json"
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+    exported = json.loads(output_path.read_text())
+
+    golden_path = Path("tests/data/golden/backtest_summary.json")
+    expected = json.loads(golden_path.read_text())
+
+    assert exported.keys() == expected.keys()
+    for key, value in expected.items():
+        assert exported[key] == pytest.approx(value)


### PR DESCRIPTION
### Motivation
- Add a deterministic, tiny backtest case to catch regressions in performance metric calculations. 
- Ensure the `engine.run` summary remains stable across changes by comparing against a known-good output. 

### Description
- Add `tests/test_backtest_summary_golden.py` which defines a tiny dataset, deterministic `SIGNALS` and `ATR_VALUES`, runs `engine.run`, writes the produced summary to a temp file, and compares it to a golden file using `pytest.approx`.
- Add the golden fixture `tests/data/golden/backtest_summary.json` containing the expected metric values produced by the test scenario.
- The test asserts that the summary keys match and that each metric value approximately equals the golden value.

### Testing
- No automated tests were executed as part of this change.
- The new test `tests/test_backtest_summary_golden.py` will be picked up by the repository's existing `pytest` suite when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e503eae8832397a35359f35d1054)