### PR TITLE
Hydrate incremental state for live processing in crypto_grid and dca_etf

### DIFF
--- a/src/quant_engine/strategies/crypto_grid.py
+++ b/src/quant_engine/strategies/crypto_grid.py
@@ -116,6 +116,8 @@ class CryptoGridStrategy(Strategy):
         signals_seen = 0
         results: List[StrategySignal] = []
         last_processed = state.last_processed_ts
+        if only_last_ts is not None and last_processed is not None:
+            self._hydrate_incremental_state(df, state)
         use_incremental = (
             only_last_ts is not None
             and last_processed is not None
@@ -204,6 +206,21 @@ class CryptoGridStrategy(Strategy):
                     )
                     break
         return results
+
+    def _hydrate_incremental_state(self, df: pd.DataFrame, state: _CryptoState) -> None:
+        if state.last_rolling_max is not None and state.prev_dd is not None:
+            return
+        if state.last_processed_ts is None:
+            return
+        history = df.loc[df.index <= state.last_processed_ts, "close"]
+        if history.empty:
+            return
+        rolling_max_value = float(history.max())
+        last_price = float(history.iloc[-1])
+        if state.last_rolling_max is None:
+            state.last_rolling_max = rolling_max_value
+        if state.prev_dd is None:
+            state.prev_dd = (last_price / rolling_max_value - 1.0) * 100.0
 
     @staticmethod
     def _allow_entries(df: pd.DataFrame, ts: pd.Timestamp) -> bool:

--- a/src/quant_engine/strategies/dca_etf.py
+++ b/src/quant_engine/strategies/dca_etf.py
@@ -109,6 +109,8 @@ class DcaEtfStrategy(Strategy):
         signals_seen = 0
         results: List[StrategySignal] = []
         last_processed = state.last_processed_ts
+        if only_last_ts is not None and last_processed is not None:
+            self._hydrate_incremental_state(df, state)
         use_incremental = (
             only_last_ts is not None
             and last_processed is not None
@@ -186,6 +188,21 @@ class DcaEtfStrategy(Strategy):
                     )
                     break
         return results
+
+    def _hydrate_incremental_state(self, df: pd.DataFrame, state: _EtfState) -> None:
+        if state.last_rolling_max is not None and state.prev_dd is not None:
+            return
+        if state.last_processed_ts is None:
+            return
+        history = df.loc[df.index <= state.last_processed_ts, "close"]
+        if history.empty:
+            return
+        rolling_max_value = float(history.max())
+        last_price = float(history.iloc[-1])
+        if state.last_rolling_max is None:
+            state.last_rolling_max = rolling_max_value
+        if state.prev_dd is None:
+            state.prev_dd = (last_price / rolling_max_value - 1.0) * 100.0
 
     @staticmethod
     def _allow_entries(df: pd.DataFrame, ts: pd.Timestamp) -> bool:


### PR DESCRIPTION
### Motivation
- Avoid recomputing full drawdown/rolling-max series during live evaluation so only newly-arrived bars are processed, reducing CPU cost.
- Preserve drawdown continuity when resuming incremental live evaluation so live behavior remains functionally identical to full-series computation.

### Description
- Added `_hydrate_incremental_state` to `CryptoGridStrategy` and `DcaEtfStrategy` to populate `last_rolling_max` and `prev_dd` from historical `close` values up to `state.last_processed_ts` when those fields are missing.
- Call `_hydrate_incremental_state` at the start of `_process` when `only_last_ts` and `state.last_processed_ts` are present so the existing incremental loop can use `state.last_rolling_max` and avoid a full recompute.
- The hydration routine is no-op if the incremental state is already populated and does not change backtest behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678c8908e883238c9b3866336b8c98)