### PR TITLE
Harden optimization retention pruning

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -713,7 +713,8 @@ Tu peux limiter le nombre de runs conserves et purger les artefacts lourds :
         "keep_last_runs": 5,
         "keep_best_runs": 3,
         "mode": "heavy_only",
-        "dry_run": false
+        "dry_run": false,
+        "base_dir": "runs"
       }
     }
   }
@@ -724,6 +725,7 @@ Tu peux limiter le nombre de runs conserves et purger les artefacts lourds :
 - `keep_best_runs` : conserve les N meilleurs runs par (strategy_id, dataset_id).
 - `mode`: `heavy_only` (purge `promoted/` + `full_pass/`) ou `full` (supprime le run complet).
 - `dry_run`: log sans suppression.
+- `base_dir`: repertoire racine a scanner pour la retention (par defaut `out_dir` parent). Doit contenir le `out_dir` courant sinon la retention est ignoree.
 
 ## Roadmap "niveau pro" (priorites)
 

--- a/src/quant_engine/optimize/variants.py
+++ b/src/quant_engine/optimize/variants.py
@@ -1729,6 +1729,9 @@ def _collect_runs(base_dir: Path) -> List[Dict[str, Any]]:
         best = summary.get("best") or {}
         objective = best.get("objective")
         metadata = summary.get("metadata") or {}
+        if not isinstance(metadata, Mapping) or not (metadata.get("config_hash") or metadata.get("data_hash")):
+            LOGGER.debug("Retention: skipping %s (missing optimization metadata)", child)
+            continue
         runs.append(
             {
                 "dir": child,
@@ -1749,6 +1752,41 @@ def _prune_heavy_artifacts(run_dir: Path) -> None:
                 shutil.rmtree(target, ignore_errors=True)
 
 
+def _is_within_dir(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_retention_base_dir(out_dir: Path, retention: Mapping[str, Any]) -> Optional[Path]:
+    base_dir_cfg = retention.get("base_dir")
+    if base_dir_cfg:
+        candidate = Path(str(base_dir_cfg)).expanduser()
+        if not candidate.is_absolute():
+            candidate = (out_dir.parent / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+    else:
+        candidate = out_dir.parent.resolve()
+    if candidate == Path(candidate.anchor):
+        LOGGER.warning("Retention: base_dir=%s is too broad; skipping retention for safety", candidate)
+        return None
+    if not candidate.exists() or not candidate.is_dir():
+        LOGGER.warning("Retention: base_dir=%s is missing or not a directory; skipping", candidate)
+        return None
+    out_dir_resolved = out_dir.resolve()
+    if not _is_within_dir(out_dir_resolved, candidate):
+        LOGGER.warning(
+            "Retention: out_dir=%s is outside base_dir=%s; skipping retention",
+            out_dir_resolved,
+            candidate,
+        )
+        return None
+    return candidate
+
+
 def _apply_retention(out_dir: Path, cfg: Mapping[str, Any]) -> None:
     storage_cfg = cfg.get("storage") or {}
     if not isinstance(storage_cfg, Mapping):
@@ -1762,10 +1800,22 @@ def _apply_retention(out_dir: Path, cfg: Mapping[str, Any]) -> None:
     keep_best = retention.get("keep_best_runs")
     mode = str(retention.get("mode", "heavy_only")).lower()
     dry_run = bool(retention.get("dry_run", False))
-    base_dir = out_dir.parent
+    base_dir = _resolve_retention_base_dir(out_dir, retention)
+    if base_dir is None:
+        return
     runs = _collect_runs(base_dir)
     if not runs:
+        LOGGER.info("Retention: no eligible runs found under %s", base_dir)
         return
+    LOGGER.info(
+        "Retention: scanning base_dir=%s (runs=%d, keep_last=%s, keep_best=%s, mode=%s, dry_run=%s)",
+        base_dir,
+        len(runs),
+        keep_last,
+        keep_best,
+        mode,
+        dry_run,
+    )
     keep_dirs: set[Path] = {out_dir.resolve()}
     if keep_last:
         try:
@@ -1798,11 +1848,11 @@ def _apply_retention(out_dir: Path, cfg: Mapping[str, Any]) -> None:
         if run_dir in keep_dirs:
             continue
         if mode == "full":
-            LOGGER.info("Retention: deleting run %s", run_dir)
+            LOGGER.warning("Retention: deleting run %s (mode=full, dry_run=%s)", run_dir, dry_run)
             if not dry_run:
                 shutil.rmtree(run_dir, ignore_errors=True)
         else:
-            LOGGER.info("Retention: pruning heavy artifacts in %s", run_dir)
+            LOGGER.info("Retention: pruning heavy artifacts in %s (dry_run=%s)", run_dir, dry_run)
             if not dry_run:
                 _prune_heavy_artifacts(run_dir)
 


### PR DESCRIPTION
### Motivation
- Prevent accidental removals when running automatic retention/pruning across runs by scoping and adding explicit safety checks.  
- Allow configuring the retention scan root so retention can be limited to a known runs tree via a `base_dir` option.  
- Avoid operating on non-optimization outputs by skipping runs that lack reproducibility metadata.  
- Improve observability with clearer logs and explicit `dry_run` behavior to make deletions auditable.

### Description
- Add a `base_dir` resolution helper ` _resolve_retention_base_dir ` and ` _is_within_dir ` checks to validate and limit the retention scan area and refuse overly broad paths.  
- Make `_collect_runs` skip directories whose `summary.json` metadata does not include `config_hash` or `data_hash` to avoid pruning unrelated folders.  
- Update `_apply_retention` to use the resolved `base_dir`, emit an informative scan log, and log deletions as warnings including `dry_run` state instead of silently removing.  
- Document the new `base_dir` retention option and safety semantics in `docs/optimization.md` and show an example `retention` snippet with `base_dir`.

### Testing
- No automated tests were run as part of this change.  
- Static code changes were added and the repository files modified include `src/quant_engine/optimize/variants.py` and `docs/optimization.md`.  
- Behavior is guarded behind configuration flags (`retention.enabled` and `dry_run`) so runtime impact is controllable.  
- Runtime validation logs were added to aid manual verification during integration runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667dd8ba288323b9f89b77a07a1dfb)