### PR TITLE
Centralize data spec parsing in core.spec helpers

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -13,7 +13,7 @@ import logging
 from . import engine
 from ..core import dataset
 from ..core.features import atr
-from ..core.spec import DataSpec, parse_data_spec
+from ..core.spec import DataSpec, parse_data_spec, uses_strategy_sources
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..performance.backtest_builder import build_backtest_payload
 from ..signals.ema_cross import EmaCross
@@ -29,14 +29,6 @@ def load_backtest_spec(path: Path | str) -> Dict[str, Any]:
 
     path_obj = Path(path)
     return json.loads(path_obj.read_text())
-
-
-def _has_delta_config(raw: Mapping[str, Any]) -> bool:
-    return any(str(key).startswith("delta_") for key in raw.keys())
-
-
-def _uses_strategy_sources(raw: Mapping[str, Any]) -> bool:
-    return bool(raw.get("mysql_env") or _has_delta_config(raw))
 
 
 def _single_symbol(symbols: List[str], fallback: Optional[str] = None) -> str:
@@ -103,7 +95,7 @@ def _load_rows(
     cached = _ROWS_CACHE.get(cache_key)
     if cached is not None:
         return cached
-    if _uses_strategy_sources(data_spec_raw):
+    if uses_strategy_sources(data_spec_raw):
         symbol = _single_symbol(data_spec.symbols, data_spec_raw.get("symbol"))
         df, source = _fetch_ohlc_with_source(symbol, asset_class, data_spec_raw)
         rows = _rows_from_dataframe(df, symbol)
@@ -151,9 +143,7 @@ def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
     """Execute a classic backtest based on a JSON specification."""
 
     data_raw = spec.get("data", {}) or {}
-    data_spec = parse_data_spec(data_raw, require_source=False)
-    if data_spec.dataset_path is None and data_spec.mysql is None and not _uses_strategy_sources(data_raw):
-        raise ValueError("data must provide dataset_path/path, mysql, or delta/mysql_env configuration")
+    data_spec = parse_data_spec(data_raw, allow_strategy_sources=True)
     strategy_cfg = spec.get("strategy", {}) or {}
     asset_class = strategy_cfg.get("asset_class") or "EQUITY"
     rows, data_source = _load_rows(data_raw, data_spec, asset_class)

--- a/src/quant_engine/core/spec.py
+++ b/src/quant_engine/core/spec.py
@@ -107,7 +107,22 @@ class Spec:
 # ---------------------------------------------------------------------------
 
 
-def parse_data_spec(raw: Mapping[str, Any], *, require_source: bool = True) -> DataSpec:
+def _has_delta_config(raw: Mapping[str, Any]) -> bool:
+    return any(str(key).startswith("delta_") for key in raw.keys())
+
+
+def uses_strategy_sources(raw: Mapping[str, Any]) -> bool:
+    """Return True when data spec should be resolved via strategy integrations."""
+
+    return bool(raw.get("mysql_env") or _has_delta_config(raw))
+
+
+def parse_data_spec(
+    raw: Mapping[str, Any],
+    *,
+    require_source: bool = True,
+    allow_strategy_sources: bool = False,
+) -> DataSpec:
     """Build a :class:`DataSpec` from a JSON-compatible mapping."""
 
     dataset_path = raw.get("dataset_path") or raw.get("path")
@@ -135,7 +150,8 @@ def parse_data_spec(raw: Mapping[str, Any], *, require_source: bool = True) -> D
         )
 
     if require_source and dataset_path is None and mysql is None:
-        raise ValueError("data must provide either dataset_path/path or mysql configuration")
+        if not allow_strategy_sources or not uses_strategy_sources(raw):
+            raise ValueError("data must provide either dataset_path/path or mysql configuration")
 
     symbols = list(raw.get("symbols", []))
     timeframe = raw.get("timeframe")
@@ -192,4 +208,3 @@ def spec_from_dict(raw: Mapping[str, Any]) -> Spec:
     """Public helper to build a :class:`Spec` from a JSON-compatible dict."""
 
     return _parse_spec(raw)
-


### PR DESCRIPTION
### Motivation

- Unify DataSpec parsing so backtest/strategy/live modules share a single entry point and avoid divergent parsing logic.
- Remove duplicated detection logic for strategy-backed sources (Delta/MySQL env) that existed in multiple modules.
- Allow callers to opt-in to strategy-integrations-based sources when validating a `data` spec to preserve backward compatibility.
- Keep validation for required `start`/`end` and `dataset_path`/`mysql` consistent across the codebase.

### Description

- Add `_has_delta_config` and `uses_strategy_sources` helpers to `src/quant_engine/core/spec.py` to centralize strategy-source detection. 
- Extend `parse_data_spec` in `src/quant_engine/core/spec.py` with an `allow_strategy_sources` boolean parameter and use `uses_strategy_sources` to relax source validation when requested. 
- Update `src/quant_engine/backtest/runner.py` to import `uses_strategy_sources`, call `parse_data_spec(..., allow_strategy_sources=True)`, and replace the local `_uses_strategy_sources` duplicate with the shared helper. 
- Remove duplicated `_has_delta_config/_uses_strategy_sources` definitions from the backtest runner and streamline data-loading decision logic.

### Testing

- No automated tests were executed for this change.
- Existing test suite was not run as part of the patch.
- Manual validation was not recorded in automated test output.
- Further CI/test runs are recommended to verify integration behavior with Delta/MySQL sources.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663cafe86083239e617814db3f430c)