### PR TITLE
Require explicit retention.base_dir to enable pruning

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -725,7 +725,7 @@ Tu peux limiter le nombre de runs conserves et purger les artefacts lourds :
 - `keep_best_runs` : conserve les N meilleurs runs par (strategy_id, dataset_id).
 - `mode`: `heavy_only` (purge `promoted/` + `full_pass/`) ou `full` (supprime le run complet).
 - `dry_run`: log sans suppression.
-- `base_dir`: repertoire racine a scanner pour la retention (par defaut `out_dir` parent). Doit contenir le `out_dir` courant sinon la retention est ignoree.
+- `base_dir`: repertoire racine **obligatoire** a scanner pour la retention. Doit contenir le `out_dir` courant sinon la retention est ignoree. Sans `base_dir`, la retention est desactivee par securite.
 
 ## Roadmap "niveau pro" (priorites)
 

--- a/src/quant_engine/optimize/variants.py
+++ b/src/quant_engine/optimize/variants.py
@@ -1762,14 +1762,17 @@ def _is_within_dir(child: Path, parent: Path) -> bool:
 
 def _resolve_retention_base_dir(out_dir: Path, retention: Mapping[str, Any]) -> Optional[Path]:
     base_dir_cfg = retention.get("base_dir")
-    if base_dir_cfg:
-        candidate = Path(str(base_dir_cfg)).expanduser()
-        if not candidate.is_absolute():
-            candidate = (out_dir.parent / candidate).resolve()
-        else:
-            candidate = candidate.resolve()
+    if not base_dir_cfg:
+        LOGGER.warning(
+            "Retention: disabled because base_dir is not set. "
+            "Configure retention.base_dir explicitly to enable pruning."
+        )
+        return None
+    candidate = Path(str(base_dir_cfg)).expanduser()
+    if not candidate.is_absolute():
+        candidate = (out_dir.parent / candidate).resolve()
     else:
-        candidate = out_dir.parent.resolve()
+        candidate = candidate.resolve()
     if candidate == Path(candidate.anchor):
         LOGGER.warning("Retention: base_dir=%s is too broad; skipping retention for safety", candidate)
         return None


### PR DESCRIPTION
### Motivation
- Avoid accidental deletion of run data by making retention pruning opt-in via an explicit `retention.base_dir` and emitting a strong warning when it is absent.

### Description
- Update `_resolve_retention_base_dir` in `src/quant_engine/optimize/variants.py` to return `None` and log a warning when `retention.base_dir` is not set (disabling retention for safety), and adjust path resolution logic accordingly; update `docs/optimization.md` to document that `base_dir` is mandatory for retention.

### Testing
- No automated tests were run for this change (manual testing not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678cad2ea08323aebaa23efa65034f)