### PR TITLE
Clarify optimization entrypoints (variants vs runner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
   ```bash
   poetry run quant-engine run-local --spec path/to/spec.json
   ```
+  Utilise le job manager si disponible, sinon le runner legacy (`optimize.runner`).
 - **submit**
   ```bash
   poetry run quant-engine submit --spec path/to/spec.json
@@ -92,6 +93,7 @@ poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
   ```bash
   poetry run qe strategy optimize --spec specs/strategy_dca_equity_example_minimal_optimize.json
   ```
+  Ces commandes utilisent l'optimiseur officiel `optimize.variants` (workflow avancé).
 
 ### Optimization spec (grid/random)
 Define `optimization.search_space` with discrete lists or `{min,max,step}` ranges. Paths can target nested fields (use dots and list indexes).

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -16,7 +16,8 @@ Il existe **deux** chemins d'optimisation dans le repo, avec des objectifs diffe
    - Ne couvre pas les fonctionnalites avancees (promotion, screening, dedup, etc.).
 
 **Recommandation :** pour toute optimisation backtest/strategy, utilisez `optimize.variants`
-via la CLI ou l'API. Le runner simple ne doit servir que pour des tests rapides ou le fallback local.
+via la CLI ou l'API. Le runner simple n'est pas l'entree officielle des commandes `optimize`
+et doit servir uniquement pour des tests rapides ou le fallback local.
 Ce document décrit le workflow d'optimization pour les specs de backtest et de strategy.
 
 ## Ce qui est stocké

--- a/src/quant_engine/optimize/runner.py
+++ b/src/quant_engine/optimize/runner.py
@@ -1,9 +1,9 @@
 """Simple optimisation runner with walk-forward evaluation.
 
 Legacy/minimal runner used as a fallback by `qe run-local` when the job manager
-is unavailable. For backtest/strategy optimization workflows, prefer
-`quant_engine.optimize.variants` which supports screening, promotion, and
-advanced artifacts.
+is unavailable. It is not the entry point for `qe backtest optimize` or
+`qe strategy optimize`; those commands use `quant_engine.optimize.variants`,
+which supports screening, promotion, and advanced artifacts.
 """
 from __future__ import annotations
 

--- a/src/quant_engine/optimize/variants.py
+++ b/src/quant_engine/optimize/variants.py
@@ -1,4 +1,9 @@
-"""Optimization utilities for backtest and strategy specs."""
+"""Optimization utilities for backtest and strategy specs.
+
+This module is the recommended entry point for backtest/strategy optimization
+workflows (CLI `qe backtest optimize` / `qe strategy optimize`). The simpler
+`quant_engine.optimize.runner` exists only as a legacy fallback for `qe run-local`.
+"""
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
### Motivation
- Clarify the official optimization entrypoint so users and the CLI consistently prefer `optimize.variants` for backtest/strategy optimization.
- Make explicit that `optimize.runner` is a legacy/simple fallback used by `qe run-local` when the job manager is unavailable.
- Reduce confusion about which module provides advanced features such as screening, promotion, deduplication and artifact levels.
- Align documentation and module docstrings with the intended workflow and recommendations.

### Description
- Update the module docstring in `src/quant_engine/optimize/variants.py` to state it is the recommended entrypoint and reference the CLI commands `qe backtest optimize` / `qe strategy optimize`.
- Update the module docstring in `src/quant_engine/optimize/runner.py` to mark it as a legacy/fallback runner and note it is not the entrypoint for the CLI `optimize` commands.
- Edit `docs/optimization.md` to explicitly state that `optimize.variants` is the official/recommended optimizer and that `optimize.runner` is only a local fallback for quick tests.
- Add brief CLI guidance in `README.md` to indicate that `run-local` will use the job manager if available or fall back to the legacy runner, and to note that the `backtest/strategy optimize` commands use `optimize.variants`.

### Testing
- No automated tests were executed because the changes are documentation and docstring updates only.
- The changes are non-functional and do not modify runtime optimization logic or unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663cd42a9483238fc686687eb27e2e)