### PR TITLE
Add paginated batching for level fills

### DIFF
--- a/docs/levels_overview.md
+++ b/docs/levels_overview.md
@@ -80,6 +80,8 @@ et `touched_level_since`, en chargeant automatiquement les levels persistes depu
 - Chaque ligne porte un `uniq_hash` deterministe (SHA-256) base sur `symbol`,
   `level_type`, `timeframe`, prix arrondis, `anchor_ts`, `valid_from_ts` optionnel
   et `params_hash`. L'index unique assure l'idempotence.
+- Les refresh `fill` parcourent les niveaux actifs en lots (pagination keyset)
+  pour eviter des limites fixes et garantir la scalabilite sur de gros univers.
 - Index b-tree additionnels sur `(symbol, level_type, anchor_ts)` et
   `(symbol, valid_from_ts, valid_to_ts)` pour accelerer les scans, overlays et
   checks de validite.

--- a/src/quant_engine/levels/repo.py
+++ b/src/quant_engine/levels/repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from hashlib import sha256
-from typing import Iterable, List, Optional
+from typing import Iterable, Iterator, List, Optional, Tuple
 
 import pandas as pd
 from sqlalchemy import create_engine, text
@@ -299,6 +299,71 @@ def select_levels(
     return pd.DataFrame(records)
 
 
+def iter_levels(
+    engine: Engine,
+    table_fqn: str,
+    symbol: str,
+    level_types: List[str],
+    active_only: bool,
+    start: Optional[str | datetime] = None,
+    end: Optional[str | datetime] = None,
+    batch_size: int = 5000,
+) -> Iterator[pd.DataFrame]:
+    """Yield levels in batches using keyset pagination."""
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    clauses = ["symbol = :symbol"]
+    params: dict = {"symbol": symbol, "limit": batch_size}
+    if level_types:
+        placeholders = ",".join(f":lt{i}" for i in range(len(level_types)))
+        clauses.append(f"level_type IN ({placeholders})")
+        params.update({f"lt{i}": lvl for i, lvl in enumerate(level_types)})
+    if active_only:
+        clauses.append("valid_to_ts IS NULL")
+    start_norm = _parse_optional_ts(start)
+    if start_norm is not None:
+        clauses.append("anchor_ts >= :start")
+        params["start"] = start_norm
+    end_norm = _parse_optional_ts(end)
+    if end_norm is not None:
+        clauses.append("anchor_ts <= :end")
+        params["end"] = end_norm
+
+    cursor: Optional[Tuple[datetime, int]] = None
+    with engine.connect() as conn:
+        while True:
+            batch_clauses = list(clauses)
+            if cursor is not None:
+                params["cursor_anchor"] = cursor[0]
+                params["cursor_id"] = cursor[1]
+                batch_clauses.append(
+                    "(anchor_ts < :cursor_anchor OR (anchor_ts = :cursor_anchor AND id < :cursor_id))"
+                )
+            query = (
+                f"SELECT id, symbol, timeframe, level_type, price, price_lo, price_hi, anchor_ts, "
+                f"valid_from_ts, valid_to_ts, params_hash FROM {table_fqn} "
+                "WHERE " + " AND ".join(batch_clauses) + " ORDER BY anchor_ts DESC, id DESC LIMIT :limit"
+            )
+            rows = conn.execute(text(query), params).fetchall()
+            if not rows:
+                break
+            records: List[dict] = []
+            for row in rows:
+                if hasattr(row, "_mapping"):
+                    records.append(dict(row._mapping))
+                elif hasattr(row, "keys"):
+                    records.append(dict(zip(row.keys(), row)))
+                else:  # pragma: no cover - defensive fallback
+                    records.append(dict(row))
+            batch = pd.DataFrame(records)
+            cursor = (
+                _ensure_datetime(batch["anchor_ts"].iloc[-1]),  # type: ignore[arg-type]
+                int(batch["id"].iloc[-1]),
+            )
+            yield batch.drop(columns=["id"])
+
+
 def upsert_valid_to_ts(engine: Engine, table_fqn: str, df_updates: pd.DataFrame) -> int:
     """Update ``valid_to_ts`` for the specified rows and return affected count."""
 
@@ -340,5 +405,6 @@ __all__ = [
     "ensure_table",
     "upsert_levels",
     "select_levels",
+    "iter_levels",
     "upsert_valid_to_ts",
 ]

--- a/src/quant_engine/levels/runner.py
+++ b/src/quant_engine/levels/runner.py
@@ -8,7 +8,7 @@ import pandas as pd
 from ..core.dataset import load_ohlcv
 from .builders import build_levels
 from .detectors import fill_fvgs, fill_gaps
-from .repo import ensure_table, get_engine, select_levels, upsert_levels, upsert_valid_to_ts
+from .repo import ensure_table, get_engine, iter_levels, upsert_levels, upsert_valid_to_ts
 from .schemas import LevelsBuildSpec
 
 
@@ -60,7 +60,7 @@ def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
             level_types.extend(["GAP_D", "GAP_W"])
         if not level_types:
             continue
-        levels = select_levels(
+        for levels in iter_levels(
             engine,
             table_fqn,
             symbol=symbol,
@@ -68,25 +68,24 @@ def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
             active_only=True,
             start=spec.range_start,
             end=spec.range_end,
-            limit=10000,
-        )
-        if levels.empty:
-            continue
-        total_checked += int(len(levels))
-        if do_fill_fvg:
-            fvgs_active = levels[levels["level_type"] == "FVG"]
-            if not fvgs_active.empty:
-                fvgs_filled = fill_fvgs(sym_df, fvgs_active)
-                fvgs_updates = fvgs_filled[fvgs_filled["valid_to_ts"].notna()]
-                if not fvgs_updates.empty:
-                    pending_updates.append(fvgs_updates)
-        if do_fill_gap:
-            gaps_active = levels[levels["level_type"].isin(["GAP_D", "GAP_W"])]
-            if not gaps_active.empty:
-                gaps_filled = fill_gaps(sym_df, gaps_active)
-                gaps_updates = gaps_filled[gaps_filled["valid_to_ts"].notna()]
-                if not gaps_updates.empty:
-                    pending_updates.append(gaps_updates)
+        ):
+            if levels.empty:
+                continue
+            total_checked += int(len(levels))
+            if do_fill_fvg:
+                fvgs_active = levels[levels["level_type"] == "FVG"]
+                if not fvgs_active.empty:
+                    fvgs_filled = fill_fvgs(sym_df, fvgs_active)
+                    fvgs_updates = fvgs_filled[fvgs_filled["valid_to_ts"].notna()]
+                    if not fvgs_updates.empty:
+                        pending_updates.append(fvgs_updates)
+            if do_fill_gap:
+                gaps_active = levels[levels["level_type"].isin(["GAP_D", "GAP_W"])]
+                if not gaps_active.empty:
+                    gaps_filled = fill_gaps(sym_df, gaps_active)
+                    gaps_updates = gaps_filled[gaps_filled["valid_to_ts"].notna()]
+                    if not gaps_updates.empty:
+                        pending_updates.append(gaps_updates)
     if pending_updates:
         updates_df = pd.concat(pending_updates, ignore_index=True)
         updated_count = upsert_valid_to_ts(engine, table_fqn, updates_df)


### PR DESCRIPTION
### Motivation
- Avoid scanning large result sets with a fixed `limit` (e.g. 10000) when refreshing `valid_to_ts` for active levels to improve scalability. 
- Enable robust, memory-safe processing of levels across large symbol universes by fetching rows in batches. 
- Use deterministic ordering to ensure no rows are skipped or duplicated during pagination. 

### Description
- Added a keyset-paginated iterator `iter_levels` in `src/quant_engine/levels/repo.py` that pages by `(anchor_ts, id)` and yields `pandas.DataFrame` batches. 
- Refactored the fill runner `run_levels_fill` in `src/quant_engine/levels/runner.py` to consume active levels via `iter_levels` instead of a fixed `limit` query. 
- Input validation for `batch_size` and safe cursor advancement are implemented, and the iterator drops the internal `id` column before yielding. 
- Documented the batched fill behavior in `docs/levels_overview.md`. 

### Testing
- No automated tests were executed as part of this change. 
- Basic local inspection and commits were performed; further CI or unit tests are recommended to validate behavior against real MySQL instances and large tables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a319c8c883238f182d3a32e67b9f)