### PR TITLE
Document require_crossing gating semantics

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -171,8 +171,21 @@ Le champ `require_crossing` contrôle comment ce masque est combiné avec le sig
 
 - **`true` (défaut)** : le signal doit **croiser** le filtre sur la même barre.
   Un signal ne passe que si `signal == 1` **et** `filter_pass == true`.
-- **`false`** : mode **latch**. Le signal doit croiser le filtre une seule fois,
-  puis il peut rester actif tant que le signal reste à 1, même si le filtre redevient faux.
+- **`false`** : mode **gated on first signal** (latch). Le filtre sert uniquement
+  à **ouvrir la porte** sur la première barre où `signal == 1`. Tant que le signal
+  reste à 1, le filtre est ignoré même s'il redevient faux. Quand le signal repasse
+  à 0, la porte se referme et un **nouveau passage** nécessite un nouveau crossing.
+
+Exemple simplifié (signal vs filtre) :
+
+| bar | signal | filtre | require_crossing=true | require_crossing=false |
+| --- | ------ | ------ | --------------------- | ---------------------- |
+| 0   | 0      | false  | 0                     | 0                      |
+| 1   | 1      | true   | 1                     | 1                      |
+| 2   | 1      | false  | 0                     | 1                      |
+| 3   | 0      | false  | 0                     | 0                      |
+| 4   | 1      | false  | 0                     | 0                      |
+| 5   | 1      | true   | 1                     | 1                      |
 
 Priorité de lecture :
 1) `signal.params.require_crossing`

--- a/tests/test_backtest_require_crossing.py
+++ b/tests/test_backtest_require_crossing.py
@@ -26,3 +26,12 @@ def test_resolve_require_crossing_prefers_signal_params():
     }
 
     assert runner._resolve_require_crossing(spec) is False
+
+
+def test_apply_filter_mask_gated_on_first_signal():
+    signal = [0, 1, 1, 0, 1, 1, 1]
+    mask = [False, True, False, False, False, True, False]
+
+    gated = runner._apply_filter_mask(signal, mask, False)
+
+    assert gated == [0, 1, 1, 0, 0, 1, 1]


### PR DESCRIPTION
### Motivation

- Clarify the semantics of `require_crossing` when combining filter masks with signals, distinguishing strict crossing vs gated-on-first-signal (latch) behavior.
- Provide a concrete example to remove ambiguity about how filters are applied while a signal remains active.
- Add a regression test to lock the intended gated behavior and prevent accidental regressions.

### Description

- Update `docs/optimization.md` to describe the `require_crossing=false` mode as "gated on first signal" and add a small per-bar example table illustrating both modes.
- Add a unit test `test_apply_filter_mask_gated_on_first_signal` in `tests/test_backtest_require_crossing.py` that asserts the latch/gating behavior when `_apply_filter_mask` is called with `require_crossing=False` and retain existing tests for the strict mode and param resolution.
- No changes to runtime logic were made; the documentation and test codify the current behavior implemented in the backtest runner.

### Testing

- Ran `python -m pytest tests/test_backtest_require_crossing.py` to exercise the new and existing tests.
- Outcome: `4 passed` (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678c30e4088323a0b79dd31f20a9df)