### PR TITLE
Clarify require_crossing gating in backtest runner

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -164,6 +164,24 @@ Flow actuel :
 2) Promotion des top-K qui passent les constraints.
 3) Persistance des heavy payloads uniquement pour les trials promus.
 
+## require_crossing (filtres + signaux)
+
+Quand des filtres sont définis, ils produisent un masque `filter_pass`.
+Le champ `require_crossing` contrôle comment ce masque est combiné avec le signal :
+
+- **`true` (défaut)** : le signal doit **croiser** le filtre sur la même barre.
+  Un signal ne passe que si `signal == 1` **et** `filter_pass == true`.
+- **`false`** : mode **latch**. Le signal doit croiser le filtre une seule fois,
+  puis il peut rester actif tant que le signal reste à 1, même si le filtre redevient faux.
+
+Priorité de lecture :
+1) `signal.params.require_crossing`
+2) `strategy.params.require_crossing`
+3) valeur par défaut `true`
+
+Valeurs acceptées : booléen, `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`.
+Une valeur invalide déclenche une erreur pour éviter un comportement implicite.
+
 ### Mode screening (raccourci)
 
 Le screening permet d'accélérer l'optimization en utilisant un sous-ensemble

--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -139,6 +139,46 @@ def _rows_to_frame(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     return df
 
 
+def _coerce_bool(value: Any, *, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    raise ValueError(f"Invalid boolean value for require_crossing: {value!r}")
+
+
+def _resolve_require_crossing(spec: Mapping[str, Any]) -> bool:
+    signal_params = (spec.get("signal", {}) or {}).get("params", {}) or {}
+    if "require_crossing" in signal_params:
+        return _coerce_bool(signal_params.get("require_crossing"))
+    strategy_params = (spec.get("strategy", {}) or {}).get("params", {}) or {}
+    return _coerce_bool(strategy_params.get("require_crossing"), default=True)
+
+
+def _apply_filter_mask(
+    signal: List[int],
+    mask: List[bool],
+    require_crossing: bool,
+) -> List[int]:
+    if require_crossing:
+        return [int(bool(s) and bool(m)) for s, m in zip(signal, mask)]
+    gated: List[int] = []
+    for idx, (s, m) in enumerate(zip(signal, mask)):
+        if idx > 0 and gated[idx - 1] == 1:
+            gated.append(int(bool(s)))
+        else:
+            gated.append(int(bool(s) and bool(m)))
+    return gated
+
+
 def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
     """Execute a classic backtest based on a JSON specification."""
 
@@ -209,21 +249,8 @@ def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
         except FilterValidationError as exc:
             LOGGER.error("Backtest filters failed: %s", exc)
             raise
-        signal_params = (spec.get("signal", {}) or {}).get("params", {}) or {}
-        require_crossing = signal_params.get("require_crossing")
-        if require_crossing is None:
-            require_crossing = (spec.get("strategy", {}) or {}).get("params", {}) or {}
-            require_crossing = require_crossing.get("require_crossing", True)
-        if require_crossing:
-            signal = [int(bool(s) and bool(m)) for s, m in zip(signal, mask)]
-        else:
-            gated: List[int] = []
-            for idx, (s, m) in enumerate(zip(signal, mask)):
-                if idx > 0 and gated[idx - 1] == 1:
-                    gated.append(int(bool(s)))
-                else:
-                    gated.append(int(bool(s) and bool(m)))
-            signal = gated
+        require_crossing = _resolve_require_crossing(spec)
+        signal = _apply_filter_mask(signal, mask, require_crossing)
 
     tpsl = spec.get("tpsl", {}) or {}
     atr_window = int(tpsl.get("atr_window", tpsl.get("atr_period", 14)))

--- a/tests/test_backtest_require_crossing.py
+++ b/tests/test_backtest_require_crossing.py
@@ -1,0 +1,28 @@
+from quant_engine.backtest import runner
+
+
+def test_apply_filter_mask_require_crossing_true():
+    signal = [0, 1, 1, 1, 0, 1]
+    mask = [False, False, True, False, False, False]
+
+    gated = runner._apply_filter_mask(signal, mask, True)
+
+    assert gated == [0, 0, 1, 0, 0, 0]
+
+
+def test_apply_filter_mask_require_crossing_false():
+    signal = [0, 1, 1, 1, 0, 1]
+    mask = [False, False, True, False, False, False]
+
+    gated = runner._apply_filter_mask(signal, mask, False)
+
+    assert gated == [0, 0, 1, 1, 0, 0]
+
+
+def test_resolve_require_crossing_prefers_signal_params():
+    spec = {
+        "signal": {"params": {"require_crossing": "false"}},
+        "strategy": {"params": {"require_crossing": True}},
+    }
+
+    assert runner._resolve_require_crossing(spec) is False


### PR DESCRIPTION
### Motivation

- Make the `require_crossing` behavior explicit and robust when combining filter masks with entry signals to avoid ambiguous/implicit handling. 
- Accept common truthy/falsey representations and fail fast on invalid values to prevent silent misconfiguration. 
- Ensure signal-vs-strategy param precedence is well-defined and consistent. 
- Provide documentation so users understand `require_crossing` semantics (cross vs latch). 

### Description

- Add helper ` _coerce_bool` to parse/validate boolean-like values and raise on invalid inputs. 
- Add `_resolve_require_crossing` which reads `require_crossing` with priority `signal.params` then `strategy.params` with default `True`. 
- Introduce `_apply_filter_mask` to implement both crossing (AND) and latch modes and wire it into `run_backtest_from_spec` replacing the inlined logic. 
- Document the behavior and accepted values in `docs/optimization.md` and add unit tests in `tests/test_backtest_require_crossing.py`. 

### Testing

- Ran unit tests for the new logic with `pytest tests/test_backtest_require_crossing.py`. 
- 3 tests collected and all passed (`3 passed`). 
- The change is covered for gating semantics and parameter precedence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664e760c3483239e05152dd64540c3)