### PR TITLE
Add resilient HTTP helpers and use shared session in CLI and Java client

### DIFF
--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -17,3 +17,8 @@ Ces variables d'environnement permettent d'ajuster la résilience réseau sans m
 
 - Les statuts `429, 500, 502, 503, 504` déclenchent un retry.
 - Le client est mutualisé pour limiter la création de connexions TCP.
+
+## Intégrations
+
+- La CLI utilise `QE_API_BASE_URL` (défaut `http://127.0.0.1:8000`) avec la session partagée.
+- Le client Java utilise `QE_JAVA_BASE_URL` (défaut `http://localhost:8090`) avec la session partagée.

--- a/src/quant_engine/cli/main.py
+++ b/src/quant_engine/cli/main.py
@@ -1,6 +1,6 @@
 
-
 import json
+import os
 from dataclasses import asdict
 from enum import Enum
 from pathlib import Path
@@ -33,11 +33,40 @@ app.add_typer(live_app, name="live")
 app.add_typer(strategy_app, name="strategy")
 app.add_typer(backtest_app, name="backtest")
 
+API_BASE_URL = os.getenv("QE_API_BASE_URL", "http://127.0.0.1:8000")
+
 
 class RunStatus(str, Enum):
     RUNNING = "running"
     FINISHED = "finished"
     FAILED = "failed"
+
+
+def _api_url(path: str, params: Optional[Dict[str, Any]] = None) -> str:
+    if not path.startswith("/"):
+        path = "/" + path
+    base_url = API_BASE_URL.rstrip("/")
+    url = f"{base_url}{path}"
+    if params:
+        url = f"{url}?{parse.urlencode(params)}"
+    return url
+
+
+def _request_api(
+    method: str,
+    path: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Any:
+    url = _api_url(path, params=params)
+    return request_json(
+        method,
+        url,
+        json=payload,
+        timeout=DEFAULT_TIMEOUT,
+        session=get_shared_session(),
+    )
 
 
 @app.command("run-local")
@@ -74,13 +103,7 @@ def submit(
     else:
         payload = asdict(sp)
     try:
-        payload = request_json(
-            "POST",
-            "http://127.0.0.1:8000/submit",
-            json=payload,
-            timeout=DEFAULT_TIMEOUT,
-            session=get_shared_session(),
-        )
+        payload = _request_api("POST", "/submit", payload=payload)
     except Exception as exc:
         typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
@@ -137,14 +160,8 @@ def stats_show(
     }
     if timeframe is not None:
         params["timeframe"] = timeframe
-    url = "http://127.0.0.1:8000/stats?" + parse.urlencode(params)
     try:
-        rows = request_json(
-            "GET",
-            url,
-            timeout=DEFAULT_TIMEOUT,
-            session=get_shared_session(),
-        )
+        rows = _request_api("GET", "/stats", params=params)
     except Exception as exc:
         typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
@@ -261,14 +278,8 @@ def seasonality_profiles(
         params["measure"] = measure
     if metrics:
         params["metrics"] = metrics
-    url = "http://127.0.0.1:8000/seasonality/profiles?" + parse.urlencode(params)
     try:
-        rows = request_json(
-            "GET",
-            url,
-            timeout=DEFAULT_TIMEOUT,
-            session=get_shared_session(),
-        )
+        rows = _request_api("GET", "/seasonality/profiles", params=params)
     except Exception as exc:
         typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
@@ -332,14 +343,8 @@ def seasonality_compare(
         }
         if timeframe is not None:
             params["timeframe"] = timeframe
-        url = "http://127.0.0.1:8000/seasonality/profiles?" + parse.urlencode(params)
         try:
-            rows = request_json(
-                "GET",
-                url,
-                timeout=DEFAULT_TIMEOUT,
-                session=get_shared_session(),
-            )
+            rows = _request_api("GET", "/seasonality/profiles", params=params)
         except Exception as exc:
             typer.echo(f"Connection error: {exc}")
             raise typer.Exit(1)
@@ -381,14 +386,8 @@ def list_runs(
     params = {"page": 1, "page_size": limit}
     if status is not None:
         params["status"] = status.value
-    url = "http://127.0.0.1:8000/runs?" + parse.urlencode(params)
     try:
-        runs = request_json(
-            "GET",
-            url,
-            timeout=DEFAULT_TIMEOUT,
-            session=get_shared_session(),
-        )
+        runs = _request_api("GET", "/runs", params=params)
     except Exception as exc:
         typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)
@@ -404,14 +403,8 @@ def list_runs(
 def show_run(run_id: str) -> None:
     """Show details about a specific run."""
 
-    url = f"http://127.0.0.1:8000/runs/{run_id}"
     try:
-        detail = request_json(
-            "GET",
-            url,
-            timeout=DEFAULT_TIMEOUT,
-            session=get_shared_session(),
-        )
+        detail = _request_api("GET", f"/runs/{run_id}")
     except Exception as exc:
         typer.echo(f"Connection error: {exc}")
         raise typer.Exit(1)

--- a/src/quant_engine/integrations/java_client.py
+++ b/src/quant_engine/integrations/java_client.py
@@ -126,9 +126,9 @@ def get_positions() -> List[Dict[str, Any]]:
     url = BASE_URL + "/api/portfolio/positions"
     try:
         session = get_shared_session()
-        resp = session.get(url, timeout=DEFAULT_TIMEOUT)
-        if resp.status_code == 200 and resp.content:
-            return resp.json()
+        payload = request_json("GET", url, session=session, timeout=DEFAULT_TIMEOUT)
+        if payload:
+            return payload
     except Exception:
         pass
     return []


### PR DESCRIPTION
### Motivation
- Make all HTTP calls resilient and uniform by using the shared requests session configured with retries, backoff and pooling.
- Remove hardcoded API URLs in the CLI and centralize URL construction to allow configuration via environment variables.
- Ensure Java integration use the same robust request flow so backend calls benefit from standardized timeouts and retries.

### Description
- Added `API_BASE_URL` environment variable support and helper functions `_api_url` and `_request_api` to `src/quant_engine/cli/main.py` and replaced inline hardcoded URLs with calls to `_request_api` using the shared session and `DEFAULT_TIMEOUT`.
- Updated `src/quant_engine/integrations/java_client.py` `get_positions` to use `request_json` with the shared session and configured timeout instead of raw `session.get`.
- Imported `os` where needed and documented CLI/Java integration base URL environment variables in `docs/http_client.md` under an "Intégrations" section.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676afd59d483239f469740c9c6a63f)