### PR TITLE
Add SQLite schema migration tracking

### DIFF
--- a/docs/persistence_migrations.md
+++ b/docs/persistence_migrations.md
@@ -1,0 +1,21 @@
+# Persistence migrations
+
+The SQLite persistence layer now keeps schema versions in a lightweight
+`schema_migrations` table. Each migration is a small Python function registered
+in `src/quant_engine/persistence/db.py` and applied automatically when a
+connection is opened via `init_db`/`session`.
+
+## How it works
+
+- `migrate()` ensures the `schema_migrations` table exists.
+- Each migration has a numeric version and name.
+- Pending migrations are executed in order and then recorded.
+
+## Adding a migration
+
+1. Create a new migration function (e.g. `_migration_3`).
+2. Append it to the `MIGRATIONS` list with the next version number.
+3. Keep migrations idempotent where possible (use `CREATE TABLE IF NOT EXISTS`,
+   `CREATE INDEX IF NOT EXISTS`, and guard `ALTER TABLE` with try/except).
+
+This approach avoids manual SQL upgrades and keeps the schema history explicit.

--- a/src/quant_engine/persistence/db.py
+++ b/src/quant_engine/persistence/db.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import sqlite3
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
 from ..config import get_settings
 
@@ -44,7 +45,14 @@ def connect() -> sqlite3.Connection:
     return conn
 
 
-def init_db(conn: sqlite3.Connection) -> None:
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    name: str
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migration_1(conn: sqlite3.Connection) -> None:
     cur = conn.cursor()
     cur.execute(
         """
@@ -181,7 +189,6 @@ def init_db(conn: sqlite3.Connection) -> None:
             n INTEGER,
             baseline REAL,
             lift REAL,
-            metrics TEXT,
             start TEXT,
             end TEXT,
             spec_id TEXT,
@@ -191,10 +198,6 @@ def init_db(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    try:
-        cur.execute("ALTER TABLE seasonality_profiles ADD COLUMN metrics TEXT")
-    except sqlite3.OperationalError:
-        pass
     cur.execute(
         """
         CREATE INDEX IF NOT EXISTS ix_seasonality_profiles_lookup
@@ -250,7 +253,55 @@ def init_db(conn: sqlite3.Connection) -> None:
         ON api_jobs(job_type, status)
         """
     )
+
+
+def _migration_2(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    try:
+        cur.execute("ALTER TABLE seasonality_profiles ADD COLUMN metrics TEXT")
+    except sqlite3.OperationalError:
+        pass
+
+
+MIGRATIONS = [
+    Migration(1, "initial_schema", _migration_1),
+    Migration(2, "seasonality_profiles_metrics", _migration_2),
+]
+
+
+def _ensure_migrations_table(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _ensure_migrations_table(conn)
+    cur = conn.cursor()
+    applied = {
+        row["version"]
+        for row in cur.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+    for migration in MIGRATIONS:
+        if migration.version in applied:
+            continue
+        migration.apply(conn)
+        cur.execute(
+            "INSERT INTO schema_migrations(version, name) VALUES (?, ?)",
+            (migration.version, migration.name),
+        )
     conn.commit()
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    migrate(conn)
 
 
 @contextmanager
@@ -264,4 +315,4 @@ def session() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-__all__ = ["connect", "init_db", "session"]
+__all__ = ["connect", "init_db", "migrate", "session"]


### PR DESCRIPTION
### Motivation

- Introduce automatic, versioned schema migrations for the lightweight SQLite persistence to avoid manual SQL edits during schema evolution.
- Make schema changes explicit and ordered so future upgrades can be applied safely when connections are opened via the persistence API.
- Prepare the codebase for additional schema changes while keeping the in-test sqlite fallback compatible with production intent.

### Description

- Add a `Migration` dataclass and register migrations as functions (`_migration_1`, `_migration_2`) collected in the `MIGRATIONS` list. 
- Implement `migrate()` and `_ensure_migrations_table()` to apply pending migrations and record applied versions in a `schema_migrations` table. 
- Move the previous inline schema creation into `_migration_1` and relocate the `ALTER TABLE` for `metrics` into `_migration_2`, and make `init_db()` call `migrate()`. 
- Export `migrate` in the module API and add `docs/persistence_migrations.md` documenting the mechanism and how to add new migrations. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d63fa9508323b551d3d0b0a39f3e)