### PR TITLE
Clarify drawdown helpers in DcaEquityStrategy

### DIFF
--- a/docs/strategies_overview.md
+++ b/docs/strategies_overview.md
@@ -18,6 +18,10 @@ commun (`StrategySignal`) et peuvent être utilisées en backtest via
   (`grid_level`), poids (`palier_used`), règle de take-profit active, etc.
 * **Logs** : `log_drawdown_summary=true` pour afficher un résumé de drawdown en
   niveau INFO (par défaut, le résumé passe en DEBUG pour éviter le spam).
+* **Référence drawdown** : configurez `drawdown_reference` (ex : `"ATH"`,
+  `"3M"`, `"90D"`, ou `{ "mode": "rolling", "window": "90D" }`) pour piloter le
+  calcul; les helpers legacy `compute_drawdown` / `compute_reference_high` ne
+  sont plus exposés.
 
 ### `DcaEtfStrategy`
 

--- a/src/quant_engine/strategies/dca_equity.py
+++ b/src/quant_engine/strategies/dca_equity.py
@@ -127,6 +127,18 @@ class DcaEquityStrategy(Strategy):
                 ref = close.rolling(window, min_periods=1).max()
         return ref.ffill().fillna(close.iloc[0])
 
+    def _compute_drawdown_series(self, close: pd.Series) -> Tuple[pd.Series, pd.Series]:
+        """
+        Compute the drawdown series and its reference high.
+
+        Legacy ``compute_drawdown`` / ``compute_reference_high`` helpers are no longer
+        exposed; use ``drawdown_reference`` configuration instead.
+        """
+
+        ref_high = self._compute_reference_high(close)
+        dd_series = ((close / ref_high) - 1.0) * 100.0
+        return dd_series.fillna(0.0), ref_high
+
     def backtest(self, ohlc: pd.DataFrame, context: Dict[str, Any]) -> List[StrategySignal]:
         df = self._normalize_ohlc(ohlc)
         state = _CycleState()
@@ -155,9 +167,7 @@ class DcaEquityStrategy(Strategy):
         if df.empty:
             return []
         close = df["close"].astype(float)
-        ref_high = self._compute_reference_high(close)
-        dd_series = ((close / ref_high) - 1.0) * 100.0
-        dd_series = dd_series.fillna(0.0)
+        dd_series, ref_high = self._compute_drawdown_series(close)
         symbol = context.get("symbol", context.get("symbol_id", ""))
         asset_class = context.get("asset_class", self.asset_class)
         screening = context.get("screening") or {}


### PR DESCRIPTION
### Motivation
- Centralize and clarify drawdown/reference-high computation in the equity DCA strategy and mark legacy helpers as no longer exposed to reduce confusion and duplicated logic.

### Description
- Add a dedicated helper ` _compute_drawdown_series` that returns the drawdown series and its reference high as a tuple `(dd_series, ref_high)`.
- Replace the inline drawdown/reference-high calculation in `_process` to call ` _compute_drawdown_series`.
- Update `docs/strategies_overview.md` to document the `drawdown_reference` configuration and state that the legacy `compute_drawdown` / `compute_reference_high` helpers are no longer exposed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678f46d7148323b4d42a5c0f27f962)