### PR TITLE
PY-DCA-EPIC-3: add robustness percentiles, dominance and reproducible stress sweep

### DIFF
--- a/src/quant_engine/optimize/runner.py
+++ b/src/quant_engine/optimize/runner.py
@@ -29,6 +29,29 @@ def _iterate_search_space(search_space: Dict[str, List[int]]):
             yield {"ema_fast": fast, "ema_slow": slow}
 
 
+def _bounded_stress_grid(base_params: Dict[str, int]) -> List[Dict[str, int]]:
+    """Return a reproducible bounded parameter sweep around base params."""
+
+    fast = int(base_params.get("ema_fast", 0))
+    slow = int(base_params.get("ema_slow", 0))
+    candidates: List[Dict[str, int]] = []
+    for df in (-2, 0, 2):
+        for ds in (-5, 0, 5):
+            f = max(2, fast + df)
+            sl = max(f + 1, slow + ds)
+            candidates.append({"ema_fast": f, "ema_slow": sl})
+
+    seen = set()
+    out: List[Dict[str, int]] = []
+    for c in candidates:
+        key = (c["ema_fast"], c["ema_slow"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(c)
+    return out
+
+
 def run(spec: Spec, out_dir: str | Path = Path(".")) -> Dict[str, Any]:
     data = dataset.load_dataset(spec.data)
     val = spec.strategy.validation
@@ -42,34 +65,35 @@ def run(spec: Spec, out_dir: str | Path = Path(".")) -> Dict[str, Any]:
     best: Dict[str, Any] | None = None
     best_folds: List[Any] = []
 
-    for params in _iterate_search_space(spec.strategy.search_space):
-        for r in range(1, 6):
-            fold_metrics = []
-            fold_artifacts = []
-            for fold in folds:
-                test = fold["test"]
-                signal = EmaCross(params["ema_fast"], params["ema_slow"]).generate(test)
-                atr_vals = atr.compute(test)
-                trades, equity, summary = engine.run(
-                    test,
-                    signal,
-                    atr_vals,
-                    spec.strategy.tpsl.atr_k,
-                    r,
-                )
-                fold_metrics.append(summary)
-                fold_artifacts.append((trades, equity))
-            if not fold_metrics:
-                continue
-            avg_sharpe = sum(m["sharpe"] for m in fold_metrics) / len(fold_metrics)
-            trial = {"params": {**params, "R": r}, "metrics": {"sharpe": avg_sharpe}}
-            trials.append(trial)
-            if (
-                len(fold_artifacts[0][0]) >= val.min_trades
-                and (best is None or avg_sharpe > best["metrics"]["sharpe"])
-            ):
-                best = trial
-                best_folds = fold_artifacts
+    for base_params in _iterate_search_space(spec.strategy.search_space):
+        for params in _bounded_stress_grid(base_params):
+            for r in range(1, 6):
+                fold_metrics = []
+                fold_artifacts = []
+                for fold in folds:
+                    test = fold["test"]
+                    signal = EmaCross(params["ema_fast"], params["ema_slow"]).generate(test)
+                    atr_vals = atr.compute(test)
+                    trades, equity, summary = engine.run(
+                        test,
+                        signal,
+                        atr_vals,
+                        spec.strategy.tpsl.atr_k,
+                        r,
+                    )
+                    fold_metrics.append(summary)
+                    fold_artifacts.append((trades, equity))
+                if not fold_metrics:
+                    continue
+                avg_sharpe = sum(m["sharpe"] for m in fold_metrics) / len(fold_metrics)
+                trial = {"params": {**params, "R": r}, "metrics": {"sharpe": avg_sharpe}}
+                trials.append(trial)
+                if (
+                    len(fold_artifacts[0][0]) >= val.min_trades
+                    and (best is None or avg_sharpe > best["metrics"]["sharpe"])
+                ):
+                    best = trial
+                    best_folds = fold_artifacts
 
     artifacts.write_trials(out_dir / "trials.parquet", [
         {**t["params"], **t["metrics"]} for t in trials

--- a/src/quant_engine/stats/__init__.py
+++ b/src/quant_engine/stats/__init__.py
@@ -1,6 +1,19 @@
 """Statistics module skeleton."""
 
-from .runner import run_stats
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .runner import run_stats as run_stats
+
 
 __all__ = ["run_stats"]
 
+
+def __getattr__(name: str):
+    if name == "run_stats":
+        from .runner import run_stats as _run_stats
+
+        return _run_stats
+    raise AttributeError(name)

--- a/src/quant_engine/stats/estimators.py
+++ b/src/quant_engine/stats/estimators.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from math import sqrt
 from statistics import NormalDist
-from typing import Dict, Tuple
+from typing import Dict, Sequence, Tuple
 
 import math
+import random
 import numpy as np
 import pandas as pd
 
@@ -198,6 +199,66 @@ def aggregate_binary_bayes(
     }
 
 
+def monte_carlo_calendar_distribution(
+    values: Sequence[float],
+    *,
+    n_runs: int,
+    sample_size: int | None = None,
+    seed: int = 42,
+) -> list[float]:
+    """Bootstrap distribution for calendar-like simulations with a traceable seed."""
+
+    if n_runs <= 0:
+        return []
+    pool = [float(v) for v in values]
+    if not pool:
+        return [0.0] * n_runs
+    k = sample_size or len(pool)
+    rng = random.Random(int(seed))
+    sims: list[float] = []
+    for _ in range(n_runs):
+        draw = [pool[rng.randrange(0, len(pool))] for _ in range(k)]
+        sims.append(float(sum(draw) / len(draw)))
+    return sims
+
+
+def percentile_rank(value: float, distribution: Sequence[float]) -> float:
+    """Return percentile rank (0..100) of value in distribution."""
+
+    if not distribution:
+        return 0.0
+    below_or_equal = sum(1 for x in distribution if float(x) <= float(value))
+    return 100.0 * below_or_equal / len(distribution)
+
+
+def stochastic_dominance_simplified(
+    observed_perf: float,
+    observed_drawdown: float,
+    passive_perf_distribution: Sequence[float],
+    passive_drawdown_distribution: Sequence[float],
+    threshold: float = 0.6,
+) -> Dict[str, float | bool]:
+    """Simplified dominance test using pairwise probability thresholds."""
+
+    n_perf = len(passive_perf_distribution)
+    n_dd = len(passive_drawdown_distribution)
+    perf_prob = (
+        sum(1 for x in passive_perf_distribution if float(observed_perf) >= float(x)) / n_perf
+        if n_perf
+        else 0.0
+    )
+    drawdown_prob = (
+        sum(1 for x in passive_drawdown_distribution if float(observed_drawdown) <= float(x)) / n_dd
+        if n_dd
+        else 0.0
+    )
+    return {
+        "perf_dominance_prob": perf_prob,
+        "drawdown_dominance_prob": drawdown_prob,
+        "is_dominant": perf_prob >= threshold and drawdown_prob >= threshold,
+    }
+
+
 __all__ = [
     "freq_with_wilson",
     "aggregate_binary",
@@ -209,5 +270,7 @@ __all__ = [
     "posterior_map",
     "beta_hdi",
     "aggregate_binary_bayes",
+    "monte_carlo_calendar_distribution",
+    "percentile_rank",
+    "stochastic_dominance_simplified",
 ]
-

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import json
 import pandas as pd
 
 from ..api.schemas import StatsSpec
@@ -11,8 +12,6 @@ from ..core.dataset import load_ohlcv
 from ..core.features import atr
 from ..validate import splitter
 from ..io import artifacts
-from ..persistence import db
-from ..persistence.repo import MarketStatsRepository
 from . import conditions as cond_mod
 from . import events as event_mod
 from . import targets as tgt_mod
@@ -21,6 +20,9 @@ from .estimators import (
     aggregate_binary_bayes,
     p_value_binomial_onesided_normal,
     benjamini_hochberg,
+    monte_carlo_calendar_distribution,
+    percentile_rank,
+    stochastic_dominance_simplified,
 )
 
 N_MIN = 300
@@ -256,6 +258,82 @@ def _aggregate(df: pd.DataFrame) -> pd.DataFrame:
     return grouped[columns]
 
 
+def _compute_robustness_artifacts(out: pd.DataFrame, seed: int = 42) -> Dict[str, Any]:
+    """Compute percentile and simplified dominance against passive benchmark distribution."""
+
+    if out.empty:
+        return {
+            "version": "dca-grid-process-v1",
+            "seed": int(seed),
+            "n_runs": 0,
+            "quantiles": {},
+            "percentile": 0.0,
+            "dominance": {
+                "perf_dominance_prob": 0.0,
+                "drawdown_dominance_prob": 0.0,
+                "is_dominant": False,
+            },
+            "stress_grid": [],
+            "notes": "Dominance simplifiee: P(perf_obs >= perf_passive) et P(dd_obs <= dd_passive)",
+        }
+
+    observed_perf = float(out["lift_freq"].mean()) if "lift_freq" in out.columns else 0.0
+    observed_drawdown = float((1.0 - out["p_hat"]).clip(lower=0).mean()) if "p_hat" in out.columns else 0.0
+
+    passive_perf_distribution = monte_carlo_calendar_distribution(
+        list(out["p_hat"].fillna(0.0).astype(float).to_numpy()),
+        n_runs=200,
+        sample_size=max(1, min(20, len(out))),
+        seed=seed,
+    )
+    passive_drawdown_distribution = monte_carlo_calendar_distribution(
+        list((1.0 - out["p_hat"].fillna(0.0).astype(float)).clip(lower=0).to_numpy()),
+        n_runs=200,
+        sample_size=max(1, min(20, len(out))),
+        seed=seed + 1,
+    )
+
+    quantiles = {}
+    for q in [0.05, 0.25, 0.5, 0.75, 0.95]:
+        quantiles[f"p{int(q*100)}"] = float(pd.Series(passive_perf_distribution).quantile(q))
+
+    dominance = stochastic_dominance_simplified(
+        observed_perf,
+        observed_drawdown,
+        passive_perf_distribution,
+        passive_drawdown_distribution,
+        threshold=0.6,
+    )
+
+    stress_grid: List[Dict[str, Any]] = []
+    for n_runs in [50, 100, 200]:
+        dist = monte_carlo_calendar_distribution(
+            list(out["p_hat"].fillna(0.0).astype(float).to_numpy()),
+            n_runs=n_runs,
+            sample_size=max(1, min(20, len(out))),
+            seed=seed,
+        )
+        stress_grid.append(
+            {
+                "n_runs": n_runs,
+                "seed": seed,
+                "mean": float(pd.Series(dist).mean()) if dist else 0.0,
+                "p50": float(pd.Series(dist).quantile(0.5)) if dist else 0.0,
+            }
+        )
+
+    return {
+        "version": "dca-grid-process-v1",
+        "seed": int(seed),
+        "n_runs": len(passive_perf_distribution),
+        "quantiles": quantiles,
+        "percentile": float(percentile_rank(observed_perf, passive_perf_distribution)),
+        "dominance": dominance,
+        "stress_grid": stress_grid,
+        "notes": "Dominance simplifiee: P(perf_obs >= perf_passive) et P(dd_obs <= dd_passive)",
+    }
+
+
 def run_stats(spec: StatsSpec) -> pd.DataFrame:
     logger.info(
         "MarketStats run started | symbols=%s timeframe=%s source_path=%s mysql=%s persistence=%s artifacts=%s",
@@ -360,6 +438,9 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
         out_dir.mkdir(parents=True, exist_ok=True)
         artifacts.write_stats_summary(out_dir / "stats_summary.parquet", out)
         artifacts.write_stats_details(out_dir / "stats_details.parquet", pd.DataFrame())
+        robustness = _compute_robustness_artifacts(out, seed=42)
+        (out_dir / "dca_robustness_v1.json").write_text(json.dumps(robustness, indent=2))
+        pd.DataFrame([robustness]).to_parquet(out_dir / "dca_robustness_v1.parquet", index=False)
         logger.info("MarketStats artifacts written | out_dir=%s", out_dir)
 
     if spec.persistence and getattr(spec.persistence, "enabled", False):
@@ -420,6 +501,8 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
                 }
             )
         if rows:
+            from ..persistence import db
+            from ..persistence.repo import MarketStatsRepository
             with db.session() as conn:
                 repo = MarketStatsRepository(conn)
                 repo.bulk_upsert(rows)

--- a/tests/integration/test_dca_robustness_pipeline.py
+++ b/tests/integration/test_dca_robustness_pipeline.py
@@ -1,0 +1,58 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from quant_engine.api import schemas
+from quant_engine.core.spec import ArtifactsSpec
+from quant_engine.stats import runner
+
+
+def test_stats_pipeline_writes_dca_robustness_artifacts(tmp_path: Path) -> None:
+    start = datetime(2021, 1, 1)
+    rows = []
+    for i in range(50):
+        ts = start + timedelta(days=i)
+        close = 100 + i
+        rows.append(
+            {
+                "timestamp": ts.isoformat(),
+                "symbol": "TST",
+                "open": close - 1,
+                "high": close + 1,
+                "low": close - 2,
+                "close": close,
+                "volume": 1000,
+            }
+        )
+
+    dataset_path = tmp_path / "tiny.json"
+    dataset_path.write_text(json.dumps(rows))
+
+    out_dir = tmp_path / "artifacts"
+    spec = schemas.StatsSpec(
+        data=schemas.StatsDataSpec(
+            dataset_path=str(dataset_path),
+            symbols=["TST"],
+            timeframe="1d",
+            start="2021-01-01",
+            end="2021-02-19",
+        ),
+        events=[schemas.StatsEventSpec(name="k_consecutive", params={"k": 2, "direction": "up"})],
+        targets=[schemas.StatsTargetSpec(name="up_next_bar")],
+        artifacts=ArtifactsSpec(out_dir=str(out_dir)),
+    )
+
+    out = runner.run_stats(spec)
+    assert not out.empty
+
+    robustness_json = out_dir / "dca_robustness_v1.json"
+    robustness_parquet = out_dir / "dca_robustness_v1.parquet"
+    assert robustness_json.exists()
+    assert robustness_parquet.exists()
+
+    payload = json.loads(robustness_json.read_text())
+    assert payload["version"] == "dca-grid-process-v1"
+    assert payload["seed"] == 42
+    assert "percentile" in payload
+    assert "dominance" in payload
+    assert len(payload["stress_grid"]) == 3

--- a/tests/stats/test_dca_robustness.py
+++ b/tests/stats/test_dca_robustness.py
@@ -1,0 +1,31 @@
+import pytest
+
+from quant_engine.stats import estimators
+
+
+def test_monte_carlo_calendar_distribution_is_seed_deterministic() -> None:
+    values = [0.1, 0.2, 0.3, 0.4]
+    a = estimators.monte_carlo_calendar_distribution(values, n_runs=20, sample_size=3, seed=123)
+    b = estimators.monte_carlo_calendar_distribution(values, n_runs=20, sample_size=3, seed=123)
+    c = estimators.monte_carlo_calendar_distribution(values, n_runs=20, sample_size=3, seed=124)
+    assert a == b
+    assert a != c
+
+
+def test_percentile_rank_consistency() -> None:
+    dist = [1.0, 2.0, 3.0, 4.0]
+    assert estimators.percentile_rank(3.0, dist) == pytest.approx(75.0)
+    assert estimators.percentile_rank(0.0, dist) == pytest.approx(0.0)
+
+
+def test_stochastic_dominance_simplified_flags() -> None:
+    dom = estimators.stochastic_dominance_simplified(
+        observed_perf=0.9,
+        observed_drawdown=0.1,
+        passive_perf_distribution=[0.1, 0.2, 0.4],
+        passive_drawdown_distribution=[0.2, 0.3, 0.5],
+        threshold=0.6,
+    )
+    assert dom["perf_dominance_prob"] == pytest.approx(1.0)
+    assert dom["drawdown_dominance_prob"] == pytest.approx(1.0)
+    assert dom["is_dominant"] is True


### PR DESCRIPTION
### Motivation
- Provide reproducible statistical robustness metrics for DCA grid runs (percentiles vs passive benchmark, simplified dominance, and bounded parameter stress sweeps) to support downstream reporting and the DCA epic contract `dca-grid-process-v1`.
- Avoid coupling estimator imports with optional persistence dependencies during test collection to reduce test flakiness and enable lightweight unit tests.

### Description
- Added seeded Monte Carlo and helper estimators in `src/quant_engine/stats/estimators.py`: `monte_carlo_calendar_distribution`, `percentile_rank`, and `stochastic_dominance_simplified` to produce bootstrap distributions, percentile ranks, and a simple dominance test.  
- Extended the stats pipeline in `src/quant_engine/stats/runner.py` with `_compute_robustness_artifacts` that computes passive quantiles (p5/p25/p50/p75/p95), DCA percentile vs passive distribution, simplified perf/drawdown dominance, and a small stress-grid table, and persists these as `dca_robustness_v1.json` and `dca_robustness_v1.parquet`.  
- Made `quant_engine.stats` lazy-load `run_stats` via `__getattr__` and deferred importing the persistence DB objects until persistence time to prevent optional DB drivers from being required at import time.  
- Added a bounded, reproducible parameter sweep helper `_bounded_stress_grid` and wired it into the fallback optimize runner in `src/quant_engine/optimize/runner.py` to produce a stable stress-grid around base search-space points.  
- Added unit and integration tests: `tests/stats/test_dca_robustness.py` (determinism, percentile, dominance) and `tests/integration/test_dca_robustness_pipeline.py` (end-to-end artifact generation). 

### Testing
- Ran `poetry run pytest -q tests/stats/test_dca_robustness.py tests/integration/test_dca_robustness_pipeline.py tests/test_stats_estimators.py` which passed (`10 passed` overall).  
- Ran each group individually during development (`tests/stats/test_dca_robustness.py`, `tests/integration/test_dca_robustness_pipeline.py`, and `tests/test_stats_estimators.py`) and all returned success.  
- The changes include a local safety measure to defer DB imports so unit tests do not require optional DB driver packages (previous `pymysql` import) during test collection, and integration tests validate artifact files (`dca_robustness_v1.json` and `dca_robustness_v1.parquet`) are created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a587527ef8832395c0998efdbe5b91)