### PR TITLE
Harden time-based rolling windows for DCA equity

### DIFF
--- a/src/quant_engine/strategies/dca_equity.py
+++ b/src/quant_engine/strategies/dca_equity.py
@@ -122,7 +122,18 @@ class DcaEquityStrategy(Strategy):
             ref = close.expanding(min_periods=1).max()
         else:
             window = self.dd_reference_window or "90D"
-            ref = close.rolling(window, min_periods=1).max()
+            if isinstance(window, str) and self._is_time_based_window(window):
+                if not isinstance(close.index, (pd.DatetimeIndex, pd.TimedeltaIndex, pd.PeriodIndex)):
+                    LOGGER.warning(
+                        "Rolling drawdown window %s requires a DatetimeIndex; "
+                        "falling back to expanding max.",
+                        window,
+                    )
+                    ref = close.expanding(min_periods=1).max()
+                else:
+                    ref = close.rolling(window, min_periods=1).max()
+            else:
+                ref = close.rolling(window, min_periods=1).max()
         return ref.ffill().fillna(close.iloc[0])
 
     @staticmethod
@@ -542,16 +553,33 @@ class DcaEquityStrategy(Strategy):
             return ohlc
         df = ohlc.copy()
         if "ts" in df.columns:
-            df["ts"] = pd.to_datetime(df["ts"], utc=True)
+            df["ts"] = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+            if df["ts"].isna().any():
+                raise ValueError("OHLC dataframe has invalid timestamps in 'ts' column")
             df = df.set_index("ts")
+        elif isinstance(df.index, pd.DatetimeIndex):
+            df.index = df.index.tz_convert("UTC") if df.index.tz is not None else df.index.tz_localize("UTC")
+        elif isinstance(df.index, pd.PeriodIndex):
+            df.index = df.index.to_timestamp().tz_localize("UTC")
         else:
-            df.index = pd.to_datetime(df.index, utc=True)
+            if df.index.dtype == object:
+                parsed = pd.to_datetime(df.index, utc=True, errors="coerce")
+                if not parsed.isna().any():
+                    df.index = parsed
         df = df.sort_index()
         required = {"open", "high", "low", "close"}
         missing = required - set(df.columns)
         if missing:
             raise ValueError(f"OHLC dataframe missing columns: {missing}")
         return df
+
+    @staticmethod
+    def _is_time_based_window(window: str) -> bool:
+        try:
+            pd.tseries.frequencies.to_offset(window)
+        except (ValueError, TypeError):
+            return False
+        return True
 
     def _state_from_dict(self, data: Dict[str, Any]) -> _CycleState:
         state = _CycleState()

--- a/tests/test_strategies_smoke.py
+++ b/tests/test_strategies_smoke.py
@@ -1,7 +1,10 @@
 """Smoke tests covering the high-level strategies and runner plumbing."""
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
+import pytest
 
 from quant_engine.strategies.dca_equity import DcaEquityStrategy
 from quant_engine.strategies.dca_etf import DcaEtfStrategy
@@ -42,7 +45,7 @@ def test_dca_equity_strategy_backtest_and_live() -> None:
         },
     }
     strategy = DcaEquityStrategy("EQ", params)
-    closes = [100, 90, 80, 70, 60, 50, 55, 60, 65, 80]
+    closes = [100, 90, 80, 70, 60, 50, 55, 60, 65, 90]
     df = _make_ohlc(closes)
     context = {"symbol": "EQ", "asset_class": "EQUITY"}
     signals = strategy.backtest(df, context)
@@ -54,6 +57,30 @@ def test_dca_equity_strategy_backtest_and_live() -> None:
     live_context = {"symbol": "EQ", "asset_class": "EQUITY", "state": {}}
     live_signals = strategy.evaluate_live_bar(df, live_context)
     assert live_signals and live_signals[-1].side == "SELL"
+
+
+def test_dca_equity_fallback_for_non_temporal_index(caplog: pytest.LogCaptureFixture) -> None:
+    params = {
+        "asset_class": "EQUITY",
+        "grid": [
+            {"dd": -10.0, "weight": 0.5},
+        ],
+    }
+    strategy = DcaEquityStrategy("EQ", params)
+    closes = [100, 95, 90, 92]
+    df = pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c * 1.01 for c in closes],
+            "low": [c * 0.99 for c in closes],
+            "close": closes,
+            "volume": [1_000] * len(closes),
+        }
+    )
+    context = {"symbol": "EQ", "asset_class": "EQUITY"}
+    with caplog.at_level(logging.WARNING, logger="quant_engine.strategies.dca_equity"):
+        strategy.backtest(df, context)
+    assert any("Rolling drawdown window" in record.message for record in caplog.records)
 
 
 def test_dca_etf_strategy_smoke() -> None:


### PR DESCRIPTION
### Motivation

- Rolling windows expressed as time offsets (eg. `"90D"`) should only be used with temporal indexes and must not silently produce incorrect results on non-temporal indexes.
- OHLC normalization must validate timestamps robustly to avoid subtle bugs when converting/setting the index.
- Provide an explicit fallback and a clear warning when a time-based rolling window cannot be applied.
- Add coverage to ensure the fallback behavior is exercised by tests.

### Description

- In `_compute_reference_high` guard time-based rolling windows with ` _is_time_based_window` and, if the series index is not temporal, emit a warning and fall back to `expanding(max)` instead of applying a time-based rolling window.
- Tighten `_normalize_ohlc` by using `pd.to_datetime(..., errors='coerce')`, raising on invalid `ts` values, and handling `DatetimeIndex`/`PeriodIndex` conversions and object indexes more safely.
- Add a small helper ` _is_time_based_window` that validates whether a window token is a time offset via `pd.tseries.frequencies.to_offset`.
- Add a smoke test `test_dca_equity_fallback_for_non_temporal_index` and adjust the DCA equity test data so TP behavior remains exercised in the existing smoke test.

### Testing

- Ran `pytest -q tests/test_strategies_smoke.py` and observed all tests passing (4 passed).
- The new smoke test asserts a warning is emitted when passing an OHLC dataframe with a non-temporal index while using rolling drawdown windows.
- Existing equity/backtest and live evaluation smoke tests continue to pass after the change.
- No other automated test suites were modified or executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667e1892608323883abf19ac7f2719)