### PR TITLE
Make live grid/DCA strategies skip already-processed bars

### DIFF
--- a/src/quant_engine/strategies/crypto_grid.py
+++ b/src/quant_engine/strategies/crypto_grid.py
@@ -116,6 +116,12 @@ class CryptoGridStrategy(Strategy):
         signals_seen = 0
         results: List[StrategySignal] = []
         last_processed = state.last_processed_ts
+        if (
+            only_last_ts is not None
+            and last_processed is not None
+            and only_last_ts <= last_processed
+        ):
+            return results
         if only_last_ts is not None and last_processed is not None:
             self._hydrate_incremental_state(df, state)
         use_incremental = (

--- a/src/quant_engine/strategies/dca_etf.py
+++ b/src/quant_engine/strategies/dca_etf.py
@@ -109,6 +109,12 @@ class DcaEtfStrategy(Strategy):
         signals_seen = 0
         results: List[StrategySignal] = []
         last_processed = state.last_processed_ts
+        if (
+            only_last_ts is not None
+            and last_processed is not None
+            and only_last_ts <= last_processed
+        ):
+            return results
         if only_last_ts is not None and last_processed is not None:
             self._hydrate_incremental_state(df, state)
         use_incremental = (

--- a/tests/test_strategies_smoke.py
+++ b/tests/test_strategies_smoke.py
@@ -113,6 +113,8 @@ def test_dca_etf_strategy_smoke() -> None:
         window = df.iloc[: i + 1]
         signals_now = strategy.evaluate_live_bar(window, rolling_context)
         collected.extend(sig.side for sig in signals_now)
+        repeat_signals = strategy.evaluate_live_bar(window, rolling_context)
+        assert repeat_signals == []
     assert collected.count("BUY") == 5
 
 
@@ -147,5 +149,7 @@ def test_crypto_grid_strategy_generates_buy_and_sell() -> None:
         window = df.iloc[: i + 1]
         signals_now = strategy.evaluate_live_bar(window, live_context)
         collected.extend(sig.side for sig in signals_now)
+        repeat_signals = strategy.evaluate_live_bar(window, live_context)
+        assert repeat_signals == []
     assert collected.count("BUY") == 3
     assert collected[-1] == "SELL"


### PR DESCRIPTION
### Motivation
- Reduce CPU work during live evaluation by processing only newly-arrived bars and avoid re-evaluating already-processed candles.
- Preserve existing functional behavior and outputs while lowering live execution cost.

### Description
- Add an early-return check in the strategies' live `_process` loops to skip work when `only_last_ts` is not newer than `state.last_processed_ts` in `CryptoGridStrategy` and `DcaEtfStrategy` (files `src/quant_engine/strategies/crypto_grid.py` and `src/quant_engine/strategies/dca_etf.py`).
- Keep the incremental hydration logic intact (`_hydrate_incremental_state`) so incremental runs still compute rolling maxima and previous drawdown when needed.
- Add smoke assertions to `tests/test_strategies_smoke.py` that call `evaluate_live_bar` twice on the same window and assert the second call returns no signals to ensure idempotence.

### Testing
- Ran `pytest -q tests/test_strategies_smoke.py` and all tests passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678f561abc832395e1be44358ec007)