### PR TITLE
Persist API jobs in SQLite and return job IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ python -m json.tool summary.json
 #### Statistiques (in-memory + SQLite)
 ```bash
 curl.exe -X POST http://127.0.0.1:8000/stats/run -H "Content-Type: application/json" --data-binary @specs/examples/stats_run.json
+# -> {"status":"completed","id":"JOB_ID"}
+```
+
+```bash
+curl.exe http://127.0.0.1:8000/status/JOB_ID
+curl.exe http://127.0.0.1:8000/result/JOB_ID | python -m json.tool
 ```
 
 ```bash

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -3,10 +3,10 @@
 ## API FastAPI
 | Endpoint | Méthode | Description | Entrée/Sortie | Référence |
 |----------|---------|-------------|---------------|-----------|
-| `/submit` | POST | Lance une optimisation synchronisée et enregistre le run en mémoire. | Body = spec JSON validée via Pydantic → `{ "id": run_id }`. | 【F:src/quant_engine/api/app.py†L540-L555】 |
+| `/submit` | POST | Lance une optimisation synchronisée et persiste le job. | Body = spec JSON validée via Pydantic → `{ "id": run_id }`. | 【F:src/quant_engine/api/app.py†L540-L560】 |
 | `/status/{job_id}` | GET | Vérifie l’état (`completed`, `unknown`, …) d’un job soumis. | Path param `job_id` → `{ "status": ... }`. | 【F:src/quant_engine/api/app.py†L557-L566】 |
 | `/result/{job_id}` | GET | Récupère le résultat complet d’un job (paramètres, métriques, artefacts). | Path param `job_id` → `{ "result": {...} }`. | 【F:src/quant_engine/api/app.py†L568-L576】 |
-| `/stats/run` | POST | Calcule un run Market Stats synchrone. | Body = `StatsSpec` → `{ "status": "completed" }`. | 【F:src/quant_engine/api/app.py†L578-L587】 |
+| `/stats/run` | POST | Calcule un run Market Stats synchrone (job persisté). | Body = `StatsSpec` → `{ "status": "completed", "id": job_id }`. | 【F:src/quant_engine/api/app.py†L600-L612】 |
 | `/stats/result` | GET | Renvoie la dernière table de stats calculée. | `{ "result": {columns, rows} }`. | 【F:src/quant_engine/api/app.py†L589-L600】 |
 | `/stats` | GET | Liste les stats persistées filtrables (symbol, event, target, split, significance). | Query params → liste de lignes enrichies (p_hat, lifts, FDR). | 【F:src/quant_engine/api/app.py†L602-L622】 |
 | `/stats/summary` | GET | Agrège les stats par condition/target et calcule Wilson CI. | Query params (symbol/timeframe/event) → tableau agrégé. | 【F:src/quant_engine/api/app.py†L624-L648】 |
@@ -62,4 +62,5 @@
 - `market_stats` : résultats stats conditionnelles (p_hat, lifts, FDR, bornes temporelles).【F:src/quant_engine/persistence/db.py†L120-L167】
 - `seasonality_profiles` : profils saisonniers, lifts et métriques sérialisées.【F:src/quant_engine/persistence/db.py†L168-L206】
 - `seasonality_runs` : suivi des runs saisonnalité (status, best_summary).【F:src/quant_engine/persistence/db.py†L207-L215】
+- `api_jobs` : persistance des jobs API (type, statut, payload, résultat).【F:src/quant_engine/persistence/db.py†L216-L245】
 - Migrations : gérées via Alembic (déclaré côté dépendances, migrations custom dans `persistence/`).【F:pyproject.toml†L9-L20】【F:docs/architecture_overview.md†L11-L36】

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -30,26 +31,171 @@ from ..seasonality.optimize import run_optimization as seasonality_run_optimizat
 from ..filters import list_filter_types
 from . import schemas
 
-_jobs: Dict[str, Dict[str, Any]] = {}
-_last_stats: Dict[str, Any] | None = None
+JOB_TYPE_OPTIMIZATION = "optimization"
+JOB_TYPE_STATS = "stats"
+JOB_TYPE_LEVELS_BUILD = "levels_build"
+JOB_TYPE_LEVELS_FILL = "levels_fill"
+JOB_TYPE_SEASONALITY_RUN = "seasonality_run"
+JOB_TYPE_SEASONALITY_OPTIMIZE = "seasonality_optimize"
+
+JOB_STATUSES = {"pending", "running", "completed", "failed"}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_payload(payload: Any) -> Any:
+    if is_dataclass(payload):
+        return asdict(payload)
+    return payload
+
+
+def _serialize_payload(payload: Any) -> str | None:
+    if payload is None:
+        return None
+    try:
+        return json.dumps(_normalize_payload(payload), default=str)
+    except TypeError:
+        return json.dumps(str(payload))
+
+
+def _decode_json(payload: Any) -> Any:
+    if payload in (None, ""):
+        return None
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            return payload
+    return payload
+
+
+def _init_job(job_id: str, job_type: str, payload: Any | None) -> None:
+    with db.session() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO api_jobs(
+                job_id,
+                job_type,
+                status,
+                payload_json,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (job_id, job_type, "pending", _serialize_payload(payload), _utc_now(), _utc_now()),
+        )
+
+
+def _update_job_status(job_id: str, status: str, *, error: str | None = None) -> None:
+    if status not in JOB_STATUSES:
+        raise ValueError(f"Unknown job status: {status}")
+    now = _utc_now()
+    started_at = now if status == "running" else None
+    finished_at = now if status in {"completed", "failed"} else None
+    with db.session() as conn:
+        conn.execute(
+            """
+            UPDATE api_jobs
+            SET status = ?,
+                error_message = COALESCE(?, error_message),
+                started_at = COALESCE(?, started_at),
+                finished_at = COALESCE(?, finished_at),
+                updated_at = ?
+            WHERE job_id = ?
+            """,
+            (status, error, started_at, finished_at, now, job_id),
+        )
+
+
+def _update_job_result(job_id: str, result: Any) -> None:
+    with db.session() as conn:
+        conn.execute(
+            """
+            UPDATE api_jobs
+            SET status = ?,
+                result_json = ?,
+                finished_at = ?,
+                updated_at = ?
+            WHERE job_id = ?
+            """,
+            ("completed", _serialize_payload(result), _utc_now(), _utc_now(), job_id),
+        )
+
+
+def _get_job(job_id: str) -> Dict[str, Any] | None:
+    with db.session() as conn:
+        row = conn.execute(
+            """
+            SELECT job_id, job_type, status, payload_json, result_json, error_message,
+                   created_at, started_at, finished_at, updated_at
+            FROM api_jobs
+            WHERE job_id = ?
+            """,
+            (job_id,),
+        ).fetchone()
+        if not row:
+            return None
+        payload = dict(row)
+        payload["payload"] = _decode_json(payload.pop("payload_json", None))
+        payload["result"] = _decode_json(payload.pop("result_json", None))
+        return payload
+
+
+def _latest_job(job_type: str) -> Dict[str, Any] | None:
+    with db.session() as conn:
+        row = conn.execute(
+            """
+            SELECT job_id, job_type, status, payload_json, result_json, error_message,
+                   created_at, started_at, finished_at, updated_at
+            FROM api_jobs
+            WHERE job_type = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (job_type,),
+        ).fetchone()
+        if not row:
+            return None
+        payload = dict(row)
+        payload["payload"] = _decode_json(payload.pop("payload_json", None))
+        payload["result"] = _decode_json(payload.pop("result_json", None))
+        return payload
+
+
+def _run_job(job_type: str, payload: Any | None, runner) -> tuple[str, Any]:
+    job_id = ids.generate_id()
+    _init_job(job_id, job_type, payload=payload)
+    _update_job_status(job_id, "running")
+    try:
+        result = runner()
+    except Exception as exc:  # pragma: no cover - defensive
+        _update_job_status(job_id, "failed", error=str(exc))
+        raise
+    _update_job_result(job_id, result)
+    return job_id, result
 
 
 def submit(spec: Spec) -> schemas.SubmitResponse:
-    job_id = ids.generate_id()
-    result = run_optimisation(spec)
-    _jobs[job_id] = {"status": "completed", "result": result}
+    job_id, _ = _run_job(
+        JOB_TYPE_OPTIMIZATION,
+        payload={"spec": asdict(spec)},
+        runner=lambda: run_optimisation(spec),
+    )
     return schemas.SubmitResponse(id=job_id)
 
 
 def status(job_id: str) -> schemas.StatusResponse:
-    job = _jobs.get(job_id)
+    job = _get_job(job_id)
     if not job:
         return schemas.StatusResponse(status="unknown")
     return schemas.StatusResponse(status=job["status"])
 
 
 def result(job_id: str) -> schemas.ResultResponse:
-    job = _jobs.get(job_id)
+    job = _get_job(job_id)
     if not job:
         return schemas.ResultResponse(result=None)
     return schemas.ResultResponse(result=job.get("result"))
@@ -62,28 +208,40 @@ def result(job_id: str) -> schemas.ResultResponse:
 def stats_run(spec: schemas.StatsSpec) -> schemas.StatusResponse:
     """Execute a statistics run synchronously and store the result."""
 
-    global _last_stats
-    _last_stats = stats_runner.run_stats(spec)
-    return schemas.StatusResponse(status="completed")
+    job_id = ids.generate_id()
+    _init_job(job_id, JOB_TYPE_STATS, payload=spec.model_dump(mode="json"))
+    _update_job_status(job_id, "running")
+    try:
+        result_df = stats_runner.run_stats(spec)
+    except Exception as exc:  # pragma: no cover - defensive
+        _update_job_status(job_id, "failed", error=str(exc))
+        raise
+    payload = _stats_payload_from_df(result_df)
+    payload["job_id"] = job_id
+    _update_job_result(job_id, payload)
+    return schemas.StatusResponse(status="completed", id=job_id)
+
+
+def _stats_payload_from_df(df: Any) -> Dict[str, Any]:
+    try:
+        import pandas as pd  # type: ignore
+    except Exception:  # pragma: no cover - pandas is an install dependency
+        payload_df = df
+    else:
+        payload_df = df.where(pd.notna(df), None)
+    return {
+        "columns": list(payload_df.columns),
+        "rows": payload_df.to_dict(orient="records"),
+    }
 
 
 def stats_result() -> schemas.ResultResponse:
     """Return the last statistics result if available."""
 
-    if _last_stats is None:
+    job = _latest_job(JOB_TYPE_STATS)
+    if not job or not job.get("result"):
         return schemas.ResultResponse(result=None)
-
-    try:
-        import pandas as pd  # type: ignore
-    except Exception:  # pragma: no cover - pandas is an install dependency
-        df = _last_stats
-    else:
-        df = _last_stats.where(pd.notna(_last_stats), None)
-    payload = {
-        "columns": list(df.columns),
-        "rows": df.to_dict(orient="records"),
-    }
-    return schemas.ResultResponse(result=payload)
+    return schemas.ResultResponse(result=job.get("result"))
 
 
 def stats_condition_types() -> List[str]:
@@ -240,13 +398,35 @@ def _nearest_levels(
 def levels_build(spec: LevelsBuildSpec) -> Dict[str, Any]:
     """Execute a levels build request synchronously."""
 
-    return run_levels_build(spec)
+    job_id, result = _run_job(
+        JOB_TYPE_LEVELS_BUILD,
+        payload=spec.model_dump(mode="json"),
+        runner=lambda: run_levels_build(spec),
+    )
+    if isinstance(result, dict):
+        payload = dict(result)
+    else:
+        payload = {"result": result}
+    payload["job_id"] = job_id
+    _update_job_result(job_id, payload)
+    return payload
 
 
 def levels_fill(spec: LevelsBuildSpec) -> Dict[str, Any]:
     """Refresh fills for GAP and FVG levels."""
 
-    return run_levels_fill(spec)
+    job_id, result = _run_job(
+        JOB_TYPE_LEVELS_FILL,
+        payload=spec.model_dump(mode="json"),
+        runner=lambda: run_levels_fill(spec),
+    )
+    if isinstance(result, dict):
+        payload = dict(result)
+    else:
+        payload = {"result": result}
+    payload["job_id"] = job_id
+    _update_job_result(job_id, payload)
+    return payload
 
 
 def levels_list(
@@ -332,15 +512,35 @@ def levels_nearest(
 def seasonality_run(spec: schemas.SeasonalitySpec) -> schemas.ResultResponse:
     """Execute a seasonality run synchronously and return its summary."""
 
-    result = seasonality_runner.run(spec)
-    return schemas.ResultResponse(result=result)
+    job_id, result = _run_job(
+        JOB_TYPE_SEASONALITY_RUN,
+        payload=spec.model_dump(mode="json"),
+        runner=lambda: seasonality_runner.run(spec),
+    )
+    if isinstance(result, dict):
+        payload = dict(result)
+    else:
+        payload = {"result": result}
+    payload["job_id"] = job_id
+    _update_job_result(job_id, payload)
+    return schemas.ResultResponse(result=payload)
 
 
 def seasonality_optimize(spec: schemas.SeasonalitySpec) -> schemas.ResultResponse:
     """Launch the seasonality optimisation loop and return its outcome."""
 
-    result = seasonality_run_optimization(spec)
-    return schemas.ResultResponse(result=result)
+    job_id, result = _run_job(
+        JOB_TYPE_SEASONALITY_OPTIMIZE,
+        payload=spec.model_dump(mode="json"),
+        runner=lambda: seasonality_run_optimization(spec),
+    )
+    if isinstance(result, dict):
+        payload = dict(result)
+    else:
+        payload = {"result": result}
+    payload["job_id"] = job_id
+    _update_job_result(job_id, payload)
+    return schemas.ResultResponse(result=payload)
 
 
 def list_seasonality_profiles(

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -20,6 +20,7 @@ class SubmitResponse:
 @dataclass
 class StatusResponse:
     status: str
+    id: Optional[str] = None
 
 
 @dataclass
@@ -397,4 +398,3 @@ class SeasonalitySpec(BaseModel):
     validation: ValidationSpec = ValidationSpec()
     artifacts: ArtifactsSpec = ArtifactsSpec()
     persistence: PersistenceSpec = PersistenceSpec()
-

--- a/src/quant_engine/persistence/db.py
+++ b/src/quant_engine/persistence/db.py
@@ -221,6 +221,35 @@ def init_db(conn: sqlite3.Connection) -> None:
         ON seasonality_runs(run_id)
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS api_jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT NOT NULL UNIQUE,
+            job_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            payload_json TEXT,
+            result_json TEXT,
+            error_message TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            started_at TEXT,
+            finished_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_api_jobs_job_id
+        ON api_jobs(job_id)
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_api_jobs_type_status
+        ON api_jobs(job_type, status)
+        """
+    )
     conn.commit()
 
 


### PR DESCRIPTION
### Motivation
- Replace fragile in-memory job/state storage with durable persistence so long-running API work (stats/levels/optimization/seasonality) can be tracked reliably. 
- Prepare the API for asynchronous/long-running runs by recording job lifecycle events and results in the DB. 
- Surface job identifiers in API responses to allow external polling of job status and retrieval of results.

### Description
- Add an `api_jobs` table to the lightweight SQLite persistence layer to store `job_id`, `job_type`, `status`, `payload_json`, `result_json`, timestamps and error messages (`src/quant_engine/persistence/db.py`).
- Implement job lifecycle helpers in the API (`_init_job`, `_update_job_status`, `_update_job_result`, `_get_job`, `_latest_job`, `_run_job`, plus JSON payload normalization and timestamp helpers) and use them to persist jobs and results (`src/quant_engine/api/app.py`).
- Refactor endpoints and helpers to persist and return job IDs for optimization (`/submit`), stats (`/stats/run`), levels (`/levels/build`, `/levels/fill`) and seasonality (`/seasonality/run`, `/seasonality/optimize`) flows, and to read the latest stats result from persistence (`stats_result`).
- Add optional `id` to the status response model (`src/quant_engine/api/schemas.py`) and update README and ARCHITECTURE_MAP to document job-id usage and new behaviour.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a2a1dbd48323847ccb585b311d53)