### PR TITLE
Vectorize p-value calculation in stats runner

### DIFF
--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -326,13 +326,15 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
             total_n = int(g["n"].sum())
             total_successes = int(g["successes"].sum())
             p0 = total_successes / total_n if total_n else 0.0
-            pvals = []
-            for _, row in g.iterrows():
-                direction = "greater" if row["lift_freq"] >= 0 else "less"
-                pval = p_value_binomial_onesided_normal(
-                    int(row["successes"]), int(row["n"]), p0, direction=direction
+            directions = g["lift_freq"].ge(0).map({True: "greater", False: "less"}).to_numpy()
+            pvals = [
+                p_value_binomial_onesided_normal(
+                    int(successes), int(n), p0, direction=direction
                 )
-                pvals.append(pval)
+                for successes, n, direction in zip(
+                    g["successes"].to_numpy(), g["n"].to_numpy(), directions
+                )
+            ]
             qvals = benjamini_hochberg(pvals)
             out.loc[idx, "p_value"] = pvals
             out.loc[idx, "q_value"] = qvals


### PR DESCRIPTION
### Motivation
- Avoid the per-row `iterrows()` loop in `run_stats` to reduce Python-level overhead when computing p-values for large result sets.
- Improve performance by using pandas/NumPy vectorized operations to determine test directions and build the p-value list.

### Description
- Replaced the `iterrows()` loop that computed per-row p-values with a vectorized path that computes `directions` using `Series.ge(0)` and `.map(...)` and then zips `successes`, `n`, and `directions` (via `.to_numpy()`) to produce `pvals` with a list comprehension. 
- Kept downstream logic unchanged: FDR adjustment via `benjamini_hochberg` and assignment to `p_value`, `q_value`, and `significant` columns remains the same.
- Change is localized to `src/quant_engine/stats/runner.py` in the p-value computation block.

### Testing
- Ran `pytest -q tests/test_stats.py` and all tests passed (8 passed, 0 failed).
- No changes to existing test expectations were required and the stats test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676b3c18088323b40612e84f14b60b)