### PR TITLE
Add batching to levels retrieval and fill updates

### DIFF
--- a/docs/code_audit.md
+++ b/docs/code_audit.md
@@ -161,13 +161,13 @@
 ## 11) Levels
 
 **Constat**
-- `run_levels_fill` traite un lot limité (limit=10000) sans pagination et peut être coûteux en RAM si les niveaux sont nombreux.【F:src/quant_engine/levels/runner.py†L32-L95】
+- Le fill parcourt désormais les niveaux actifs par pages (keyset) et applique les updates par lot, ce qui réduit la pression mémoire sur des univers étendus.【F:src/quant_engine/levels/runner.py†L32-L95】
 
 **Risques/impact**
-- Scalabilité limitée pour gros univers.
+- La volumétrie extrême reste sensible au coût DB (index et batch_size à ajuster).
 
 **Recommandations**
-- Ajouter une pagination DB et un mode batch chunké.
+- Ajuster `batch_size` côté repo si besoin et monitorer la latence DB.
 
 ---
 

--- a/docs/levels_overview.md
+++ b/docs/levels_overview.md
@@ -82,6 +82,9 @@ et `touched_level_since`, en chargeant automatiquement les levels persistes depu
   et `params_hash`. L'index unique assure l'idempotence.
 - Les refresh `fill` parcourent les niveaux actifs en lots (pagination keyset)
   pour eviter des limites fixes et garantir la scalabilite sur de gros univers.
+- `select_levels` s'appuie sur la meme pagination keyset : `limit=None` charge
+  l'ensemble des niveaux filtrés, avec un `batch_size` configurable pour le
+  streaming.
 - Index b-tree additionnels sur `(symbol, level_type, anchor_ts)` et
   `(symbol, valid_from_ts, valid_to_ts)` pour accelerer les scans, overlays et
   checks de validite.

--- a/src/quant_engine/levels/repo.py
+++ b/src/quant_engine/levels/repo.py
@@ -261,42 +261,42 @@ def select_levels(
     active_only: bool,
     start: Optional[str | datetime] = None,
     end: Optional[str | datetime] = None,
-    limit: int = 10000,
+    limit: Optional[int] = None,
+    batch_size: int = 5000,
 ) -> pd.DataFrame:
     """Return levels filtered by symbol, type and validity flags."""
 
-    clauses = ["symbol = :symbol"]
-    params: dict = {"symbol": symbol, "limit": limit}
-    if level_types:
-        placeholders = ",".join(f":lt{i}" for i in range(len(level_types)))
-        clauses.append(f"level_type IN ({placeholders})")
-        params.update({f"lt{i}": lvl for i, lvl in enumerate(level_types)})
-    if active_only:
-        clauses.append("valid_to_ts IS NULL")
-    start_norm = _parse_optional_ts(start)
-    if start_norm is not None:
-        clauses.append("anchor_ts >= :start")
-        params["start"] = start_norm
-    end_norm = _parse_optional_ts(end)
-    if end_norm is not None:
-        clauses.append("anchor_ts <= :end")
-        params["end"] = end_norm
-    query = (
-        f"SELECT symbol, timeframe, level_type, price, price_lo, price_hi, anchor_ts, "
-        f"valid_from_ts, valid_to_ts, params_hash FROM {table_fqn} "
-        "WHERE " + " AND ".join(clauses) + " ORDER BY anchor_ts DESC LIMIT :limit"
-    )
-    with engine.connect() as conn:
-        rows = conn.execute(text(query), params).fetchall()
-    records: List[dict] = []
-    for row in rows:
-        if hasattr(row, "_mapping"):
-            records.append(dict(row._mapping))
-        elif hasattr(row, "keys"):
-            records.append(dict(zip(row.keys(), row)))
-        else:  # pragma: no cover - defensive fallback
-            records.append(dict(row))
-    return pd.DataFrame(records)
+    if limit is not None and limit <= 0:
+        return pd.DataFrame()
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    collected: List[pd.DataFrame] = []
+    remaining = limit
+    per_page = batch_size if remaining is None else min(batch_size, remaining)
+    for batch in iter_levels(
+        engine,
+        table_fqn,
+        symbol=symbol,
+        level_types=level_types,
+        active_only=active_only,
+        start=start,
+        end=end,
+        batch_size=per_page,
+    ):
+        if batch.empty:
+            continue
+        if remaining is not None and len(batch) > remaining:
+            batch = batch.iloc[:remaining]
+        collected.append(batch)
+        if remaining is not None:
+            remaining -= len(batch)
+            if remaining <= 0:
+                break
+        per_page = batch_size
+    if not collected:
+        return pd.DataFrame()
+    return pd.concat(collected, ignore_index=True)
 
 
 def iter_levels(

--- a/src/quant_engine/levels/runner.py
+++ b/src/quant_engine/levels/runner.py
@@ -48,7 +48,7 @@ def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
     ensure_table(engine, table_fqn)
 
     total_checked = 0
-    pending_updates: list[pd.DataFrame] = []
+    total_updated = 0
     for symbol in spec.symbols:
         sym_df = df[df["symbol"] == symbol]
         if sym_df.empty:
@@ -72,6 +72,7 @@ def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
             if levels.empty:
                 continue
             total_checked += int(len(levels))
+            pending_updates: list[pd.DataFrame] = []
             if do_fill_fvg:
                 fvgs_active = levels[levels["level_type"] == "FVG"]
                 if not fvgs_active.empty:
@@ -86,12 +87,10 @@ def run_levels_fill(spec: LevelsBuildSpec) -> Dict[str, object]:
                     gaps_updates = gaps_filled[gaps_filled["valid_to_ts"].notna()]
                     if not gaps_updates.empty:
                         pending_updates.append(gaps_updates)
-    if pending_updates:
-        updates_df = pd.concat(pending_updates, ignore_index=True)
-        updated_count = upsert_valid_to_ts(engine, table_fqn, updates_df)
-    else:
-        updated_count = 0
-    return {"updated": int(updated_count), "checked": int(total_checked)}
+            if pending_updates:
+                updates_df = pd.concat(pending_updates, ignore_index=True)
+                total_updated += upsert_valid_to_ts(engine, table_fqn, updates_df)
+    return {"updated": int(total_updated), "checked": int(total_checked)}
 
 
 __all__ = ["run_levels_build", "run_levels_fill"]


### PR DESCRIPTION
### Motivation
- Remove the fixed `limit=10000` read and make levels retrieval scalable for large universes by streaming results from the DB.  
- Reduce memory pressure during `run_levels_fill` by applying `valid_to_ts` updates per page instead of collecting all updates in memory.

### Description
- Change `select_levels` signature to `limit: Optional[int] = None, batch_size: int = 5000` and implement streaming assembly of results using the existing `iter_levels` keyset pagination.  
- Reuse `iter_levels` keyset pagination to page through results with a configurable `batch_size` and support `limit=None` to fetch the full filtered set in streaming mode.  
- Refactor `run_levels_fill` to compute per-page `pending_updates` and call `upsert_valid_to_ts` for each page while accumulating the total updated count.  
- Update documentation in `docs/levels_overview.md` and `docs/code_audit.md` to describe the new pagination/batching behavior and recommendations for tuning `batch_size`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676b4e8b5c8323adefa3fbf03b99e1)