### PR TITLE
Support trailing-stop in canonical DCA input and DCA equity strategy

### DIFF
--- a/docs/canonical_runs_dca_source_of_truth_2026-02-20.md
+++ b/docs/canonical_runs_dca_source_of_truth_2026-02-20.md
@@ -88,6 +88,19 @@ Supported shapes:
 
 3. Preset string format: `tp_<X>_sl_<Y>` (example: `tp_2_sl_1`)
 
+4. Optional trailing stop (explicit object only):
+
+```json
+{
+  "trailing": {"enabled": true, "type": "percent", "value": 1.0, "trigger_pct": 1.2}
+}
+```
+
+Trailing rules:
+- `type` must be `percent`
+- `value` must be > 0
+- `trigger_pct` is optional (defaults to `value`) and must be >= 0
+
 Not wired:
 
 - string presets outside `tp_<X>_sl_<Y>` format

--- a/specs/tests/strategy_dca_equity_trailing_stop_bar_close.json
+++ b/specs/tests/strategy_dca_equity_trailing_stop_bar_close.json
@@ -1,0 +1,46 @@
+{
+  "strategy": {
+    "strategy_id": "DCA_EQUITY_TRAILING_BAR",
+    "type": "dca_equity",
+    "params": {
+      "asset_class": "EQUITY",
+      "execution_mode": "bar_close",
+      "drawdown_reference": "ATH",
+      "grid": [
+        {"dd": -5.0, "weight": 1.0}
+      ],
+      "tp_sl": {
+        "enabled": true,
+        "mode": "per_grid_max_dd",
+        "sl_dd": -50.0,
+        "rules": [
+          {"max_dd_reached": -5.0, "tp_pct": 50.0}
+        ],
+        "trailing": {
+          "enabled": true,
+          "type": "percent",
+          "value": 2.0,
+          "trigger_pct": 1.0
+        }
+      },
+      "require_crossing": false
+    }
+  },
+  "data": {
+    "source": "csv",
+    "path": "tests/data/ohlcv_ts_stop_loss.csv",
+    "timeframe": "1D",
+    "start": "2025-01-01",
+    "end": "2025-01-05"
+  },
+  "universe": [
+    {
+      "symbol": "SPY",
+      "asset_class": "EQUITY"
+    }
+  ],
+  "performance": {
+    "initial_capital": 10000,
+    "capital_per_unit": 100
+  }
+}

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -982,14 +982,18 @@ def _canonical_dca_tp_sl_to_internal(params: Dict[str, Any]) -> tuple[Any, bool]
     if isinstance(tp_sl_raw, dict):
         # Already internal-compatible shape used by the strategy runtime.
         if "rules" in tp_sl_raw or "sl_dd" in tp_sl_raw:
+            trailing_cfg = tp_sl_raw.get("trailing")
+            if trailing_cfg is not None and not _canonical_dca_trailing_supported(trailing_cfg):
+                return None, False
             return tp_sl_raw, True
 
-        # Canonical explicit shape: tp/sl/break_even.
+        # Canonical explicit shape: tp/sl/break_even[/trailing].
         if not (isinstance(tp_sl_raw.get("tp"), dict) and isinstance(tp_sl_raw.get("sl"), dict)):
             return None, False
         tp_cfg = tp_sl_raw.get("tp", {})
         sl_cfg = tp_sl_raw.get("sl", {})
         be_cfg = tp_sl_raw.get("break_even", {})
+        trailing_cfg = tp_sl_raw.get("trailing")
         if str(tp_cfg.get("type", "")).strip().lower() != "percent":
             return None, False
         if str(sl_cfg.get("type", "")).strip().lower() != "percent":
@@ -1007,12 +1011,21 @@ def _canonical_dca_tp_sl_to_internal(params: Dict[str, Any]) -> tuple[Any, bool]
                 be_value = float(be_cfg.get("trigger_pct"))
             except Exception:
                 return None, False
+
+        trailing_internal = None
+        if trailing_cfg is not None:
+            trailing_internal, trailing_supported = _canonical_dca_trailing_to_internal(trailing_cfg)
+            if not trailing_supported:
+                return None, False
+
         converted = {
             "enabled": bool(tp_sl_raw.get("enabled", True)),
             "mode": "per_grid_max_dd",
             "sl_dd": -abs(sl_value),
             "rules": [{"max_dd_reached": 0.0, "tp_pct": tp_value, "be_pct": be_value}],
         }
+        if trailing_internal is not None:
+            converted["trailing"] = trailing_internal
         return converted, True
 
     if isinstance(tp_sl_raw, str):
@@ -1034,6 +1047,42 @@ def _canonical_dca_tp_sl_to_internal(params: Dict[str, Any]) -> tuple[Any, bool]
         }, True
 
     return None, False
+
+
+def _canonical_dca_trailing_supported(trailing_cfg: Any) -> bool:
+    _internal, supported = _canonical_dca_trailing_to_internal(trailing_cfg)
+    return supported
+
+
+def _canonical_dca_trailing_to_internal(trailing_cfg: Any) -> tuple[Any, bool]:
+    if trailing_cfg is None:
+        return None, True
+    if not isinstance(trailing_cfg, dict):
+        return None, False
+    if trailing_cfg.get("enabled", True) is False:
+        return {"enabled": False}, True
+    trailing_type = str(trailing_cfg.get("type", "percent")).strip().lower()
+    if trailing_type != "percent":
+        return None, False
+    try:
+        value = float(trailing_cfg.get("value"))
+    except Exception:
+        return None, False
+    if value <= 0:
+        return None, False
+    trigger_raw = trailing_cfg.get("trigger_pct", trailing_cfg.get("triggerPct", value))
+    try:
+        trigger_pct = float(trigger_raw)
+    except Exception:
+        return None, False
+    if trigger_pct < 0:
+        return None, False
+    return {
+        "enabled": True,
+        "type": "percent",
+        "value": value,
+        "trigger_pct": trigger_pct,
+    }, True
 
 
 def _canonical_dca_to_strategy_spec(request: Dict[str, Any]) -> Dict[str, Any]:
@@ -2478,7 +2527,7 @@ def _canonical_runs_capabilities(spec_type: str) -> Dict[str, Any]:
         "presets": {
             "supported": {
                 "strategy.grid": ["grid_balanced"],
-                "strategy.params.tp_sl": ["tp_X_sl_Y"],
+                "strategy.params.tp_sl": ["tp_X_sl_Y", "tp_sl.trailing(percent)"],
             },
             "not_supported": {
                 "strategy.grid": ["grid_conservative", "grid_aggressive"],

--- a/src/quant_engine/strategies/dca_equity.py
+++ b/src/quant_engine/strategies/dca_equity.py
@@ -26,6 +26,8 @@ class _CycleState:
     last_processed_ts: Optional[pd.Timestamp] = None
     tp_emitted: bool = False
     be_armed: bool = False
+    trailing_armed: bool = False
+    trailing_peak: Optional[float] = None
     position_qty: float = 0.0
     position_cost: float = 0.0  # somme prix*qty pour prix moyen
 
@@ -38,6 +40,8 @@ class _CycleState:
         self.prev_dd = None
         self.tp_emitted = False
         self.be_armed = False
+        self.trailing_armed = False
+        self.trailing_peak = None
         self.position_qty = 0.0
         self.position_cost = 0.0
 
@@ -254,7 +258,7 @@ class DcaEquityStrategy(Strategy):
                         results.append(sig)
                 for sig in sells:
                     action = (sig.meta or {}).get("action") if hasattr(sig, "meta") else None
-                    if action in {"take_profit", "break_even", "stop_loss"}:
+                    if action in {"take_profit", "break_even", "stop_loss", "trailing_stop"}:
                         trade_count += 1
                         if max_trades is not None and max_trades > 0 and trade_count >= max_trades:
                             return results
@@ -401,12 +405,40 @@ class DcaEquityStrategy(Strategy):
         tp_pct = tp_rule.get("tp_pct") if tp_rule else None
         be_pct = tp_rule.get("be_pct") if tp_rule else None
         sl_dd = cfg.get("sl_dd")
+        trailing_cfg = self._resolve_trailing_cfg()
         if state.position_qty <= 0:
             return signals
 
         avg_entry = state.position_cost / state.position_qty if state.position_qty > 0 else close
         if avg_entry == 0:
             return signals
+
+        should_trailing_exit = False
+        trailing_stop_price: Optional[float] = None
+        trailing_trigger_price: Optional[float] = None
+        trailing_peak: Optional[float] = None
+
+        if trailing_cfg is not None:
+            trigger_pct = trailing_cfg["trigger_pct"]
+            trail_pct = trailing_cfg["trail_pct"]
+            trailing_trigger_price = avg_entry * (1.0 + trigger_pct / 100.0)
+            if self.execution_mode == "intracandle":
+                if high >= trailing_trigger_price:
+                    state.trailing_armed = True
+                if state.trailing_armed:
+                    state.trailing_peak = max(state.trailing_peak or high, high)
+                    trailing_peak = state.trailing_peak
+                    trailing_stop_price = trailing_peak * (1.0 - trail_pct / 100.0)
+                    should_trailing_exit = low <= trailing_stop_price
+            else:
+                if close >= trailing_trigger_price:
+                    state.trailing_armed = True
+                if state.trailing_armed:
+                    state.trailing_peak = max(state.trailing_peak or close, close)
+                    trailing_peak = state.trailing_peak
+                    trailing_stop_price = trailing_peak * (1.0 - trail_pct / 100.0)
+                    should_trailing_exit = close <= trailing_stop_price
+
         if self.execution_mode == "intracandle":
             tp_price = avg_entry * (1.0 + float(tp_pct) / 100.0) if tp_pct is not None else None
             be_arm_price = avg_entry * (1.0 + float(be_pct) / 100.0) if be_pct is not None else None
@@ -424,17 +456,11 @@ class DcaEquityStrategy(Strategy):
             should_be_exit = state.be_armed and pnl_pct <= 0.0
             should_sl = sl_dd is not None and dd <= float(sl_dd)
 
-        # Debug trace for TP/BE decisions (muted; re-enable for troubleshooting)
-        # print(
-        #     f"[TP_CHECK] cycle={state.cycle_id} sym={symbol} ts={ts} "
-        #     f"avg_entry={avg_entry:.4f} price={price:.4f} pnl_pct={pnl_pct:.2f} "
-        #     f"tp_pct={tp_pct} be_pct={be_pct} should_tp={should_tp} should_be={should_be} "
-        #     f"pos_qty={state.position_qty:.4f}"
-        # )
-
         action = None
         if should_sl and not state.tp_emitted:
             action = "stop_loss"
+        elif should_trailing_exit and not state.tp_emitted:
+            action = "trailing_stop"
         elif should_tp and not state.tp_emitted:
             action = "take_profit"
         elif should_be_exit and not state.tp_emitted:
@@ -444,6 +470,8 @@ class DcaEquityStrategy(Strategy):
             if self.execution_mode == "intracandle":
                 if action == "stop_loss":
                     exit_price = sl_price
+                elif action == "trailing_stop":
+                    exit_price = trailing_stop_price
                 elif action == "take_profit":
                     exit_price = tp_price
                 else:
@@ -460,6 +488,11 @@ class DcaEquityStrategy(Strategy):
                 "tp_pct": tp_pct,
                 "be_pct": be_pct,
                 "sl_dd": sl_dd,
+                "trailing": trailing_cfg,
+                "trailing_armed": state.trailing_armed,
+                "trailing_peak": trailing_peak,
+                "trailing_stop_price": trailing_stop_price,
+                "trailing_trigger_price": trailing_trigger_price,
                 "max_dd_reached": state.max_dd,
                 "drawdown_pct": state.max_dd,
                 "cycle_id": state.cycle_id,
@@ -531,6 +564,32 @@ class DcaEquityStrategy(Strategy):
                 selected = rule
         return selected
 
+
+    def _resolve_trailing_cfg(self) -> Optional[Dict[str, float]]:
+        cfg = self.tp_sl_config or {}
+        trailing_raw = cfg.get("trailing")
+        if not isinstance(trailing_raw, dict):
+            return None
+        if trailing_raw.get("enabled", True) is False:
+            return None
+        trailing_type = str(trailing_raw.get("type", "percent")).strip().lower()
+        if trailing_type != "percent":
+            return None
+        try:
+            trail_pct = float(trailing_raw.get("value"))
+            trigger_pct = float(trailing_raw.get("trigger_pct", trail_pct))
+        except Exception:
+            return None
+        if trail_pct <= 0 or trigger_pct < 0:
+            return None
+        return {
+            "enabled": True,
+            "type": "percent",
+            "value": trail_pct,
+            "trigger_pct": trigger_pct,
+            "trail_pct": trail_pct,
+        }
+
     def _normalize_ohlc(self, ohlc: pd.DataFrame) -> pd.DataFrame:
         if ohlc.empty:
             return ohlc
@@ -586,6 +645,10 @@ class DcaEquityStrategy(Strategy):
         )
         state.tp_emitted = bool(data.get("tp_emitted", False))
         state.be_armed = bool(data.get("be_armed", False))
+        state.trailing_armed = bool(data.get("trailing_armed", False))
+        state.trailing_peak = (
+            float(data.get("trailing_peak")) if data.get("trailing_peak") is not None else None
+        )
         state.position_qty = float(data.get("position_qty", 0.0))
         state.position_cost = float(data.get("position_cost", 0.0))
         state.current_price = float(data.get("current_price", 0.0))
@@ -607,6 +670,8 @@ class DcaEquityStrategy(Strategy):
                 else None,
                 "tp_emitted": state.tp_emitted,
                 "be_armed": state.be_armed,
+                "trailing_armed": state.trailing_armed,
+                "trailing_peak": state.trailing_peak,
                 "position_qty": state.position_qty,
                 "position_cost": state.position_cost,
                 "current_price": state.current_price,

--- a/tests/test_api_runs_lifecycle_endpoints.py
+++ b/tests/test_api_runs_lifecycle_endpoints.py
@@ -301,6 +301,7 @@ def test_runs_capabilities_returns_dca_runtime_matrix(tmp_path, monkeypatch) -> 
     assert "strategy.params.tp_sl" in body["fields"]["supported"]
     assert "performance.stress_tests" in body["fields"]["supported"]
     assert body["presets"]["supported"]["strategy.grid"] == ["grid_balanced"]
+    assert "tp_sl.trailing(percent)" in body["presets"]["supported"]["strategy.params.tp_sl"]
     assert "grid_conservative" in body["presets"]["not_supported"]["strategy.grid"]
     assert "grid_aggressive" in body["presets"]["not_supported"]["strategy.grid"]
     assert "filters" in body

--- a/tests/test_api_worker_queue.py
+++ b/tests/test_api_worker_queue.py
@@ -690,6 +690,61 @@ def test_worker_processes_canonical_dca_with_explicit_tp_sl_object(tmp_path, mon
     assert tp_sl["sl_dd"] == -1.5
 
 
+def test_worker_processes_canonical_dca_with_explicit_tp_sl_trailing_object(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("DB_SQLITE_PATH", str(tmp_path / "quant.db"))
+    reset_settings_cache()
+    payload = _canonical_dca_payload()
+    payload["strategy"]["params"]["tp_sl"] = {
+        "enabled": True,
+        "mode": "rule_based",
+        "tp": {"type": "percent", "value": 2.5},
+        "sl": {"type": "percent", "value": 1.5},
+        "trailing": {"enabled": True, "type": "percent", "value": 1.0, "trigger_pct": 1.2},
+    }
+    observed = {}
+
+    def _fake_backtest(spec):
+        observed["spec"] = spec
+        return {"result": {"counts": {"BTCUSD": 1}}, "payload": {"run": {"status": "ok"}}}
+
+    monkeypatch.setattr(api_app.strategies_runner, "run_backtest_with_payload", _fake_backtest)
+
+    response = api_app.enqueue_run_request(payload)
+    result = worker_module.process_next_job()
+
+    assert result is not None
+    job = api_app._get_job(response.run_id)
+    assert job["status"] == api_app.JOB_STATUS_SUCCEEDED
+    tp_sl = observed["spec"]["strategy"]["params"]["tp_sl"]
+    assert tp_sl["trailing"]["type"] == "percent"
+    assert tp_sl["trailing"]["value"] == 1.0
+    assert tp_sl["trailing"]["trigger_pct"] == 1.2
+
+
+def test_worker_marks_canonical_dca_not_implemented_for_invalid_trailing_tp_sl(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("DB_SQLITE_PATH", str(tmp_path / "quant.db"))
+    reset_settings_cache()
+    payload = _canonical_dca_payload()
+    payload["strategy"]["params"]["tp_sl"] = {
+        "enabled": True,
+        "mode": "rule_based",
+        "tp": {"type": "percent", "value": 2.5},
+        "sl": {"type": "percent", "value": 1.5},
+        "trailing": {"enabled": True, "type": "atr", "value": 1.0},
+    }
+
+    response = api_app.enqueue_run_request(payload)
+    result = worker_module.process_next_job()
+
+    assert result is not None
+    job = api_app._get_job(response.run_id)
+    assert job["status"] == api_app.JOB_STATUS_FAILED
+    error = job["result"]["error"]
+    assert error["code"] == "not_implemented_feature"
+    fields = [item["field"] for item in error["details"]]
+    assert "strategy.params.tp_sl" in fields
+
+
 def test_worker_processes_canonical_dca_with_grid_preset_and_rolling_high(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("DB_SQLITE_PATH", str(tmp_path / "quant.db"))
     reset_settings_cache()

--- a/tests/test_strategy_dca_stop_loss.py
+++ b/tests/test_strategy_dca_stop_loss.py
@@ -36,3 +36,13 @@ def test_strategy_dca_equity_stop_loss_bar_close(monkeypatch) -> None:
     spec = _load_spec("strategy_dca_equity_stop_loss_bar_close.json")
     result = strategies_runner.run_backtest_with_payload(spec)
     _assert_stop_loss(result)
+
+
+def test_strategy_dca_equity_trailing_stop_bar_close(monkeypatch) -> None:
+    monkeypatch.delenv("DB_DSN", raising=False)
+    _reset_cache()
+    spec = _load_spec("strategy_dca_equity_trailing_stop_bar_close.json")
+    result = strategies_runner.run_backtest_with_payload(spec)
+    trades = result.get("payload", {}).get("trades", [])
+    assert trades
+    assert any(t.get("meta", {}).get("action") == "trailing_stop" for t in trades)


### PR DESCRIPTION
### Motivation

- Add optional trailing-stop configuration to canonical `tp_sl` input so users can express trailing exits alongside TP/SL/break-even in DCA specs.
- Wire trailing-stop validation and conversion in the API so invalid trailing configs are rejected early as "not implemented".
- Implement runtime trailing-stop logic in the `DcaEquityStrategy` so backtests can emit `trailing_stop` sell signals and include trailing metadata in outputs.

### Description

- Documentation: updated `docs/canonical_runs_dca_source_of_truth_2026-02-20.md` to document the optional `trailing` object (fields: `enabled`, `type`, `value`, `trigger_pct`) and basic validation rules.
- API conversion/validation: extended `_canonical_dca_tp_sl_to_internal` with support for a `trailing` sub-object and added `_canonical_dca_trailing_to_internal` / `_canonical_dca_trailing_supported` helpers to validate/convert canonical trailing configs into internal runtime shapes.
- Capabilities: added `tp_sl.trailing(percent)` to the DCA presets in `_canonical_runs_capabilities` so it's advertised as a supported preset.
- Strategy runtime: extended `DcaEquityStrategy` with trailing-stop state (`trailing_armed`, `trailing_peak`), a `_resolve_trailing_cfg` helper, and integrated trailing-stop handling into `_check_take_profit` to arm, track peak, compute trailing stop price, and emit `trailing_stop` actions with metadata.
- Persistence/serialization: included `trailing_armed` and `trailing_peak` in state (de)serialization and the context dictionary so state is preserved across checkpoints.
- Tests & specs: added a new canonical spec `specs/tests/strategy_dca_equity_trailing_stop_bar_close.json` and extended tests to cover the new behavior and validation paths.

### Testing

- Ran `pytest tests/test_strategy_dca_stop_loss.py::test_strategy_dca_equity_trailing_stop_bar_close` which executed the backtest spec and asserted a `trailing_stop` trade was produced; test passed.
- Ran `pytest tests/test_api_worker_queue.py::test_worker_processes_canonical_dca_with_explicit_tp_sl_trailing_object` to verify canonical trailing config is converted to internal spec; test passed.
- Ran `pytest tests/test_api_worker_queue.py::test_worker_marks_canonical_dca_not_implemented_for_invalid_trailing_tp_sl` to verify invalid trailing types are rejected and result in a `not_implemented_feature` failure; test passed.
- Ran `pytest tests/test_api_runs_lifecycle_endpoints.py::test_runs_capabilities_returns_dca_runtime_matrix` to ensure the capabilities payload advertises trailing preset; test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a8dd0bb88323963a51d0610f7e90)