### PR TITLE
Normalize backtest metrics with timeframe-aware annualization and RF handling

### DIFF
--- a/docs/backtest_metrics.md
+++ b/docs/backtest_metrics.md
@@ -1,0 +1,12 @@
+# Backtest metrics normalization
+
+Les métriques de backtest sont normalisées pour être comparables entre périodes et timeframes. Les ratios de risque (volatilité, Sharpe, Sortino) sont annualisés à partir des rendements périodiques dérivés de la courbe d'équité et du timeframe.
+
+## Paramètres utiles
+
+Le bloc `performance` d'un run peut accepter :
+
+- `risk_free_rate` : taux sans risque annualisé (exprimé en décimal, ex. `0.02` pour 2%).
+- `risk_free_pct` : taux sans risque annualisé en pourcentage (ex. `2.0`).
+
+Si le timeframe est fourni, l'annualisation utilise un nombre de périodes par an cohérent avec l'asset class (crypto 24/7, actions ~252 jours de bourse). Si le timeframe est absent, l'annualisation est déduite de la durée du backtest.

--- a/src/quant_engine/performance/backtest_builder.py
+++ b/src/quant_engine/performance/backtest_builder.py
@@ -1,7 +1,13 @@
-"""Build performance payloads for classic backtests."""
+"""Build performance payloads for classic backtests.
+
+Backtest metrics are normalized to be comparable across timeframes by
+annualizing risk metrics and applying a configurable risk-free rate.
+"""
 from __future__ import annotations
 
 from datetime import datetime
+import math
+import re
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 import pandas as pd
@@ -27,6 +33,89 @@ def _equity_value_curve(equity: Iterable[float], initial_capital: float) -> List
     return values
 
 
+def _parse_timeframe(timeframe: Optional[str]) -> Optional[Tuple[int, str]]:
+    if not timeframe:
+        return None
+    raw = str(timeframe).strip()
+    if not raw:
+        return None
+
+    match = re.match(r"^(?P<num>\d+)\s*(?P<unit>[A-Za-z]+)$", raw)
+    if not match:
+        match = re.match(r"^(?P<unit>[A-Za-z]+)\s*(?P<num>\d+)$", raw)
+    if not match:
+        return None
+
+    value = int(match.group("num"))
+    unit_raw = match.group("unit")
+    unit_lower = unit_raw.lower()
+
+    if unit_raw == "M" or unit_lower in {"mo", "mon", "month", "months"}:
+        unit = "mo"
+    elif unit_raw == "m" or unit_lower in {"min", "mins", "minute", "minutes"}:
+        unit = "m"
+    elif unit_lower in {"s", "sec", "secs", "second", "seconds"}:
+        unit = "s"
+    elif unit_lower in {"h", "hr", "hrs", "hour", "hours"}:
+        unit = "h"
+    elif unit_lower in {"d", "day", "days"}:
+        unit = "d"
+    elif unit_lower in {"w", "wk", "wks", "week", "weeks"}:
+        unit = "w"
+    elif unit_lower in {"y", "yr", "yrs", "year", "years"}:
+        unit = "y"
+    else:
+        return None
+
+    if value <= 0:
+        return None
+    return value, unit
+
+
+def _periods_per_year(
+    *,
+    timeframe: Optional[str],
+    asset_class: str,
+    start_ts: Optional[datetime],
+    end_ts: Optional[datetime],
+    periods_count: int,
+) -> Optional[float]:
+    parsed = _parse_timeframe(timeframe)
+    is_crypto = asset_class.upper() == "CRYPTO"
+
+    if parsed:
+        value, unit = parsed
+        if is_crypto:
+            days_per_year = 365.0
+            hours_per_year = days_per_year * 24.0
+        else:
+            days_per_year = 252.0
+            hours_per_year = days_per_year * 6.5
+        minutes_per_year = hours_per_year * 60.0
+        seconds_per_year = minutes_per_year * 60.0
+
+        base_map = {
+            "s": seconds_per_year,
+            "m": minutes_per_year,
+            "h": hours_per_year,
+            "d": days_per_year,
+            "w": 52.0,
+            "mo": 12.0,
+            "y": 1.0,
+        }
+        base = base_map.get(unit)
+        if base:
+            return base / float(value)
+
+    if start_ts and end_ts and periods_count > 1:
+        duration = (end_ts - start_ts).total_seconds()
+        if duration > 0:
+            years = duration / (365.25 * 24 * 60 * 60)
+            if years > 0:
+                return periods_count / years
+    return None
+
+
 def build_backtest_performance(
     *,
     strategy_id: str,
@@ -42,6 +131,8 @@ def build_backtest_performance(
 ) -> Tuple[StrategyRunResult, List[CompletedTrade]]:
     config = config or {}
     initial_capital = float(config.get("initial_capital", 10_000.0))
+    start_dt = _maybe_dt(start_ts)
+    end_dt = _maybe_dt(end_ts)
 
     completed: List[CompletedTrade] = []
     returns_pct: List[float] = []
@@ -65,8 +156,8 @@ def build_backtest_performance(
                 asset_class=asset_class,
                 side=str(tr.get("side") or "LONG").upper(),
                 cycle_id=None,
-                entry_time_utc=entry_time or _maybe_dt(start_ts) or datetime.utcnow(),
-                exit_time_utc=exit_time or _maybe_dt(end_ts) or datetime.utcnow(),
+                entry_time_utc=entry_time or start_dt or datetime.utcnow(),
+                exit_time_utc=exit_time or end_dt or datetime.utcnow(),
                 entry_price=entry_price,
                 exit_price=exit_price,
                 quantity=quantity,
@@ -86,6 +177,11 @@ def build_backtest_performance(
     equity_values = _equity_value_curve(equity, initial_capital)
     final_capital = equity_values[-1] if equity_values else initial_capital
     return_pct = ((final_capital - initial_capital) / initial_capital * 100.0) if initial_capital else None
+    cagr_pct = None
+    if start_dt and end_dt and end_dt > start_dt and initial_capital > 0:
+        years = (end_dt - start_dt).total_seconds() / (365.25 * 24 * 60 * 60)
+        if years > 0:
+            cagr_pct = ((final_capital / initial_capital) ** (1 / years) - 1) * 100.0
 
     max_drawdown = 0.0
     max_drawdown_pct = None
@@ -98,18 +194,56 @@ def build_backtest_performance(
         max_drawdown = max_dd_val
         max_drawdown_pct = (max_dd_val / peak * 100.0) if peak else None
 
-    volatility_pct = float(pd.Series(returns_pct).std(ddof=0)) if returns_pct else None
-    mean_ret = float(pd.Series(returns_pct).mean()) if returns_pct else None
+    periodic_returns: List[float] = []
+    if len(equity_values) > 1:
+        prev = equity_values[0]
+        for val in equity_values[1:]:
+            if prev != 0:
+                periodic_returns.append((val - prev) / prev)
+            else:
+                periodic_returns.append(0.0)
+            prev = val
+
+    periods_per_year = _periods_per_year(
+        timeframe=timeframe,
+        asset_class=asset_class,
+        start_ts=start_dt,
+        end_ts=end_dt,
+        periods_count=len(periodic_returns),
+    )
+    risk_free_rate = config.get("risk_free_rate")
+    if risk_free_rate is None:
+        risk_free_pct = config.get("risk_free_pct")
+        risk_free_rate = (float(risk_free_pct) / 100.0) if risk_free_pct is not None else 0.0
+    else:
+        risk_free_rate = float(risk_free_rate)
+
+    volatility_pct = None
     sharpe = None
     sortino = None
-    if volatility_pct and volatility_pct != 0 and mean_ret is not None:
-        sharpe = mean_ret / volatility_pct * (len(returns_pct) ** 0.5)
-    if returns_pct:
-        downside = pd.Series([r for r in returns_pct if r < 0])
-        if not downside.empty:
-            downside_std = float(downside.std(ddof=0))
-            if downside_std:
-                sortino = mean_ret / downside_std * (len(returns_pct) ** 0.5) if mean_ret is not None else None
+    mean_ret = None
+    if periodic_returns:
+        returns_series = pd.Series(periodic_returns)
+        mean_ret = float(returns_series.mean())
+        std = float(returns_series.std(ddof=0))
+        if periods_per_year and std:
+            rf_period = (1 + risk_free_rate) ** (1 / periods_per_year) - 1 if periods_per_year > 0 else 0.0
+            volatility_pct = std * math.sqrt(periods_per_year) * 100.0
+            sharpe = (mean_ret - rf_period) / std * math.sqrt(periods_per_year)
+
+            downside = returns_series[returns_series < 0]
+            if not downside.empty:
+                downside_std = float(downside.std(ddof=0))
+                if downside_std:
+                    sortino = (mean_ret - rf_period) / downside_std * math.sqrt(periods_per_year)
+        elif std:
+            volatility_pct = std * 100.0
+            sharpe = mean_ret / std
+            downside = returns_series[returns_series < 0]
+            if not downside.empty:
+                downside_std = float(downside.std(ddof=0))
+                if downside_std:
+                    sortino = mean_ret / downside_std
 
     rr_moyen = None
     win_vals = [r for r in returns_pct if r > 0]
@@ -125,8 +259,8 @@ def build_backtest_performance(
         timeframe=timeframe,
         symbol=symbol,
         compared_symbol=None,
-        start_ts_utc=_maybe_dt(start_ts) or datetime.utcnow(),
-        end_ts_utc=_maybe_dt(end_ts) or datetime.utcnow(),
+        start_ts_utc=start_dt or datetime.utcnow(),
+        end_ts_utc=end_dt or datetime.utcnow(),
         win_count=win_count,
         loss_count=loss_count,
         total_return=total_return,
@@ -147,7 +281,12 @@ def build_backtest_performance(
         sharpe=sharpe,
         sortino=sortino,
         winrate_pct=(win_count / nb_trades * 100.0) if nb_trades else None,
-        extra={"note": "Backtest performance computed from pct returns."},
+        extra={
+            "note": "Backtest performance normalized with timeframe-aware annualization.",
+            "periods_per_year": periods_per_year,
+            "risk_free_rate": risk_free_rate,
+            "cagr_pct": cagr_pct,
+        },
     )
     return run, completed
 


### PR DESCRIPTION
### Motivation

- Make backtest performance metrics comparable across different timeframes and asset classes by annualizing risk metrics and accounting for a configurable risk-free rate. 
- Provide CAGR and normalization metadata so consumers can understand how ratios were annualized.

### Description

- Added timeframe parsing via `_parse_timeframe` and periods-per-year inference via `_periods_per_year` to support timeframe- and asset-class-aware annualization. 
- Derived periodic returns from the equity value curve and compute `periods_per_year`, supporting fallback estimation from `start_ts`/`end_ts` when timeframe is absent. 
- Support `risk_free_rate` (decimal) and `risk_free_pct` (percent) in the `performance` config and apply the per-period risk-free rate when computing annualized Sharpe and Sortino. 
- Annualize volatility, Sharpe and Sortino when `periods_per_year` is available, compute `cagr_pct` from `start_ts`/`end_ts`, and attach `periods_per_year`, `risk_free_rate`, and `cagr_pct` to the run `extra` metadata. 
- Use normalized `start_dt`/`end_dt` for trade timestamps and updated module docstring and added `docs/backtest_metrics.md` explaining the normalization parameters.

### Testing

- No automated tests were executed as part of this change (none were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d4ab31d88323b3f335b7c2be3178)