### PR TITLE
Add TTL pruning and observability to OHLC and filter caches

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -8,9 +8,10 @@ Le moteur utilise deux caches mémoire pour limiter les recalculs :
 2. **Cache des filtres** dans `filters.utils` (résultats des masques).
 
 Chaque cache est borné (LRU) et dispose d'un TTL afin d'éviter toute croissance
-illimitée. Des métriques simples (hits/misses/expirations/evictions) sont
-loguées à chaque exécution de backtest ou application de filtres pour faciliter
-le suivi.
+illimitée. Les entrées expirées sont purgées lors des accès et des écritures.
+Des métriques simples (hits/misses/expirations/evictions, taille, TTL, max)
+sont loguées à chaque exécution de backtest ou application de filtres pour
+faciliter le suivi.
 
 ## Cache OHLC
 

--- a/src/quant_engine/filters/utils.py
+++ b/src/quant_engine/filters/utils.py
@@ -74,6 +74,10 @@ _FILTER_CACHE: "OrderedDict[tuple, tuple[pd.Series, float]]" = OrderedDict()
 _CACHE_DEFAULT_MAX = 2048
 _CACHE_DEFAULT_TTL_SECONDS = 900.0
 _FILTER_CACHE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "expirations": 0}
+_FILTER_CACHE_CONFIG = {
+    "max_items": _CACHE_DEFAULT_MAX,
+    "ttl_seconds": _CACHE_DEFAULT_TTL_SECONDS,
+}
 
 
 def _make_cache_key(df: pd.DataFrame, flt_type: str, params: Mapping[str, Any]) -> Optional[tuple]:
@@ -87,7 +91,19 @@ def _make_cache_key(df: pd.DataFrame, flt_type: str, params: Mapping[str, Any]) 
     return (cache_key, flt_type, params_key)
 
 
+def _prune_filter_cache(ttl_seconds: float) -> int:
+    if ttl_seconds <= 0 or not _FILTER_CACHE:
+        return 0
+    now = time.monotonic()
+    expired = [k for k, (_, created) in _FILTER_CACHE.items() if now - created > ttl_seconds]
+    for k in expired:
+        _FILTER_CACHE.pop(k, None)
+        _FILTER_CACHE_STATS["expirations"] += 1
+    return len(expired)
+
+
 def _cache_get(key: tuple, ttl_seconds: float) -> Optional[pd.Series]:
+    _prune_filter_cache(ttl_seconds)
     entry = _FILTER_CACHE.get(key)
     if entry is None:
         _FILTER_CACHE_STATS["misses"] += 1
@@ -105,7 +121,8 @@ def _cache_get(key: tuple, ttl_seconds: float) -> Optional[pd.Series]:
     return series
 
 
-def _cache_set(key: tuple, series: pd.Series, max_items: int) -> None:
+def _cache_set(key: tuple, series: pd.Series, max_items: int, ttl_seconds: float) -> None:
+    _prune_filter_cache(ttl_seconds)
     _FILTER_CACHE[key] = (series, time.monotonic())
     _FILTER_CACHE.move_to_end(key)
     while len(_FILTER_CACHE) > max_items:
@@ -113,19 +130,24 @@ def _cache_set(key: tuple, series: pd.Series, max_items: int) -> None:
         _FILTER_CACHE_STATS["evictions"] += 1
 
 
-def _log_filter_cache_stats_delta(start_stats: Mapping[str, int], logger: logging.Logger) -> None:
+def _log_filter_cache_stats_delta(
+    start_stats: Mapping[str, int],
+    logger: logging.Logger,
+) -> None:
     delta = {
         key: _FILTER_CACHE_STATS.get(key, 0) - start_stats.get(key, 0)
         for key in _FILTER_CACHE_STATS
     }
     if any(value > 0 for value in delta.values()):
         logger.info(
-            "Filter cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
+            "Filter cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d max=%d ttl=%.0fs",
             delta.get("hits", 0),
             delta.get("misses", 0),
             delta.get("expirations", 0),
             delta.get("evictions", 0),
             len(_FILTER_CACHE),
+            _FILTER_CACHE_CONFIG.get("max_items", _CACHE_DEFAULT_MAX),
+            _FILTER_CACHE_CONFIG.get("ttl_seconds", _CACHE_DEFAULT_TTL_SECONDS),
         )
 
 
@@ -335,6 +357,8 @@ def apply_filter_stack(
         ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
     if ttl_seconds < 0:
         ttl_seconds = _CACHE_DEFAULT_TTL_SECONDS
+    _FILTER_CACHE_CONFIG.update({"max_items": max_cache, "ttl_seconds": ttl_seconds})
+    _prune_filter_cache(ttl_seconds)
 
     for raw in filters:
         flt_type, params = _normalize_filter_spec(raw)
@@ -379,7 +403,7 @@ def apply_filter_stack(
                         raise FilterValidationError(msg) from exc
                     continue
                 if max_cache > 0:
-                    _cache_set(cache_key, series, max_cache)
+                    _cache_set(cache_key, series, max_cache, ttl_seconds)
         else:
             try:
                 series = fn(df, **params)

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -39,6 +39,11 @@ _OHLC_CACHE: "OrderedDict[str, tuple[pd.DataFrame, float]]" = OrderedDict()
 _OHLC_CACHE_DEFAULT_MAX = 256
 _OHLC_CACHE_DEFAULT_TTL_SECONDS = 900.0
 _OHLC_CACHE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "expirations": 0}
+_OHLC_CACHE_CONFIG = {
+    "enabled": True,
+    "ttl_seconds": _OHLC_CACHE_DEFAULT_TTL_SECONDS,
+    "max_items": _OHLC_CACHE_DEFAULT_MAX,
+}
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
@@ -255,7 +260,7 @@ def _fetch_ohlc_for_symbol(
     if missing:
         raise ValueError(f"Missing OHLC columns for {symbol}: {missing}")
     if cache_enabled and max_items > 0:
-        _cache_ohlc_set(cache_key, df.copy(), max_items)
+        _cache_ohlc_set(cache_key, df.copy(), max_items, ttl_seconds)
     return df
 
 
@@ -282,10 +287,25 @@ def _resolve_ohlc_cache_settings(merged_spec: Mapping[str, Any]) -> tuple[bool, 
         enabled = False
     if ttl_seconds <= 0:
         ttl_seconds = 0.0
+    _OHLC_CACHE_CONFIG.update(
+        {"enabled": enabled, "ttl_seconds": ttl_seconds, "max_items": max_items}
+    )
     return enabled, ttl_seconds, max_items
 
 
+def _prune_ohlc_cache(ttl_seconds: float) -> int:
+    if ttl_seconds <= 0 or not _OHLC_CACHE:
+        return 0
+    now = time.monotonic()
+    expired = [key for key, (_, created) in _OHLC_CACHE.items() if now - created > ttl_seconds]
+    for key in expired:
+        _OHLC_CACHE.pop(key, None)
+        _OHLC_CACHE_STATS["expirations"] += 1
+    return len(expired)
+
+
 def _cache_ohlc_get(cache_key: str, ttl_seconds: float) -> Optional[pd.DataFrame]:
+    _prune_ohlc_cache(ttl_seconds)
     entry = _OHLC_CACHE.get(cache_key)
     if entry is None:
         _OHLC_CACHE_STATS["misses"] += 1
@@ -303,7 +323,13 @@ def _cache_ohlc_get(cache_key: str, ttl_seconds: float) -> Optional[pd.DataFrame
     return df
 
 
-def _cache_ohlc_set(cache_key: str, df: pd.DataFrame, max_items: int) -> None:
+def _cache_ohlc_set(
+    cache_key: str,
+    df: pd.DataFrame,
+    max_items: int,
+    ttl_seconds: float,
+) -> None:
+    _prune_ohlc_cache(ttl_seconds)
     _OHLC_CACHE[cache_key] = (df, time.monotonic())
     _OHLC_CACHE.move_to_end(cache_key)
     while len(_OHLC_CACHE) > max_items:
@@ -318,12 +344,14 @@ def _log_ohlc_cache_stats_delta(start_stats: Mapping[str, int]) -> None:
     }
     if any(value > 0 for value in delta.values()):
         LOGGER.info(
-            "OHLC cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d",
+            "OHLC cache stats: hits=%d misses=%d expirations=%d evictions=%d size=%d max=%d ttl=%.0fs",
             delta.get("hits", 0),
             delta.get("misses", 0),
             delta.get("expirations", 0),
             delta.get("evictions", 0),
             len(_OHLC_CACHE),
+            _OHLC_CACHE_CONFIG.get("max_items", _OHLC_CACHE_DEFAULT_MAX),
+            _OHLC_CACHE_CONFIG.get("ttl_seconds", _OHLC_CACHE_DEFAULT_TTL_SECONDS),
         )
 
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth by expiring stale cache entries for OHLC loads and filter masks.
- Make cache behavior observable by tracking and logging TTL, max size, and basic metrics (hits/misses/expirations/evictions/size).
- Keep existing cache aliases and defaults while allowing per-strategy configuration of TTL and max items.

### Description
- In `src/quant_engine/strategies/runner.py` added `_OHLC_CACHE_CONFIG`, a `_prune_ohlc_cache` function, and updated `_cache_ohlc_get`/`_cache_ohlc_set` to prune expired entries and accept `ttl_seconds`, and augmented `_log_ohlc_cache_stats_delta` to log `max` and `ttl`.
- In `src/quant_engine/filters/utils.py` added `_FILTER_CACHE_CONFIG`, a `_prune_filter_cache` function, and updated `_cache_get`/`_cache_set` to prune on access/write and accept `ttl_seconds`, and updated `_log_filter_cache_stats_delta` to include `max` and `ttl` in logs.
- Updated `apply_filter_stack` to propagate per-call cache settings into `_FILTER_CACHE_CONFIG`, prune before use, and pass `ttl_seconds` into cache writes; updated OHLC cache usage to pass `ttl_seconds` on set.
- Updated `docs/cache.md` to mention that expired entries are purged on access/writes and that logs include size, TTL and max configuration.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676b1c3b788323a47788eec0a0aca3)