### PR TITLE
Throttle DcaEquityStrategy drawdown summary logs (debug by default)

### DIFF
--- a/docs/strategies_overview.md
+++ b/docs/strategies_overview.md
@@ -16,6 +16,8 @@ commun (`StrategySignal`) et peuvent être utilisées en backtest via
   `SELL` sont optionnelles via des règles `tp_sl` (mode `per_grid_max_dd`).
 * **Métadonnées** : profondeur atteinte (`dd_pct`), niveau de grille
   (`grid_level`), poids (`palier_used`), règle de take-profit active, etc.
+* **Logs** : `log_drawdown_summary=true` pour afficher un résumé de drawdown en
+  niveau INFO (par défaut, le résumé passe en DEBUG pour éviter le spam).
 
 ### `DcaEtfStrategy`
 

--- a/src/quant_engine/strategies/dca_equity.py
+++ b/src/quant_engine/strategies/dca_equity.py
@@ -62,6 +62,7 @@ class DcaEquityStrategy(Strategy):
             self.params.get("drawdown_reference")
         )
         self.require_crossing = bool(self.params.get("require_crossing", True))
+        self.log_drawdown_summary = bool(self.params.get("log_drawdown_summary", False))
 
     @staticmethod
     def compute_drawdown(close: pd.Series) -> pd.Series:
@@ -206,24 +207,27 @@ class DcaEquityStrategy(Strategy):
         bars_seen = 0
         signals_seen = 0
         allow_mask = df["_filter_ok"].astype(bool) if "_filter_ok" in df.columns else pd.Series(True, index=df.index)
-        try:
-            dd_allowed = dd_series[allow_mask]
-            min_dd_all = float(dd_series.min()) if not dd_series.empty else 0.0
-            min_dd_allowed = float(dd_allowed.min()) if not dd_allowed.empty else 0.0
-            crossings: List[str] = []
-            for level in self.grid:
-                threshold = float(level.get("dd", 0.0))
-                crossed = (dd_series <= threshold) & (dd_series.shift(1) > threshold) & allow_mask
-                crossings.append(f"{threshold:.2f}={int(crossed.fillna(False).sum())}")
-            LOGGER.info(
-                "Drawdown summary for %s: min_dd=%.2f%% min_dd_allowed=%.2f%% crossings(%s)",
-                symbol,
-                min_dd_all,
-                min_dd_allowed,
-                ", ".join(crossings),
-            )
-        except Exception:
-            LOGGER.info("Drawdown summary for %s: unavailable", symbol)
+        log_level = logging.INFO if self.log_drawdown_summary else logging.DEBUG
+        if LOGGER.isEnabledFor(log_level):
+            try:
+                dd_allowed = dd_series[allow_mask]
+                min_dd_all = float(dd_series.min()) if not dd_series.empty else 0.0
+                min_dd_allowed = float(dd_allowed.min()) if not dd_allowed.empty else 0.0
+                crossings: List[str] = []
+                for level in self.grid:
+                    threshold = float(level.get("dd", 0.0))
+                    crossed = (dd_series <= threshold) & (dd_series.shift(1) > threshold) & allow_mask
+                    crossings.append(f"{threshold:.2f}={int(crossed.fillna(False).sum())}")
+                LOGGER.log(
+                    log_level,
+                    "Drawdown summary for %s: min_dd=%.2f%% min_dd_allowed=%.2f%% crossings(%s)",
+                    symbol,
+                    min_dd_all,
+                    min_dd_allowed,
+                    ", ".join(crossings),
+                )
+            except Exception:
+                LOGGER.log(log_level, "Drawdown summary for %s: unavailable", symbol)
         results: List[StrategySignal] = []
         last_processed = state.last_processed_ts
         for ts, price, dd, ref_h, high, low in zip(


### PR DESCRIPTION
### Motivation

* Reduce noisy drawdown-summary logging during large/automated optimization runs to avoid spam.
* Allow operators to enable the summary at INFO level when desired while keeping the default quieter.

### Description

* Add a `log_drawdown_summary` boolean parsed from `params` in `DcaEquityStrategy.__init__` to control verbosity.
* Gate the drawdown-summary computation behind `LOGGER.isEnabledFor(...)` and emit the message at `INFO` when enabled or at `DEBUG` otherwise to avoid expensive work when not needed.
* Replace the previous unconditional `LOGGER.info(...)` calls with `LOGGER.log(log_level, ...)` and catch exceptions to keep behavior safe.
* Document the new `log_drawdown_summary` parameter in `docs/strategies_overview.md` with usage notes.

### Testing

* No automated tests were executed for this change.
* Static inspection and lightweight local checks were used during development (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667dfb123c8323ac41c9636a8b2578)