### PR TITLE
Guard ATR TP/SL edge cases in backtests

### DIFF
--- a/src/quant_engine/backtest/engine.py
+++ b/src/quant_engine/backtest/engine.py
@@ -77,9 +77,16 @@ def run(
         if position == 0 and signal == 1:
             entry_price = nxt["open"] * (1 + cost_rate)
             entry_ts = nxt["timestamp"]
-            stop_price, sl_distance = StopInitializer.fixed_atr(
+            stop_data = StopInitializer.fixed_atr(
                 atr_values, atr_mult, 1, i + 1, entry_price
             )
+            if stop_data is None:
+                logger.debug(
+                    "Skipping entry at idx=%d: missing/invalid ATR stop inputs.",
+                    i + 1,
+                )
+                continue
+            stop_price, sl_distance = stop_data
             tp_price = TakeProfit.r_multiple(entry_price, stop_price, r_mult, 1)
             position = 1
         elif position == 1:

--- a/src/quant_engine/tpsl/rules.py
+++ b/src/quant_engine/tpsl/rules.py
@@ -1,12 +1,19 @@
 """Modular stop-loss and take-profit helpers."""
 from __future__ import annotations
 
-from typing import List
+from math import isfinite
+from typing import List, Optional, Tuple
 
 
 class StopInitializer:
     @staticmethod
-    def fixed_atr(atr_values: List[float], atr_mult: float, side: int, idx: int, entry_price: float) -> tuple[float, float]:
+    def fixed_atr(
+        atr_values: List[float],
+        atr_mult: float,
+        side: int,
+        idx: int,
+        entry_price: float,
+    ) -> Optional[Tuple[float, float]]:
         """Return stop price and distance based on ATR.
 
         Parameters
@@ -17,7 +24,22 @@ class StopInitializer:
         idx: index of the entry bar in ``atr_values``.
         entry_price: execution price of the trade.
         """
-        dist = atr_values[idx] * atr_mult
+        if idx < 0 or idx >= len(atr_values):
+            return None
+        atr = atr_values[idx]
+        if atr is None:
+            return None
+        try:
+            atr_value = float(atr)
+        except (TypeError, ValueError):
+            return None
+        if not isfinite(atr_value) or atr_value <= 0:
+            return None
+        if not isfinite(atr_mult) or atr_mult <= 0:
+            return None
+        dist = atr_value * atr_mult
+        if not isfinite(dist) or dist <= 0:
+            return None
         if side > 0:
             stop = entry_price - dist
         else:

--- a/tests/test_backtest_engine_tpsl_edge_cases.py
+++ b/tests/test_backtest_engine_tpsl_edge_cases.py
@@ -1,0 +1,65 @@
+from quant_engine.backtest import engine
+
+
+def test_backtest_engine_skips_entry_when_atr_index_missing():
+    dataset = [
+        {
+            "timestamp": "2020-01-01",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 102.0,
+        },
+        {
+            "timestamp": "2020-01-02",
+            "open": 110.0,
+            "high": 112.0,
+            "low": 108.0,
+            "close": 111.0,
+        },
+        {
+            "timestamp": "2020-01-03",
+            "open": 120.0,
+            "high": 125.0,
+            "low": 115.0,
+            "close": 122.0,
+        },
+    ]
+    signals = [1, 0, 0]
+    atr_values = [1.0]
+
+    trades, _, _ = engine.run(dataset, signals, atr_values, atr_mult=1.0, r_mult=1.0)
+
+    assert trades == []
+
+
+def test_backtest_engine_skips_entry_when_atr_is_nan():
+    dataset = [
+        {
+            "timestamp": "2020-01-01",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 102.0,
+        },
+        {
+            "timestamp": "2020-01-02",
+            "open": 110.0,
+            "high": 112.0,
+            "low": 108.0,
+            "close": 111.0,
+        },
+        {
+            "timestamp": "2020-01-03",
+            "open": 120.0,
+            "high": 125.0,
+            "low": 115.0,
+            "close": 122.0,
+        },
+    ]
+    signals = [1, 0, 0]
+    atr_values = [1.0, float("nan"), 1.0]
+
+    trades, _, _ = engine.run(dataset, signals, atr_values, atr_mult=1.0, r_mult=1.0)
+
+    assert trades == []


### PR DESCRIPTION
### Motivation

- Prevent crashes and invalid stop/take-profit computation when ATR is missing, NaN, non-finite, <= 0, or when the ATR index is out of range at the start of a series.
- Avoid silent failures that could create invalid stops or raise exceptions inside the backtest engine during entry initialization.
- Make TP/SL initialization and backtest entry logic more defensive so strategies are safe on short or incomplete ATR series.

### Description

- Updated `StopInitializer.fixed_atr` in `src/quant_engine/tpsl/rules.py` to validate `idx`, the ATR value and `atr_mult`, ensure values are finite and > 0, and return `None` for invalid inputs (signature changed to return `Optional[Tuple[float, float]]`).
- Updated `src/quant_engine/backtest/engine.py` to handle a `None` return from `fixed_atr`, log a debug message, and skip opening the position instead of creating an invalid stop/tp.
- Added regression tests `tests/test_backtest_engine_tpsl_edge_cases.py` with two tests asserting that entries are skipped when the ATR index is missing or when the ATR value is `NaN`.

### Testing

- Ran `pytest -k "tpsl_edge_cases"`, but collection failed due to an unrelated test (`tests/test_api_http_contract.py`) raising `TypeError: Client.__init__() got an unexpected keyword argument 'app'`, so the new tests could not be executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d60e55308323858252551003467e)