### PR TITLE
Improve timezone-aware session handling

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -120,11 +120,11 @@ Ces filtres exploitent des indicateurs de tendance ou de volatilité calculés d
 ## Seasonality & Time filters
 
 ### `session_time`
-- **Sessions pré-définies (UTC)** :
-  - Asia : 23:00–07:00
-  - London : 07:00–15:00
-  - NewYork : 13:00–21:00
-- **Paramètres** : `session` (`"asia"`, `"london"`, `"newyork"`), `tz` (timezone de référence).
+- **Sessions pré-définies (locales, DST-aware)** :
+  - Asia (Tokyo) : 09:00–17:00 JST
+  - London : 08:00–16:30 Europe/London
+  - New York : 09:30–16:00 America/New_York
+- **Paramètres** : `session` (`"asia"`, `"london"`, `"newyork"`), `tz` (optionnel pour forcer la timezone).
 - **Retour** : `True` si la barre tombe dans la session choisie.
 
 ### `day_of_week`

--- a/src/quant_engine/core/dataset.py
+++ b/src/quant_engine/core/dataset.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pandas as pd
 
 from .spec import DataSpec
+from ..time_sessions import assign_session_label
 
 
 def _parse_timestamp(value: str) -> datetime:
@@ -58,16 +59,7 @@ def _coerce_date(value: str) -> date:
 
 
 def _assign_session(ts: datetime) -> str:
-    hour = ts.hour
-    if 0 <= hour < 7:
-        return "Asia"
-    if 7 <= hour < 12:
-        return "Europe"
-    if 12 <= hour < 16:
-        return "EU_US_overlap"
-    if 16 <= hour < 21:
-        return "US"
-    return "Other"
+    return assign_session_label(ts)
 
 
 def _parse_row_types(row: Dict[str, str]) -> Dict[str, Any]:

--- a/src/quant_engine/filters/time_seasonality.py
+++ b/src/quant_engine/filters/time_seasonality.py
@@ -9,7 +9,7 @@ from typing import Iterable, Literal, Optional
 
 import pandas as pd
 
-SessionName = Literal["asia", "london", "newyork"]
+from ..time_sessions import SessionName, session_time_mask
 
 
 def _ensure_datetime_index(df: pd.DataFrame) -> pd.DatetimeIndex:
@@ -21,22 +21,17 @@ def _ensure_datetime_index(df: pd.DataFrame) -> pd.DatetimeIndex:
     if idx.tz is None:
         idx = idx.tz_localize("UTC")
     return idx
+
+
 def session_time_filter(
     df: pd.DataFrame,
     session: SessionName = "london",
-    tz: str = "UTC",
+    tz: Optional[str] = None,
 ) -> pd.Series:
     """Return ``True`` when timestamps fall within the configured session."""
 
-    idx = _ensure_datetime_index(df).tz_convert(tz)
-    hours = idx.hour
-    if session == "asia":
-        mask = (hours >= 23) | (hours < 7)
-    elif session == "london":
-        mask = (hours >= 7) & (hours < 15)
-    else:  # "newyork"
-        mask = (hours >= 13) & (hours < 21)
-    return pd.Series(mask, index=df.index)
+    idx = _ensure_datetime_index(df)
+    return session_time_mask(idx, session=session, tz=tz)
 
 
 def day_of_week_filter(

--- a/src/quant_engine/filters/utils.py
+++ b/src/quant_engine/filters/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import logging
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from collections import OrderedDict
@@ -119,6 +120,19 @@ def _ensure_datetime_index(df: pd.DataFrame, errors: List[str]) -> None:
         errors.append("requires a DatetimeIndex")
 
 
+def _validate_timezone_param(params: Mapping[str, Any], errors: List[str]) -> None:
+    tz = params.get("tz")
+    if tz is None:
+        return
+    if not isinstance(tz, str):
+        errors.append("tz must be a string timezone identifier")
+        return
+    try:
+        ZoneInfo(tz)
+    except ZoneInfoNotFoundError:
+        errors.append(f"unknown timezone '{tz}'")
+
+
 def _require_columns(df: pd.DataFrame, columns: Iterable[str], errors: List[str]) -> None:
     missing = [col for col in columns if col not in df.columns]
     if missing:
@@ -186,6 +200,7 @@ def _validate_filter_inputs(
         "intraday_time",
     }:
         _ensure_datetime_index(df, errors)
+        _validate_timezone_param(params, errors)
     elif flt_type == "k_consecutive":
         use_body = params.get("use_body", True)
         _require_columns(df, ["close"], errors)

--- a/src/quant_engine/time_sessions.py
+++ b/src/quant_engine/time_sessions.py
@@ -1,0 +1,94 @@
+"""Timezone-aware trading session utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time, timezone
+from typing import Literal, Mapping, Optional
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+SessionName = Literal["asia", "london", "newyork"]
+
+
+@dataclass(frozen=True)
+class MarketSessionSpec:
+    """Describe a market session in its local timezone."""
+
+    tz: str
+    start: time
+    end: time
+
+
+MARKET_SESSIONS: Mapping[SessionName, MarketSessionSpec] = {
+    "asia": MarketSessionSpec("Asia/Tokyo", time(9, 0), time(17, 0)),
+    "london": MarketSessionSpec("Europe/London", time(8, 0), time(16, 30)),
+    "newyork": MarketSessionSpec("America/New_York", time(9, 30), time(16, 0)),
+}
+
+
+def _ensure_utc(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
+def _seconds_since_midnight(value: time) -> int:
+    return value.hour * 3600 + value.minute * 60 + value.second
+
+
+def _is_in_window(ts_utc: datetime, spec: MarketSessionSpec, tz: Optional[str] = None) -> bool:
+    tz_name = tz or spec.tz
+    local = ts_utc.astimezone(ZoneInfo(tz_name))
+    local_seconds = local.hour * 3600 + local.minute * 60 + local.second
+    start_seconds = _seconds_since_midnight(spec.start)
+    end_seconds = _seconds_since_midnight(spec.end)
+    if start_seconds <= end_seconds:
+        return start_seconds <= local_seconds < end_seconds
+    return local_seconds >= start_seconds or local_seconds < end_seconds
+
+
+def assign_session_label(ts: datetime) -> str:
+    """Return the trading session bucket for a timestamp (timezone-aware)."""
+
+    ts_utc = _ensure_utc(ts)
+    in_asia = _is_in_window(ts_utc, MARKET_SESSIONS["asia"])
+    in_london = _is_in_window(ts_utc, MARKET_SESSIONS["london"])
+    in_newyork = _is_in_window(ts_utc, MARKET_SESSIONS["newyork"])
+    if in_london and in_newyork:
+        return "EU_US_overlap"
+    if in_london:
+        return "Europe"
+    if in_newyork:
+        return "US"
+    if in_asia:
+        return "Asia"
+    return "Other"
+
+
+def session_time_mask(
+    index: pd.DatetimeIndex,
+    session: SessionName,
+    tz: Optional[str] = None,
+) -> pd.Series:
+    """Return a boolean mask for timestamps falling within a market session."""
+
+    if not isinstance(index, pd.DatetimeIndex):  # pragma: no cover - defensive
+        raise TypeError("index must be a DatetimeIndex")
+    idx = index
+    if idx.tz is None:
+        idx = idx.tz_localize("UTC")
+    spec = MARKET_SESSIONS[session]
+    tz_name = tz or spec.tz
+    local_idx = idx.tz_convert(tz_name)
+    local_seconds = local_idx.hour * 3600 + local_idx.minute * 60 + local_idx.second
+    start_seconds = _seconds_since_midnight(spec.start)
+    end_seconds = _seconds_since_midnight(spec.end)
+    if start_seconds <= end_seconds:
+        mask = (local_seconds >= start_seconds) & (local_seconds < end_seconds)
+    else:
+        mask = (local_seconds >= start_seconds) | (local_seconds < end_seconds)
+    return pd.Series(mask, index=index)
+
+
+__all__ = ["MARKET_SESSIONS", "SessionName", "assign_session_label", "session_time_mask"]


### PR DESCRIPTION
### Motivation
- Align session assignment and time-based filters with realistic market hours and timezones rather than coarse UTC hour buckets.
- Centralize session window logic to make session calculations DST-aware and reusable across dataset loaders and filters.
- Validate timezone parameters passed to filters to catch configuration errors early.

### Description
- Add a new helper module `src/quant_engine/time_sessions.py` exposing `MARKET_SESSIONS`, `assign_session_label` and `session_time_mask` with ZoneInfo-based, DST-aware windows for `asia`, `london`, and `newyork` sessions.
- Replace the ad-hoc session heuristic in `src/quant_engine/core/dataset.py` by calling `assign_session_label` when injecting `session` into rows.
- Update `src/quant_engine/filters/time_seasonality.py` so `session_time_filter` delegates to `session_time_mask` and support an optional `tz` override.
- Add timezone parameter validation to `src/quant_engine/filters/utils.py` by checking `tz` is a string and resolvable via `zoneinfo`, and update docs `docs/filters.md` to describe the DST-aware local session windows.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d795058083239761cae7f5688db3)