### PR TITLE
Add TTL-aware cache metrics for OHLC and filter caches

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -9,7 +9,8 @@ Le moteur utilise deux caches mémoire pour limiter les recalculs :
 
 Chaque cache est borné (LRU) et dispose d'un TTL afin d'éviter toute croissance
 illimitée. Des métriques simples (hits/misses/expirations/evictions) sont
-loguées pour faciliter le suivi.
+loguées à chaque exécution de backtest ou application de filtres pour faciliter
+le suivi.
 
 ## Cache OHLC
 

--- a/src/quant_engine/filters/utils.py
+++ b/src/quant_engine/filters/utils.py
@@ -89,6 +89,7 @@ def _make_cache_key(df: pd.DataFrame, flt_type: str, params: Mapping[str, Any]) 
 def _cache_get(key: tuple, ttl_seconds: float) -> Optional[pd.Series]:
     entry = _FILTER_CACHE.get(key)
     if entry is None:
+        _FILTER_CACHE_STATS["misses"] += 1
         return None
     series, created = entry
     if ttl_seconds > 0:
@@ -96,6 +97,7 @@ def _cache_get(key: tuple, ttl_seconds: float) -> Optional[pd.Series]:
         if age > ttl_seconds:
             _FILTER_CACHE.pop(key, None)
             _FILTER_CACHE_STATS["expirations"] += 1
+            _FILTER_CACHE_STATS["misses"] += 1
             return None
     _FILTER_CACHE.move_to_end(key)
     _FILTER_CACHE_STATS["hits"] += 1
@@ -108,6 +110,22 @@ def _cache_set(key: tuple, series: pd.Series, max_items: int) -> None:
     while len(_FILTER_CACHE) > max_items:
         _FILTER_CACHE.popitem(last=False)
         _FILTER_CACHE_STATS["evictions"] += 1
+
+
+def _log_filter_cache_stats_delta(start_stats: Mapping[str, int], logger: logging.Logger) -> None:
+    delta = {
+        key: _FILTER_CACHE_STATS.get(key, 0) - start_stats.get(key, 0)
+        for key in _FILTER_CACHE_STATS
+    }
+    if any(value > 0 for value in delta.values()):
+        logger.info(
+            "Filter cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
+            delta.get("hits", 0),
+            delta.get("misses", 0),
+            delta.get("expirations", 0),
+            delta.get("evictions", 0),
+            len(_FILTER_CACHE),
+        )
 
 
 class FilterValidationError(ValueError):
@@ -289,6 +307,7 @@ def apply_filter_stack(
         return pd.Series(True, index=df.index)
 
     mask = pd.Series(True, index=df.index)
+    cache_stats_start = dict(_FILTER_CACHE_STATS)
     max_cache = df.attrs.get("qe_cache_max_items", _CACHE_DEFAULT_MAX)
     ttl_seconds = df.attrs.get("qe_cache_ttl_seconds", _CACHE_DEFAULT_TTL_SECONDS)
     try:
@@ -301,9 +320,6 @@ def apply_filter_stack(
         ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
     if ttl_seconds < 0:
         ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
-
-    cache_hits = 0
-    cache_misses = 0
 
     for raw in filters:
         flt_type, params = _normalize_filter_spec(raw)
@@ -338,9 +354,7 @@ def apply_filter_stack(
             cached = _cache_get(cache_key, ttl_seconds)
             if cached is not None:
                 series = cached
-                cache_hits += 1
             else:
-                cache_misses += 1
                 try:
                     series = fn(df, **params)
                 except Exception as exc:
@@ -351,7 +365,6 @@ def apply_filter_stack(
                     continue
                 if max_cache > 0:
                     _cache_set(cache_key, series, max_cache)
-                _FILTER_CACHE_STATS["misses"] += 1
         else:
             try:
                 series = fn(df, **params)
@@ -371,14 +384,6 @@ def apply_filter_stack(
 
         mask &= series.reindex(df.index).fillna(False).astype(bool)
 
-    if cache_hits or cache_misses:
-        log.info(
-            "Filter cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
-            cache_hits,
-            cache_misses,
-            _FILTER_CACHE_STATS.get("expirations", 0),
-            _FILTER_CACHE_STATS.get("evictions", 0),
-            len(_FILTER_CACHE),
-        )
+    _log_filter_cache_stats_delta(cache_stats_start, log)
 
     return mask

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -227,7 +227,6 @@ def _fetch_ohlc_for_symbol(
         cached = _cache_ohlc_get(cache_key, ttl_seconds)
         if cached is not None:
             return cached.copy()
-        _OHLC_CACHE_STATS["misses"] += 1
     source = merged_spec.get("source")
     if source == "csv":
         path = Path(merged_spec["path"])
@@ -289,6 +288,7 @@ def _resolve_ohlc_cache_settings(merged_spec: Mapping[str, Any]) -> tuple[bool, 
 def _cache_ohlc_get(cache_key: str, ttl_seconds: float) -> Optional[pd.DataFrame]:
     entry = _OHLC_CACHE.get(cache_key)
     if entry is None:
+        _OHLC_CACHE_STATS["misses"] += 1
         return None
     df, created = entry
     if ttl_seconds > 0:
@@ -296,6 +296,7 @@ def _cache_ohlc_get(cache_key: str, ttl_seconds: float) -> Optional[pd.DataFrame
         if age > ttl_seconds:
             _OHLC_CACHE.pop(cache_key, None)
             _OHLC_CACHE_STATS["expirations"] += 1
+            _OHLC_CACHE_STATS["misses"] += 1
             return None
     _OHLC_CACHE.move_to_end(cache_key)
     _OHLC_CACHE_STATS["hits"] += 1


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth and improve observability of in-memory caches by ensuring TTL expirations and missing lookups are counted as cache misses. 
- Surface per-run cache behavior for filters so operators can see hits/misses/expirations/evictions at each backtest or filter application.

### Description
- In `strategies.runner`, move OHLC cache miss accounting into `_cache_ohlc_get` so missing entries and TTL expirations increment `_OHLC_CACHE_STATS["misses"]` and callers no longer need to increment misses manually.
- In `filters.utils`, increment `_FILTER_CACHE_STATS["misses"]` for missing/expired entries and `_FILTER_CACHE_STATS["hits"]` on successful lookups in `_cache_get`, and add `_log_filter_cache_stats_delta` with a snapshot in `apply_filter_stack` to log per-run deltas instead of ad-hoc counters.
- Remove redundant miss increments at call sites and update docs (`docs/cache.md`) to state that cache metrics are logged per backtest or filter application.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966d7bb89f083239ca3c611a304b8ed)