### PR TITLE
Add test for exact train/test date boundaries with non-zero embargo

### DIFF
--- a/tests/test_validation_splitter.py
+++ b/tests/test_validation_splitter.py
@@ -70,3 +70,17 @@ def test_timezone_aware_utc_offsets_are_supported() -> None:
     assert len(folds) == 1
     assert folds[0]["train"]
     assert folds[0]["test"]
+
+
+def test_train_test_boundaries_with_embargo() -> None:
+    dataset = _build_dataset(datetime(2020, 1, 1), days=62)
+
+    folds = generate_folds(dataset, train_months=1, test_months=1, folds=1, embargo_days=2)
+
+    train_rows = folds[0]["train"]
+    test_rows = folds[0]["test"]
+
+    assert train_rows[0]["timestamp"].startswith("2020-01-01")
+    assert train_rows[-1]["timestamp"].startswith("2020-01-31")
+    assert test_rows[0]["timestamp"].startswith("2020-02-03")
+    assert test_rows[-1]["timestamp"].startswith("2020-03-02")


### PR DESCRIPTION
### Motivation
- Ensure the validation splitter produces exact train/test boundary dates when an embargo is applied.
- Cover a dataset spanning roughly two months so month arithmetic and embargo interact over February boundaries.
- Prevent regressions where the `generate_folds` boundaries shift by a day when `embargo_days` is non-zero.

### Description
- Added a new unit test `test_train_test_boundaries_with_embargo` to `tests/test_validation_splitter.py`.
- The test builds a 62-day dataset via `_build_dataset` and calls `generate_folds(..., train_months=1, test_months=1, folds=1, embargo_days=2)`.
- The test asserts exact start/end timestamps for both `train` and `test` slices using `startswith` checks to verify boundary dates are `2020-01-01`, `2020-01-31`, `2020-02-03`, and `2020-03-02` respectively.
- No production code was modified; only the test suite was extended.

### Testing
- No automated tests were executed as part of this change.
- A single new unit test was added: `test_train_test_boundaries_with_embargo` in `tests/test_validation_splitter.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e5068e948323926b6259f096a83b)