### PR TITLE
Unify data spec parsing in core spec helpers

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -13,7 +13,7 @@ import logging
 from . import engine
 from ..core import dataset
 from ..core.features import atr
-from ..core.spec import DataSpec, MySQLDataConfig
+from ..core.spec import DataSpec, parse_data_spec
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..performance.backtest_builder import build_backtest_payload
 from ..signals.ema_cross import EmaCross
@@ -37,50 +37,6 @@ def _has_delta_config(raw: Mapping[str, Any]) -> bool:
 
 def _uses_strategy_sources(raw: Mapping[str, Any]) -> bool:
     return bool(raw.get("mysql_env") or _has_delta_config(raw))
-
-
-def _parse_data_spec(raw: Mapping[str, Any]) -> DataSpec:
-    dataset_path = raw.get("dataset_path") or raw.get("path")
-    mysql_raw = raw.get("mysql")
-    mysql: MySQLDataConfig | None = None
-    if mysql_raw is not None:
-        mysql = MySQLDataConfig(
-            connection_url=mysql_raw.get("connection_url"),
-            env_var=mysql_raw.get("env_var", "QE_MARKETDATA_MYSQL_URL"),
-            schema=mysql_raw.get("schema"),
-            table=mysql_raw.get("table", "ohlcv"),
-            symbol_col=mysql_raw.get("symbol_col", "symbol"),
-            ts_col=mysql_raw.get("ts_col", "ts"),
-            open_col=mysql_raw.get("open_col", "open"),
-            high_col=mysql_raw.get("high_col", "high"),
-            low_col=mysql_raw.get("low_col", "low"),
-            close_col=mysql_raw.get("close_col", "close"),
-            volume_col=mysql_raw.get("volume_col", "volume"),
-            timeframe_col=mysql_raw.get("timeframe_col", "timeframe"),
-            extra_where=mysql_raw.get("extra_where"),
-            chunk_minutes=int(mysql_raw.get("chunk_minutes", 0)),
-            symbol_lookup_table=mysql_raw.get("symbol_lookup_table"),
-            symbol_lookup_symbol_col=mysql_raw.get("symbol_lookup_symbol_col", "symbol"),
-            symbol_lookup_id_col=mysql_raw.get("symbol_lookup_id_col", "id"),
-        )
-
-    symbols = list(raw.get("symbols", []))
-    timeframe = raw.get("timeframe")
-    start = raw.get("start")
-    end = raw.get("end")
-    if start is None or end is None:
-        raise ValueError("data.start and data.end are required")
-    if dataset_path is None and mysql is None and not _uses_strategy_sources(raw):
-        raise ValueError("data must provide dataset_path/path, mysql, or delta/mysql_env configuration")
-
-    return DataSpec(
-        dataset_path=dataset_path,
-        mysql=mysql,
-        symbols=symbols,
-        timeframe=timeframe,
-        start=str(start),
-        end=str(end),
-    )
 
 
 def _single_symbol(symbols: List[str], fallback: Optional[str] = None) -> str:
@@ -195,7 +151,9 @@ def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
     """Execute a classic backtest based on a JSON specification."""
 
     data_raw = spec.get("data", {}) or {}
-    data_spec = _parse_data_spec(data_raw)
+    data_spec = parse_data_spec(data_raw, require_source=False)
+    if data_spec.dataset_path is None and data_spec.mysql is None and not _uses_strategy_sources(data_raw):
+        raise ValueError("data must provide dataset_path/path, mysql, or delta/mysql_env configuration")
     strategy_cfg = spec.get("strategy", {}) or {}
     asset_class = strategy_cfg.get("asset_class") or "EQUITY"
     rows, data_source = _load_rows(data_raw, data_spec, asset_class)

--- a/src/quant_engine/core/spec.py
+++ b/src/quant_engine/core/spec.py
@@ -107,14 +107,11 @@ class Spec:
 # ---------------------------------------------------------------------------
 
 
-def _parse_spec(raw: Mapping[str, Any]) -> Spec:
-    """Build a :class:`Spec` from an in-memory mapping."""
+def parse_data_spec(raw: Mapping[str, Any], *, require_source: bool = True) -> DataSpec:
+    """Build a :class:`DataSpec` from a JSON-compatible mapping."""
 
-    data_raw = raw["data"]
-    strat_raw = raw["strategy"]
-
-    dataset_path = data_raw.get("dataset_path") or data_raw.get("path")
-    mysql_raw = data_raw.get("mysql")
+    dataset_path = raw.get("dataset_path") or raw.get("path")
+    mysql_raw = raw.get("mysql")
     mysql: MySQLDataConfig | None = None
     if mysql_raw is not None:
         mysql = MySQLDataConfig(
@@ -137,17 +134,17 @@ def _parse_spec(raw: Mapping[str, Any]) -> Spec:
             symbol_lookup_id_col=mysql_raw.get("symbol_lookup_id_col", "id"),
         )
 
-    if dataset_path is None and mysql is None:
+    if require_source and dataset_path is None and mysql is None:
         raise ValueError("data must provide either dataset_path/path or mysql configuration")
 
-    symbols = list(data_raw.get("symbols", []))
-    timeframe = data_raw.get("timeframe")
-    start = data_raw.get("start")
-    end = data_raw.get("end")
+    symbols = list(raw.get("symbols", []))
+    timeframe = raw.get("timeframe")
+    start = raw.get("start")
+    end = raw.get("end")
     if start is None or end is None:
         raise ValueError("data.start and data.end are required")
 
-    data = DataSpec(
+    return DataSpec(
         dataset_path=dataset_path,
         mysql=mysql,
         symbols=symbols,
@@ -155,6 +152,15 @@ def _parse_spec(raw: Mapping[str, Any]) -> Spec:
         start=str(start),
         end=str(end),
     )
+
+
+def _parse_spec(raw: Mapping[str, Any]) -> Spec:
+    """Build a :class:`Spec` from an in-memory mapping."""
+
+    data_raw = raw["data"]
+    strat_raw = raw["strategy"]
+
+    data = parse_data_spec(data_raw)
     filters = FiltersSpec(**strat_raw["filters"])
     tpsl = TPSLSpec(**strat_raw["tpsl"])
     val_raw = strat_raw.get("validation", {})
@@ -186,5 +192,4 @@ def spec_from_dict(raw: Mapping[str, Any]) -> Spec:
     """Public helper to build a :class:`Spec` from a JSON-compatible dict."""
 
     return _parse_spec(raw)
-
 


### PR DESCRIPTION
### Motivation
- Remove duplicated DataSpec parsing logic spread across modules to avoid divergence between backtest/strategy/live code paths.
- Provide a single, well-tested entry point for building `DataSpec` objects from JSON-like mappings.
- Keep backtest-specific validation separate while reusing the shared parsing logic.

### Description
- Add a shared `parse_data_spec(raw, *, require_source: bool = True)` helper in `src/quant_engine/core/spec.py` to encapsulate DataSpec/MySQL parsing and validation.
- Update `_parse_spec` in `core.spec` to reuse `parse_data_spec` when building full `Spec` objects.
- Replace the duplicated `_parse_data_spec` in `src/quant_engine/backtest/runner.py` with an import of `parse_data_spec` and call `parse_data_spec(data_raw, require_source=False)` while keeping backtest-specific source validation in the runner.
- Remove duplicated parsing code and streamline imports to use the centralized helper.

### Testing
- No automated tests were executed as part of this change.
- Existing test suite was not run and therefore current behavior should be validated by CI or local tests before deployment.
- The changes are limited to parsing/helpers and should be low-risk, pending test verification.
- Manual review ensured no behavioral regressions in the modified call sites using `parse_data_spec`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663a0cb2c48323ba1f1792d8144f96)