### PR TITLE
PY-DCA-EPIC-2: Moteur métriques DCA (final_perf_norm, TWR, XIRR, drawdown) + persistance API

### DIFF
--- a/docs/backtest_metrics.md
+++ b/docs/backtest_metrics.md
@@ -10,3 +10,18 @@ Le bloc `performance` d'un run peut accepter :
 - `risk_free_pct` : taux sans risque annualisé en pourcentage (ex. `2.0`).
 
 Si le timeframe est fourni, l'annualisation utilise un nombre de périodes par an cohérent avec l'asset class (crypto 24/7, actions ~252 jours de bourse). Si le timeframe est absent, l'annualisation est déduite de la durée du backtest.
+
+## Métriques DCA supplémentaires (v1)
+
+Pour les runs `spec_type=dca`, le moteur expose aussi :
+
+- `final_performance_normalized` : performance finale normalisée par le capital réellement contribué.
+- `twr` : time-weighted return basé sur les rendements de cycles.
+- `xirr` : rendement annualisé sur cashflows irréguliers (statut séparé `xirr_status` pour non-convergence).
+- `max_drawdown_on_contributed_capital` : drawdown max rapporté au capital contribué au fil de l'eau.
+- `time_under_water` : plus longue durée passée sous le dernier plus haut de la courbe de valeur.
+
+### Limites connues
+
+- Les cashflows très irréguliers peuvent entraîner des non-convergences `xirr` (`xirr_status=non_convergent`).
+- Certaines séries de cashflows peuvent admettre plusieurs racines IRR; l'algorithme retourne une solution numérique locale si convergence.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -1804,6 +1804,8 @@ def _execute_job(
         result = _run_job_payload(job_type, payload)
         if job_type == JOB_TYPE_OPTIMIZATION:
             _persist_optimization_result(job_id, payload, result)
+        if job_type == JOB_TYPE_CANONICAL_RUN:
+            _persist_canonical_run_metrics(job_id, payload, result)
     except Exception as exc:  # pragma: no cover - defensive
         _update_job_status(job_id, failure_status, error=str(exc))
         raise
@@ -1817,6 +1819,41 @@ def _first_numeric_metric(metrics: Dict[str, Any]) -> float | None:
         if isinstance(value, (int, float)):
             return float(value)
     return None
+
+
+def _persist_canonical_run_metrics(job_id: str, payload: Any | None, result: Any) -> None:
+    if not isinstance(payload, dict) or not isinstance(result, dict):
+        return
+    request = payload.get("request") if isinstance(payload.get("request"), dict) else {}
+    spec_type = str(request.get("spec_type") or "").strip().lower()
+    if spec_type != "dca" or result.get("accepted") is not True:
+        return
+
+    run_payload = result.get("payload") if isinstance(result.get("payload"), dict) else {}
+    run = run_payload.get("run") if isinstance(run_payload.get("run"), dict) else {}
+    extra = run.get("extra") if isinstance(run.get("extra"), dict) else {}
+
+    metrics_map: Dict[str, float] = {}
+    for key in (
+        "final_performance_normalized",
+        "twr",
+        "xirr",
+        "max_drawdown_on_contributed_capital",
+        "time_under_water",
+    ):
+        value = extra.get(key)
+        if isinstance(value, (int, float)):
+            metrics_map[key] = float(value)
+
+    xirr_status = extra.get("xirr_status")
+    if isinstance(xirr_status, str):
+        metrics_map["xirr_converged"] = 1.0 if xirr_status == "ok" else 0.0
+
+    if not metrics_map:
+        return
+
+    with db.session() as conn:
+        MetricsRepository(conn).bulk_upsert_metrics(job_id, metrics_map, fold=None)
 
 
 def _persist_optimization_result(job_id: str, payload: Any | None, result: Any) -> None:

--- a/src/quant_engine/api/worker.py
+++ b/src/quant_engine/api/worker.py
@@ -179,6 +179,8 @@ def process_next_job(
     if api_app._is_true_flag(api_app._get_job(job_id).get("cancel_requested")):
         api_app._mark_canceled(job_id)
         return None
+    if job.get("job_type") == api_app.JOB_TYPE_CANONICAL_RUN:
+        api_app._persist_canonical_run_metrics(job_id, job.get("payload"), result)
     payload_out = api_app._build_job_result(job.get("job_type"), job_id, result)
     api_app._update_job_result(job_id, payload_out, status=success_status)
     return payload_out

--- a/src/quant_engine/backtest/metrics.py
+++ b/src/quant_engine/backtest/metrics.py
@@ -1,8 +1,143 @@
 """Performance metrics used during optimisation."""
 from __future__ import annotations
 
+from datetime import datetime
 import math
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Sequence, Tuple
+
+
+CashflowPoint = Tuple[datetime, float]
+
+
+def final_performance_normalized(final_value: float, contributed_capital: float) -> float:
+    """Return normalized performance relative to contributed capital.
+
+    Formula: ``(final_value - contributed_capital) / contributed_capital``.
+    Returns ``0.0`` when ``contributed_capital <= 0`` to keep the metric safe.
+    """
+
+    contributed = float(contributed_capital)
+    if contributed <= 0:
+        return 0.0
+    return (float(final_value) - contributed) / contributed
+
+
+def twr(period_returns: Sequence[float]) -> float:
+    """Compute Time-Weighted Return for periodic returns in decimal form."""
+
+    if not period_returns:
+        return 0.0
+    growth = 1.0
+    for ret in period_returns:
+        growth *= 1.0 + float(ret)
+    return growth - 1.0
+
+
+def xirr(cashflows: Sequence[CashflowPoint], *, max_iter: int = 100, tol: float = 1e-8) -> Tuple[float | None, str]:
+    """Compute annualized XIRR and return ``(value, status)``.
+
+    Status values:
+    - ``ok``: converged
+    - ``invalid_cashflows``: no sign change in cashflows
+    - ``non_convergent``: Newton/bisection did not converge
+    """
+
+    if len(cashflows) < 2:
+        return None, "invalid_cashflows"
+
+    flows = sorted(cashflows, key=lambda item: item[0])
+    amounts = [float(v) for _, v in flows]
+    if not any(v < 0 for v in amounts) or not any(v > 0 for v in amounts):
+        return None, "invalid_cashflows"
+
+    t0 = flows[0][0]
+    years = [max(0.0, (dt - t0).total_seconds()) / (365.25 * 24 * 3600) for dt, _ in flows]
+
+    def _npv(rate: float) -> float:
+        base = 1.0 + rate
+        if base <= 0.0:
+            return float("inf")
+        return sum(cf / (base ** yr) for yr, (_, cf) in zip(years, flows))
+
+    def _d_npv(rate: float) -> float:
+        base = 1.0 + rate
+        if base <= 0.0:
+            return float("inf")
+        return sum((-yr * cf) / (base ** (yr + 1.0)) for yr, (_, cf) in zip(years, flows))
+
+    rate = 0.1
+    for _ in range(max_iter):
+        value = _npv(rate)
+        if abs(value) < tol:
+            return rate, "ok"
+        deriv = _d_npv(rate)
+        if deriv == 0 or not math.isfinite(deriv):
+            break
+        new_rate = rate - value / deriv
+        if not math.isfinite(new_rate) or new_rate <= -0.999999:
+            break
+        if abs(new_rate - rate) < tol:
+            return new_rate, "ok"
+        rate = new_rate
+
+    low, high = -0.9999, 10.0
+    f_low = _npv(low)
+    f_high = _npv(high)
+    if not (math.isfinite(f_low) and math.isfinite(f_high)) or f_low * f_high > 0:
+        return None, "non_convergent"
+
+    for _ in range(max_iter):
+        mid = (low + high) / 2.0
+        f_mid = _npv(mid)
+        if not math.isfinite(f_mid):
+            return None, "non_convergent"
+        if abs(f_mid) < tol or abs(high - low) < tol:
+            return mid, "ok"
+        if f_low * f_mid <= 0:
+            high = mid
+            f_high = f_mid
+        else:
+            low = mid
+            f_low = f_mid
+    return None, "non_convergent"
+
+
+def max_drawdown_on_contributed_capital(equity_values: Sequence[float], contributed_capital: Sequence[float]) -> float:
+    """Return max drawdown normalized by contributed capital at each step."""
+
+    length = min(len(equity_values), len(contributed_capital))
+    if length == 0:
+        return 0.0
+    peak = float(equity_values[0])
+    max_dd = 0.0
+    for idx in range(length):
+        value = float(equity_values[idx])
+        contrib = float(contributed_capital[idx])
+        peak = max(peak, value)
+        denom = contrib if contrib > 0 else 1.0
+        dd = (peak - value) / denom
+        if dd > max_dd:
+            max_dd = dd
+    return max_dd
+
+
+def time_under_water(equity_values: Sequence[float]) -> int:
+    """Return the longest consecutive period below the last peak."""
+
+    if not equity_values:
+        return 0
+    peak = float(equity_values[0])
+    current = 0
+    longest = 0
+    for val in equity_values:
+        value = float(val)
+        if value >= peak:
+            peak = value
+            current = 0
+            continue
+        current += 1
+        longest = max(longest, current)
+    return longest
 
 
 def sharpe_ratio(returns: List[float]) -> float:

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Protocol, Tuple
 import pandas as pd
 
 from .models import CompletedTrade, StrategyRunResult, to_backend_payload
+from ..backtest import metrics as backtest_metrics
 from .stress_tests import run_monte_carlo_on_trades
 
 LOGGER = logging.getLogger(__name__)
@@ -38,6 +39,30 @@ def _maybe_dt(value: Any) -> Optional[datetime]:
         return pd.to_datetime(value, utc=True).to_pydatetime()
     except Exception:
         return None
+
+
+def _extract_buy_cashflows(trade: CompletedTrade) -> List[Tuple[datetime, float]]:
+    """Extract negative cashflows from trade metadata buy entries."""
+
+    raw_entries = trade.meta.get("buy_entries") if isinstance(trade.meta, dict) else None
+    if not isinstance(raw_entries, list):
+        return []
+    out: List[Tuple[datetime, float]] = []
+    for item in raw_entries:
+        if not isinstance(item, dict):
+            continue
+        dt = _maybe_dt(item.get("ts_utc"))
+        qty = item.get("qty")
+        price = item.get("price")
+        if dt is None:
+            continue
+        try:
+            amount = float(qty) * float(price)
+        except Exception:
+            continue
+        if amount > 0:
+            out.append((dt, -amount))
+    return out
 
 
 def _start_end_from_signals(signals_by_symbol: Mapping[str, Iterable[SignalLike]]) -> Tuple[Optional[datetime], Optional[datetime]]:
@@ -192,6 +217,7 @@ def build_dca_performance_from_signals(
                     "synthetic_entry": not bool(buys),
                 }
             )
+            tp_meta["buy_entries"] = buy_entries
             if len(buy_entries) > 1:
                 tp_meta["intermediate_entries"] = buy_entries[1:]
 
@@ -254,9 +280,11 @@ def build_dca_performance_from_signals(
     total_return = sum(t.gross_pnl_pct for t in trades)  # points de pourcentage cumulés
     nb_trades = len(trades)
     average_trade = total_return / nb_trades if nb_trades else 0.0
+
+    sorted_trades = sorted(trades, key=lambda t: t.exit_time_utc) if trades else []
+
     # max drawdown sur l'équité cumulée en pourcentage (somme des pnl_pct)
-    if trades:
-        sorted_trades = sorted(trades, key=lambda t: t.exit_time_utc)
+    if sorted_trades:
         equity = 0.0
         peak = 0.0
         max_dd_val = 0.0
@@ -267,19 +295,42 @@ def build_dca_performance_from_signals(
         max_drawdown_val = abs(max_dd_val)
     else:
         max_drawdown_val = 0.0
-    # Courbe de capital en valeur (utilise capital_per_unit * qty comme notionnel)
-    equity_value = initial_capital
-    equity_peak_value = initial_capital
-    max_dd_value = 0.0
-    if trades:
-        for tr in sorted(trades, key=lambda t: t.exit_time_utc):
-            notionnel = capital_per_unit * (tr.quantity or 0.0)
-            pnl_value = notionnel * (tr.gross_pnl_pct / 100.0)
-            equity_value += pnl_value
-            equity_peak_value = max(equity_peak_value, equity_value)
-            max_dd_value = max(max_dd_value, equity_peak_value - equity_value)
-    max_drawdown_pct_value = (max_dd_value / equity_peak_value * 100.0) if equity_peak_value > 0 else None
+
+    # Courbe de capital en valeur (cashflows irréguliers: entrées BUY puis sortie SELL agrégée)
+    cashflows: List[Tuple[datetime, float]] = []
+    equity_values: List[float] = []
+    contributed_values: List[float] = []
+    contributed_capital = 0.0
+    equity_value = float(initial_capital)
+
+    if sorted_trades:
+        for tr in sorted_trades:
+            for dt, amount in _extract_buy_cashflows(tr):
+                cashflows.append((dt, amount))
+                contributed_capital += abs(amount)
+                equity_value += amount
+                equity_values.append(equity_value)
+                contributed_values.append(contributed_capital)
+
+            exit_dt = tr.exit_time_utc
+            sale_amount = (tr.exit_price or 0.0) * (tr.quantity or 0.0)
+            if sale_amount:
+                cashflows.append((exit_dt, sale_amount))
+                equity_value += sale_amount
+                equity_values.append(equity_value)
+                contributed_values.append(contributed_capital)
+
+    max_drawdown_pct_value = (
+        backtest_metrics.max_drawdown_on_contributed_capital(equity_values, contributed_values) * 100.0
+        if equity_values
+        else None
+    )
     return_pct_value = ((equity_value - initial_capital) / initial_capital * 100.0) if initial_capital else None
+
+    final_perf_norm = backtest_metrics.final_performance_normalized(equity_value, contributed_capital)
+    twr_value = backtest_metrics.twr([t.gross_pnl_pct / 100.0 for t in sorted_trades])
+    xirr_value, xirr_status = backtest_metrics.xirr(cashflows) if cashflows else (None, "invalid_cashflows")
+    time_under_water_periods = backtest_metrics.time_under_water(equity_values)
     tp_values: List[float] = []
     for tr in trades:
         tp_val = tr.meta.get("tp_pct") if isinstance(tr.meta, dict) else None
@@ -340,7 +391,15 @@ def build_dca_performance_from_signals(
         winrate_pct=(win_count / nb_trades * 100.0) if nb_trades else None,
         extra={
             "capital_per_unit": capital_per_unit,
-            "note": "DCA performance computed from pct PnL with simple capital model.",
+            "note": "DCA performance computed from pct PnL with cashflow-aware metrics.",
+            "metrics_version": "dca-grid-process-v1",
+            "final_performance_normalized": final_perf_norm,
+            "twr": twr_value,
+            "xirr": xirr_value,
+            "xirr_status": xirr_status,
+            "max_drawdown_on_contributed_capital": max_drawdown_pct_value,
+            "time_under_water": time_under_water_periods,
+            "contributed_capital": contributed_capital,
         },
     )
 

--- a/src/quant_engine/persistence/db.py
+++ b/src/quant_engine/persistence/db.py
@@ -156,6 +156,9 @@ class _CompatCursor:
     def fetchall(self) -> Any:
         return self._raw.fetchall()
 
+    def __iter__(self):
+        return iter(self._raw)
+
     @property
     def rowcount(self) -> int:
         return int(getattr(self._raw, "rowcount", 0))

--- a/tests/api/test_runs_metrics_dca.py
+++ b/tests/api/test_runs_metrics_dca.py
@@ -1,0 +1,78 @@
+import sys
+import types
+
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_stub.connect = lambda *args, **kwargs: None
+    cursors_stub = types.ModuleType("pymysql.cursors")
+    cursors_stub.DictCursor = object
+    pymysql_stub.cursors = cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = cursors_stub
+
+from quant_engine.api import app as api_app
+from quant_engine.api import worker as worker_module
+from quant_engine.config import reset_settings_cache
+
+
+def _canonical_dca_payload() -> dict:
+    return {
+        "spec_type": "dca",
+        "catalog_version": "v1",
+        "data": {
+            "symbol": "BTCUSD",
+            "timeframe": "H1",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-02",
+        },
+        "strategy": {
+            "type": "dca_equity",
+            "grid": [],
+            "params": {
+                "grid": [{"dd": -5.0, "weight": 1.0}],
+                "execution_mode": "bar_close",
+                "drawdown_reference": "ATH",
+            },
+        },
+    }
+
+
+def _setup_db(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("DB_SQLITE_PATH", str(tmp_path / "quant.db"))
+    reset_settings_cache()
+
+
+def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> None:
+    _setup_db(tmp_path, monkeypatch)
+
+    def _fake_backtest(_spec):
+        return {
+            "result": {"counts": {"BTCUSD": 1}},
+            "payload": {
+                "run": {
+                    "status": "ok",
+                    "extra": {
+                        "final_performance_normalized": 0.12,
+                        "twr": 0.10,
+                        "xirr": 0.08,
+                        "xirr_status": "ok",
+                        "max_drawdown_on_contributed_capital": 15.0,
+                        "time_under_water": 3,
+                    },
+                }
+            },
+        }
+
+    monkeypatch.setattr(api_app.strategies_runner, "run_backtest_with_payload", _fake_backtest)
+
+    response = api_app.enqueue_run_request(_canonical_dca_payload())
+    worker_module.process_next_job()
+
+    payload = api_app.run_metrics_endpoint(response.run_id)
+    aggregated = payload["aggregated"]
+    assert aggregated["final_performance_normalized"] == 0.12
+    assert aggregated["twr"] == 0.10
+    assert aggregated["xirr"] == 0.08
+    assert aggregated["max_drawdown_on_contributed_capital"] == 15.0
+    assert aggregated["time_under_water"] == 3.0
+    assert aggregated["xirr_converged"] == 1.0

--- a/tests/backtest/test_dca_metrics.py
+++ b/tests/backtest/test_dca_metrics.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from quant_engine.backtest import metrics
+
+
+def test_final_performance_normalized() -> None:
+    assert metrics.final_performance_normalized(1300.0, 1000.0) == pytest.approx(0.3)
+
+
+def test_twr_compounds_period_returns() -> None:
+    assert metrics.twr([0.1, -0.05, 0.02]) == pytest.approx((1.1 * 0.95 * 1.02) - 1.0)
+
+
+def test_xirr_converges_on_regular_cashflows() -> None:
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    value, status = metrics.xirr(
+        [
+            (start, -1000.0),
+            (start + timedelta(days=365), 1100.0),
+        ]
+    )
+    assert status == "ok"
+    assert value == pytest.approx(0.1, rel=1e-3)
+
+
+def test_xirr_invalid_without_sign_change() -> None:
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    value, status = metrics.xirr([(start, -100.0), (start + timedelta(days=1), -10.0)])
+    assert value is None
+    assert status == "invalid_cashflows"
+
+
+def test_drawdown_and_time_under_water_on_contributed_capital() -> None:
+    equity = [100.0, 150.0, 120.0, 140.0, 170.0]
+    contributed = [100.0, 120.0, 120.0, 140.0, 140.0]
+    assert metrics.max_drawdown_on_contributed_capital(equity, contributed) == pytest.approx(0.25)
+    assert metrics.time_under_water(equity) == 2


### PR DESCRIPTION
### Motivation
- Fournir un moteur réutilisable de métriques DCA permettant de comparer DCA Grid et benchmarks passifs en tenant compte des cashflows irréguliers et du capital effectivement contribué.
- Exposer ces métriques via l’API `/runs/{run_id}/metrics` pour les runs canoniques afin d’alimenter tableaux et artefacts versionnés.
- Rendre le calcul robuste face aux non-convergences IRR en conservant un statut explicite (`xirr_status`) au lieu de masquer l’erreur.

### Description
- Ajout des primitives métriques dans `src/quant_engine/backtest/metrics.py`: `final_performance_normalized`, `twr`, `xirr` (retourne `(value, status)`), `max_drawdown_on_contributed_capital`, et `time_under_water` avec typage et gestion des cas limites.
- Intégration cashflow-aware dans `src/quant_engine/performance/dca_builder.py` en sauvegardant les `buy_entries` dans `trade.meta`, en reconstruisant les cashflows BUY/SELL, en calculant les métriques ci-dessus et en exposant le résultat dans `run.extra` (inclut `metrics_version: dca-grid-process-v1`).
- Persistance et exposition via l’API: ajout de `_persist_canonical_run_metrics` dans `src/quant_engine/api/app.py` et appel lors du traitement de jobs canoniques dans `src/quant_engine/api/worker.py`, en upsertant les métriques (`run_metrics`) et en conservant un flag `xirr_converged`.
- Ajustements d’infrastructure et documentation: ajout de l’itérateur sur `_CompatCursor` (`src/quant_engine/persistence/db.py`) pour compatibilité lors de lectures itératives, et enrichissement de `docs/backtest_metrics.md` sur les métriques DCA et limites XIRR.
- Tests ajoutés: unitaires numériques dans `tests/backtest/test_dca_metrics.py` et test d’intégration endpoint dans `tests/api/test_runs_metrics_dca.py`.

### Testing
- Unit tests numériques exécutés: `poetry run pytest -q tests/backtest/test_dca_metrics.py` — Passed (all tests passed).
- Integration test executed: `poetry run pytest -q tests/api/test_runs_metrics_dca.py` — Passed (endpoint persistence and metrics exposure passed).
- Regression check: `poetry run pytest -q tests/test_backtest_metrics.py` — Passed (existing backtest metrics tests remain green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a584bbe8508323a70c778a9d43f28b)