### PR TITLE
Add TTL and metrics to OHLC/filter caches

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,49 @@
+# Cache OHLC et filtres (TTL + métriques)
+
+## Vue d'ensemble
+
+Le moteur utilise deux caches mémoire pour limiter les recalculs :
+
+1. **Cache OHLC** dans `strategies.runner` (chargement des données).
+2. **Cache des filtres** dans `filters.utils` (résultats des masques).
+
+Chaque cache est borné (LRU) et dispose d'un TTL afin d'éviter toute croissance
+illimitée. Des métriques simples (hits/misses/expirations/evictions) sont
+loguées pour faciliter le suivi.
+
+## Cache OHLC
+
+Configuration côté `data` (ou directement par instrument) :
+
+```json
+{
+  "data": {
+    "ohlc_cache": {
+      "enabled": true,
+      "ttl_seconds": 900,
+      "max_items": 256
+    }
+  }
+}
+```
+
+Alias acceptés : `cache_ohlc` ou `cache`.
+
+## Cache des filtres
+
+Configuration côté optimisation (déjà utilisée pour activer le cache) :
+
+```json
+{
+  "optimization": {
+    "cache_features": {
+      "enabled": true,
+      "ttl_seconds": 900,
+      "max_items": 2048
+    }
+  }
+}
+```
+
+Le TTL et la taille maximale peuvent être ajustés par stratégie ; sinon les
+valeurs par défaut s'appliquent.

--- a/src/quant_engine/filters/utils.py
+++ b/src/quant_engine/filters/utils.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from collections import OrderedDict
 import json
+import time
 
 import pandas as pd
 
@@ -68,8 +69,10 @@ FILTER_SUMMARIES: Dict[str, FilterSummary] = {
     "stats_gate": FilterSummary("Gate using persisted market stats.", "market_stats table"),
 }
 
-_FILTER_CACHE: "OrderedDict[tuple, pd.Series]" = OrderedDict()
+_FILTER_CACHE: "OrderedDict[tuple, tuple[pd.Series, float]]" = OrderedDict()
 _CACHE_DEFAULT_MAX = 2048
+_CACHE_DEFAULT_TTL_SECONDS = 900.0
+_FILTER_CACHE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "expirations": 0}
 
 
 def _make_cache_key(df: pd.DataFrame, flt_type: str, params: Mapping[str, Any]) -> Optional[tuple]:
@@ -83,18 +86,28 @@ def _make_cache_key(df: pd.DataFrame, flt_type: str, params: Mapping[str, Any]) 
     return (cache_key, flt_type, params_key)
 
 
-def _cache_get(key: tuple) -> Optional[pd.Series]:
-    series = _FILTER_CACHE.get(key)
-    if series is not None:
-        _FILTER_CACHE.move_to_end(key)
+def _cache_get(key: tuple, ttl_seconds: float) -> Optional[pd.Series]:
+    entry = _FILTER_CACHE.get(key)
+    if entry is None:
+        return None
+    series, created = entry
+    if ttl_seconds > 0:
+        age = time.monotonic() - created
+        if age > ttl_seconds:
+            _FILTER_CACHE.pop(key, None)
+            _FILTER_CACHE_STATS["expirations"] += 1
+            return None
+    _FILTER_CACHE.move_to_end(key)
+    _FILTER_CACHE_STATS["hits"] += 1
     return series
 
 
 def _cache_set(key: tuple, series: pd.Series, max_items: int) -> None:
-    _FILTER_CACHE[key] = series
+    _FILTER_CACHE[key] = (series, time.monotonic())
     _FILTER_CACHE.move_to_end(key)
     while len(_FILTER_CACHE) > max_items:
         _FILTER_CACHE.popitem(last=False)
+        _FILTER_CACHE_STATS["evictions"] += 1
 
 
 class FilterValidationError(ValueError):
@@ -277,10 +290,20 @@ def apply_filter_stack(
 
     mask = pd.Series(True, index=df.index)
     max_cache = df.attrs.get("qe_cache_max_items", _CACHE_DEFAULT_MAX)
+    ttl_seconds = df.attrs.get("qe_cache_ttl_seconds", _CACHE_DEFAULT_TTL_SECONDS)
     try:
         max_cache = int(max_cache)
     except Exception:
         max_cache = _CACHE_DEFAULT_MAX
+    try:
+        ttl_seconds = float(ttl_seconds)
+    except Exception:
+        ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
+    if ttl_seconds < 0:
+        ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
+
+    cache_hits = 0
+    cache_misses = 0
 
     for raw in filters:
         flt_type, params = _normalize_filter_spec(raw)
@@ -312,10 +335,12 @@ def apply_filter_stack(
 
         cache_key = _make_cache_key(df, flt_type, params)
         if cache_key is not None:
-            cached = _cache_get(cache_key)
+            cached = _cache_get(cache_key, ttl_seconds)
             if cached is not None:
                 series = cached
+                cache_hits += 1
             else:
+                cache_misses += 1
                 try:
                     series = fn(df, **params)
                 except Exception as exc:
@@ -326,6 +351,7 @@ def apply_filter_stack(
                     continue
                 if max_cache > 0:
                     _cache_set(cache_key, series, max_cache)
+                _FILTER_CACHE_STATS["misses"] += 1
         else:
             try:
                 series = fn(df, **params)
@@ -344,5 +370,15 @@ def apply_filter_stack(
             continue
 
         mask &= series.reindex(df.index).fillna(False).astype(bool)
+
+    if cache_hits or cache_misses:
+        log.info(
+            "Filter cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
+            cache_hits,
+            cache_misses,
+            _FILTER_CACHE_STATS.get("expirations", 0),
+            _FILTER_CACHE_STATS.get("evictions", 0),
+            len(_FILTER_CACHE),
+        )
 
     return mask

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -5,7 +5,9 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
@@ -33,7 +35,10 @@ except Exception:
 _WARNED_MCAL_MISSING = False
 _WARNED_MCAL_ERROR = False
 _MARKET_SCHEDULE_CACHE: Dict[tuple[str, object, object], pd.DatetimeIndex] = {}
-_OHLC_CACHE: Dict[str, pd.DataFrame] = {}
+_OHLC_CACHE: "OrderedDict[str, tuple[pd.DataFrame, float]]" = OrderedDict()
+_OHLC_CACHE_DEFAULT_MAX = 256
+_OHLC_CACHE_DEFAULT_TTL_SECONDS = 900.0
+_OHLC_CACHE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "expirations": 0}
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
@@ -99,6 +104,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
     signals_by_symbol: Dict[str, List[Dict[str, Any]]] = {}
     counts: Dict[str, int] = {}
     ohlc_by_symbol: Dict[str, pd.DataFrame] = {}
+    cache_stats_start = dict(_OHLC_CACHE_STATS)
     for instrument in universe:
         symbol = instrument.get("symbol")
         if not symbol:
@@ -148,6 +154,11 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
                 df_filter.attrs["qe_cache_key"] = cache_key
                 if "max_items" in cache_cfg:
                     df_filter.attrs["qe_cache_max_items"] = cache_cfg.get("max_items")
+                if "ttl_seconds" in cache_cfg or "ttl" in cache_cfg:
+                    df_filter.attrs["qe_cache_ttl_seconds"] = cache_cfg.get(
+                        "ttl_seconds",
+                        cache_cfg.get("ttl"),
+                    )
             try:
                 mask = apply_filter_stack(df_filter, filters_spec, symbol=symbol, logger=LOGGER, strict=True)
             except FilterValidationError as exc:
@@ -171,6 +182,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
         serialized = [_serialize_signal(sig) for sig in signals]
         signals_by_symbol[symbol] = serialized
         counts[symbol] = len(serialized)
+    _log_ohlc_cache_stats_delta(cache_stats_start)
     result = {
         "strategy_id": strategy_id,
         "strategy_type": strategy_type,
@@ -210,9 +222,12 @@ def _fetch_ohlc_for_symbol(
         sort_keys=True,
         default=str,
     )
-    cached = _OHLC_CACHE.get(cache_key)
-    if cached is not None:
-        return cached.copy()
+    cache_enabled, ttl_seconds, max_items = _resolve_ohlc_cache_settings(merged_spec)
+    if cache_enabled and max_items > 0:
+        cached = _cache_ohlc_get(cache_key, ttl_seconds)
+        if cached is not None:
+            return cached.copy()
+        _OHLC_CACHE_STATS["misses"] += 1
     source = merged_spec.get("source")
     if source == "csv":
         path = Path(merged_spec["path"])
@@ -240,8 +255,75 @@ def _fetch_ohlc_for_symbol(
     missing = required - set(df.columns)
     if missing:
         raise ValueError(f"Missing OHLC columns for {symbol}: {missing}")
-    _OHLC_CACHE[cache_key] = df.copy()
+    if cache_enabled and max_items > 0:
+        _cache_ohlc_set(cache_key, df.copy(), max_items)
     return df
+
+
+def _resolve_ohlc_cache_settings(merged_spec: Mapping[str, Any]) -> tuple[bool, float, int]:
+    cache_cfg = merged_spec.get("ohlc_cache")
+    if cache_cfg is None:
+        cache_cfg = merged_spec.get("cache_ohlc")
+    if cache_cfg is None:
+        cache_cfg = merged_spec.get("cache")
+    if not isinstance(cache_cfg, Mapping):
+        cache_cfg = {}
+    enabled = cache_cfg.get("enabled", True) is not False
+    ttl_seconds = cache_cfg.get("ttl_seconds", cache_cfg.get("ttl", _OHLC_CACHE_DEFAULT_TTL_SECONDS))
+    max_items = cache_cfg.get("max_items", _OHLC_CACHE_DEFAULT_MAX)
+    try:
+        ttl_seconds = float(ttl_seconds)
+    except Exception:
+        ttl_seconds = _OHLC_CACHE_DEFAULT_TTL_SECONDS
+    try:
+        max_items = int(max_items)
+    except Exception:
+        max_items = _OHLC_CACHE_DEFAULT_MAX
+    if max_items <= 0:
+        enabled = False
+    if ttl_seconds <= 0:
+        ttl_seconds = 0.0
+    return enabled, ttl_seconds, max_items
+
+
+def _cache_ohlc_get(cache_key: str, ttl_seconds: float) -> Optional[pd.DataFrame]:
+    entry = _OHLC_CACHE.get(cache_key)
+    if entry is None:
+        return None
+    df, created = entry
+    if ttl_seconds > 0:
+        age = time.monotonic() - created
+        if age > ttl_seconds:
+            _OHLC_CACHE.pop(cache_key, None)
+            _OHLC_CACHE_STATS["expirations"] += 1
+            return None
+    _OHLC_CACHE.move_to_end(cache_key)
+    _OHLC_CACHE_STATS["hits"] += 1
+    return df
+
+
+def _cache_ohlc_set(cache_key: str, df: pd.DataFrame, max_items: int) -> None:
+    _OHLC_CACHE[cache_key] = (df, time.monotonic())
+    _OHLC_CACHE.move_to_end(cache_key)
+    while len(_OHLC_CACHE) > max_items:
+        _OHLC_CACHE.popitem(last=False)
+        _OHLC_CACHE_STATS["evictions"] += 1
+
+
+def _log_ohlc_cache_stats_delta(start_stats: Mapping[str, int]) -> None:
+    delta = {
+        key: _OHLC_CACHE_STATS.get(key, 0) - start_stats.get(key, 0)
+        for key in _OHLC_CACHE_STATS
+    }
+    if any(value > 0 for value in delta.values()):
+        LOGGER.info(
+            "OHLC cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
+            delta.get("hits", 0),
+            delta.get("misses", 0),
+            delta.get("expirations", 0),
+            delta.get("evictions", 0),
+            len(_OHLC_CACHE),
+        )
 
 
 def _build_delta_storage_options() -> Dict[str, Any]:


### PR DESCRIPTION
### Motivation

- Prevent unbounded memory growth by making in-memory OHLC and filter caches size-bounded and TTL-aware.
- Improve observability by recording simple cache metrics (hits/misses/expirations/evictions) and logging them per run.
- Allow per-strategy configuration of cache TTL and max items so caching behavior can be tuned.
- Make filter caching safer by expiring stale entries and moving to an LRU eviction policy.

### Description

- Introduce an LRU + TTL OHLC cache in `src/quant_engine/strategies/runner.py` implemented with `OrderedDict`, and add `_resolve_ohlc_cache_settings`, `_cache_ohlc_get`, `_cache_ohlc_set`, and `_log_ohlc_cache_stats_delta` helpers, plus `_OHLC_CACHE_STATS` for metrics and defaults `(_OHLC_CACHE_DEFAULT_MAX`, `_OHLC_CACHE_DEFAULT_TTL_SECONDS)`.
- Wire per-instrument/`data` cache config (aliases `ohlc_cache`, `cache_ohlc`, `cache`) to enable/disable the OHLC cache and control `ttl_seconds` and `max_items` via `_resolve_ohlc_cache_settings`.
- Extend the existing filter cache in `src/quant_engine/filters/utils.py` to store timestamps, support TTL checks on lookup, count hits/misses/expirations/evictions in `_FILTER_CACHE_STATS`, and log per-apply stats; add `_CACHE_DEFAULT_TTL_SECONDS` and pass TTL from `df.attrs['qe_cache_ttl_seconds']`.
- Add short documentation `docs/cache.md` describing cache knobs and defaults and examples for configuring OHLC and filter cache TTL/max size.

### Testing

- No automated tests were run for these changes.
- Changes were small, localized, and covered by existing function call flows during manual verification in the rollout, but no CI/unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a2ce27008323ae7527d01a73b031)