### PR TITLE
Add HTTP contract tests for read-only endpoints

### DIFF
--- a/tests/test_api_http_contract.py
+++ b/tests/test_api_http_contract.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from quant_engine.api import app as api_app
+
+
+client = TestClient(api_app.fastapi_app)
+
+
+def test_stats_conditions_http_contract():
+    response = client.get("/stats/conditions")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert "session" in payload
+    assert all(isinstance(item, str) for item in payload)
+
+
+def test_filters_list_http_contract():
+    response = client.get("/filters/list")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert "adx" in payload
+    assert all(isinstance(item, str) for item in payload)


### PR DESCRIPTION
### Motivation
- Add lightweight HTTP contract tests to validate read-only API endpoints respond correctly.
- Ensure basic JSON schema and presence of expected entries for key endpoints used by clients.
- Use a fast, framework-level test harness to catch regressions in API surface.

### Description
- Create `tests/test_api_http_contract.py` containing tests using `fastapi.testclient.TestClient`.
- Exercise the endpoints `GET /stats/conditions` and `GET /filters/list` via `TestClient(api_app.fastapi_app)`.
- Assert each endpoint returns `HTTP 200`, that the payload is a list, contains expected entries (`"session"` and `"adx"`), and that all items are strings.
- No changes were made to production code or API handlers.

### Testing
- No automated test suite was executed as part of this change.
- The new tests are unit/contract tests intended to be run with the existing test runner (e.g., `pytest`).
- The added file was committed to the repository as `tests/test_api_http_contract.py`.
- No failures reported because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e504e8188323bf3a964622b4d53f)