### PR TITLE
Add resilient shared HTTP client with retries/backoff and pooling

### DIFF
--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,0 +1,19 @@
+# HTTP client résilient
+
+Le moteur utilise un client HTTP partagé configuré avec pooling, timeouts, retries et backoff pour rendre les appels réseau plus robustes.
+
+## Configuration
+
+Ces variables d'environnement permettent d'ajuster la résilience réseau sans modifier le code :
+
+- `QE_HTTP_CONNECT_TIMEOUT` : timeout de connexion (secondes). Défaut : `3.0`.
+- `QE_HTTP_READ_TIMEOUT` : timeout de lecture (secondes). Défaut : `10.0`.
+- `QE_HTTP_RETRIES` : nombre total de retries (connexions, lectures, statuts). Défaut : `3`.
+- `QE_HTTP_BACKOFF` : facteur de backoff exponentiel. Défaut : `0.4`.
+- `QE_HTTP_POOL_CONNECTIONS` : nombre de pools. Défaut : `10`.
+- `QE_HTTP_POOL_MAXSIZE` : taille max par pool. Défaut : `10`.
+
+## Comportement
+
+- Les statuts `429, 500, 502, 503, 504` déclenchent un retry.
+- Le client est mutualisé pour limiter la création de connexions TCP.

--- a/src/quant_engine/cli/main.py
+++ b/src/quant_engine/cli/main.py
@@ -5,11 +5,12 @@ from dataclasses import asdict
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib import error, parse, request
+from urllib import parse
 
 import typer
 
 from ..core import spec as spec_module
+from ..http_client import DEFAULT_TIMEOUT, get_shared_session, request_json
 
 try:  # Job manager may not be available in lightweight tests
     from ..optimize.job_manager import JobManager  # type: ignore
@@ -72,21 +73,16 @@ def submit(
         payload = sp.model_dump()  # type: ignore[union-attr]
     else:
         payload = asdict(sp)
-    data = json.dumps(payload).encode()
-    req = request.Request(
-        "http://127.0.0.1:8000/submit", data=data, headers={"Content-Type": "application/json"}
-    )
     try:
-        with request.urlopen(req) as resp:
-            if resp.status != 200:
-                typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                raise typer.Exit(1)
-            payload = json.loads(resp.read().decode())
-    except error.HTTPError as e:
-        typer.echo(f"HTTP {e.code}: {e.reason}")
-        raise typer.Exit(1)
-    except error.URLError as e:
-        typer.echo(f"Connection error: {e.reason}")
+        payload = request_json(
+            "POST",
+            "http://127.0.0.1:8000/submit",
+            json=payload,
+            timeout=DEFAULT_TIMEOUT,
+            session=get_shared_session(),
+        )
+    except Exception as exc:
+        typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
     typer.echo(payload.get("id", ""))
 
@@ -143,16 +139,14 @@ def stats_show(
         params["timeframe"] = timeframe
     url = "http://127.0.0.1:8000/stats?" + parse.urlencode(params)
     try:
-        with request.urlopen(url) as resp:
-            if resp.status != 200:
-                typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                raise typer.Exit(1)
-            rows = json.loads(resp.read().decode())
-    except error.HTTPError as e:
-        typer.echo(f"HTTP {e.code}: {e.reason}")
-        raise typer.Exit(1)
-    except error.URLError as e:
-        typer.echo(f"Connection error: {e.reason}")
+        rows = request_json(
+            "GET",
+            url,
+            timeout=DEFAULT_TIMEOUT,
+            session=get_shared_session(),
+        )
+    except Exception as exc:
+        typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
     df = pd.DataFrame(rows)
     if df.empty:
@@ -269,16 +263,14 @@ def seasonality_profiles(
         params["metrics"] = metrics
     url = "http://127.0.0.1:8000/seasonality/profiles?" + parse.urlencode(params)
     try:
-        with request.urlopen(url) as resp:
-            if resp.status != 200:
-                typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                raise typer.Exit(1)
-            rows = json.loads(resp.read().decode())
-    except error.HTTPError as e:
-        typer.echo(f"HTTP {e.code}: {e.reason}")
-        raise typer.Exit(1)
-    except error.URLError as e:
-        typer.echo(f"Connection error: {e.reason}")
+        rows = request_json(
+            "GET",
+            url,
+            timeout=DEFAULT_TIMEOUT,
+            session=get_shared_session(),
+        )
+    except Exception as exc:
+        typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
 
     df = pd.DataFrame(rows)
@@ -342,16 +334,14 @@ def seasonality_compare(
             params["timeframe"] = timeframe
         url = "http://127.0.0.1:8000/seasonality/profiles?" + parse.urlencode(params)
         try:
-            with request.urlopen(url) as resp:
-                if resp.status != 200:
-                    typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                    raise typer.Exit(1)
-                rows = json.loads(resp.read().decode())
-        except error.HTTPError as e:
-            typer.echo(f"HTTP {e.code}: {e.reason}")
-            raise typer.Exit(1)
-        except error.URLError as e:
-            typer.echo(f"Connection error: {e.reason}")
+            rows = request_json(
+                "GET",
+                url,
+                timeout=DEFAULT_TIMEOUT,
+                session=get_shared_session(),
+            )
+        except Exception as exc:
+            typer.echo(f"Connection error: {exc}")
             raise typer.Exit(1)
         table = pl.DataFrame(rows)
         if "metrics" in table.columns:
@@ -393,16 +383,14 @@ def list_runs(
         params["status"] = status.value
     url = "http://127.0.0.1:8000/runs?" + parse.urlencode(params)
     try:
-        with request.urlopen(url) as resp:
-            if resp.status != 200:
-                typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                raise typer.Exit(1)
-            runs = json.loads(resp.read().decode())
-    except error.HTTPError as e:
-        typer.echo(f"HTTP {e.code}: {e.reason}")
-        raise typer.Exit(1)
-    except error.URLError as e:
-        typer.echo(f"Connection error: {e.reason}")
+        runs = request_json(
+            "GET",
+            url,
+            timeout=DEFAULT_TIMEOUT,
+            session=get_shared_session(),
+        )
+    except Exception as exc:
+        typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
     header = "run_id | status | objective | started_at | finished_at"
     typer.echo(header)
@@ -418,16 +406,14 @@ def show_run(run_id: str) -> None:
 
     url = f"http://127.0.0.1:8000/runs/{run_id}"
     try:
-        with request.urlopen(url) as resp:
-            if resp.status != 200:
-                typer.echo(f"HTTP {resp.status}: {resp.reason}")
-                raise typer.Exit(1)
-            detail = json.loads(resp.read().decode())
-    except error.HTTPError as e:
-        typer.echo(f"HTTP {e.code}: {e.reason}")
-        raise typer.Exit(1)
-    except error.URLError as e:
-        typer.echo(f"Connection error: {e.reason}")
+        detail = request_json(
+            "GET",
+            url,
+            timeout=DEFAULT_TIMEOUT,
+            session=get_shared_session(),
+        )
+    except Exception as exc:
+        typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
 
     run = detail.get("run", {})

--- a/src/quant_engine/http_client.py
+++ b/src/quant_engine/http_client.py
@@ -1,0 +1,68 @@
+"""Shared HTTP client configuration with retries/backoff and pooling."""
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_CONNECT_TIMEOUT = float(os.getenv("QE_HTTP_CONNECT_TIMEOUT", "3.0"))
+DEFAULT_READ_TIMEOUT = float(os.getenv("QE_HTTP_READ_TIMEOUT", "10.0"))
+DEFAULT_TIMEOUT = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
+DEFAULT_RETRIES = int(os.getenv("QE_HTTP_RETRIES", "3"))
+DEFAULT_BACKOFF = float(os.getenv("QE_HTTP_BACKOFF", "0.4"))
+DEFAULT_POOL_CONNECTIONS = int(os.getenv("QE_HTTP_POOL_CONNECTIONS", "10"))
+DEFAULT_POOL_MAXSIZE = int(os.getenv("QE_HTTP_POOL_MAXSIZE", "10"))
+
+_SESSION: Optional[requests.Session] = None
+
+
+def _build_retry() -> Retry:
+    return Retry(
+        total=DEFAULT_RETRIES,
+        connect=DEFAULT_RETRIES,
+        read=DEFAULT_RETRIES,
+        status=DEFAULT_RETRIES,
+        backoff_factor=DEFAULT_BACKOFF,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
+        raise_on_status=False,
+    )
+
+
+def get_shared_session() -> requests.Session:
+    """Return a pooled session configured with retries and backoff."""
+
+    global _SESSION
+    if _SESSION is None:
+        session = requests.Session()
+        adapter = HTTPAdapter(
+            max_retries=_build_retry(),
+            pool_connections=DEFAULT_POOL_CONNECTIONS,
+            pool_maxsize=DEFAULT_POOL_MAXSIZE,
+        )
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        _SESSION = session
+    return _SESSION
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    timeout: Optional[float | tuple[float, float]] = None,
+    session: Optional[requests.Session] = None,
+    **kwargs: Any,
+) -> Any:
+    """Issue an HTTP request and return the parsed JSON payload."""
+
+    http = session or get_shared_session()
+    response = http.request(method, url, timeout=timeout or DEFAULT_TIMEOUT, **kwargs)
+    response.raise_for_status()
+    if not response.content:
+        return None
+    return response.json()
+

--- a/src/quant_engine/integrations/java_client.py
+++ b/src/quant_engine/integrations/java_client.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
-import requests
+from ..http_client import DEFAULT_TIMEOUT, get_shared_session, request_json
 
 BASE_URL = os.getenv("QE_JAVA_BASE_URL", "http://localhost:8090")
 
@@ -49,18 +49,16 @@ def get_scan(endpoint: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Fetch a scan payload from the Java backend using ``GET``."""
 
     url = BASE_URL + endpoint
-    resp = requests.get(url, params=params, timeout=5)
-    resp.raise_for_status()
-    return resp.json()
+    session = get_shared_session()
+    return request_json("GET", url, params=params, session=session)
 
 
 def get_market_scan(scan_type: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Fetch one of the supported market scans exposed by the Java backend."""
 
     url = BASE_URL + f"/api/market/scans/{scan_type}"
-    resp = requests.get(url, params=params, timeout=5)
-    resp.raise_for_status()
-    return resp.json()
+    session = get_shared_session()
+    return request_json("GET", url, params=params, session=session)
 
 
 def get_ohlc(
@@ -79,6 +77,7 @@ def get_ohlc(
     if start_dt and end_dt and end_dt > start_dt:
         results: List[Dict[str, Any]] = []
         current = start_dt
+        session = get_shared_session()
         while current < end_dt:
             chunk_end = min(current + timedelta(days=365), end_dt)
             params = {
@@ -86,17 +85,22 @@ def get_ohlc(
                 "start": current.isoformat().replace("+00:00", "Z"),
                 "end": chunk_end.isoformat().replace("+00:00", "Z"),
             }
-            resp = requests.get(url, params=params, timeout=10)
-            resp.raise_for_status()
-            results.extend(resp.json())
+            chunk = request_json(
+                "GET",
+                url,
+                params=params,
+                session=session,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            if chunk:
+                results.extend(chunk)
             current = chunk_end
         return results
 
     # Fallback single request when dates are missing or unparsable.
     params = {**base_params, "start": start_iso, "end": end_iso}
-    resp = requests.get(url, params=params, timeout=10)
-    resp.raise_for_status()
-    return resp.json()
+    session = get_shared_session()
+    return request_json("GET", url, params=params, session=session, timeout=DEFAULT_TIMEOUT)
 
 
 def request_historical_ingestion(
@@ -112,9 +116,8 @@ def request_historical_ingestion(
         "start": start,
         "end": end,
     }
-    resp = requests.post(url, json=payload, timeout=10)
-    resp.raise_for_status()
-    return resp.json()
+    session = get_shared_session()
+    return request_json("POST", url, json=payload, session=session, timeout=DEFAULT_TIMEOUT)
 
 
 def get_positions() -> List[Dict[str, Any]]:
@@ -122,8 +125,9 @@ def get_positions() -> List[Dict[str, Any]]:
 
     url = BASE_URL + "/api/portfolio/positions"
     try:
-        resp = requests.get(url, timeout=5)
-        if resp.status_code == 200:
+        session = get_shared_session()
+        resp = session.get(url, timeout=DEFAULT_TIMEOUT)
+        if resp.status_code == 200 and resp.content:
             return resp.json()
     except Exception:
         pass


### PR DESCRIPTION
### Motivation

- Improve network resilience for Java backend and CLI calls by adding timeouts, retries and exponential backoff. 
- Reduce connection churn by reusing a pooled HTTP session across the codebase. 
- Centralise HTTP configuration so resilience tuning is possible via environment variables.

### Description

- Add `src/quant_engine/http_client.py` which exposes `get_shared_session()`, `request_json()` and configurable defaults via `QE_HTTP_*` environment variables. 
- Refactor `src/quant_engine/integrations/java_client.py` to use the shared session and `request_json()` for all backend requests and to stream chunked OHLC requests through the pooled client. 
- Refactor `src/quant_engine/cli/main.py` to replace `urllib.request.urlopen` calls with `request_json()` and to use the shared session and unified `DEFAULT_TIMEOUT`. 
- Add `docs/http_client.md` documenting the available environment variables and retry behaviour (status codes that trigger retries and pooling rationale). 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a2b77270832380b977d38317a207)