### PR TITLE
PY-DCA-EPIC-4: Rolling windows, market regimes & structural underperformance

### DIFF
--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -65,6 +65,109 @@ def _extract_buy_cashflows(trade: CompletedTrade) -> List[Tuple[datetime, float]
     return out
 
 
+
+
+def _label_market_regime(return_pct: float) -> str:
+    """Label market regime from window return.
+
+    Rules:
+    - return >= 20%: ``bull``
+    - return <= -20%: ``bear``
+    - otherwise: ``sideways``
+    """
+    if return_pct >= 20.0:
+        return "bull"
+    if return_pct <= -20.0:
+        return "bear"
+    return "sideways"
+
+
+def _rolling_window_analytics(
+    ohlc_by_symbol: Dict[str, "pd.DataFrame"],
+    *,
+    window_years: List[int],
+    step_months: int,
+) -> Dict[str, Any]:
+    """Compute rolling return/xirr series, regime labels and structural underperformance."""
+    if not ohlc_by_symbol:
+        return {"series": [], "underperformance": {"duration_windows": 0, "severity_pct_points": 0.0}}
+
+    returns_by_symbol: Dict[str, pd.Series] = {}
+    for symbol, df in ohlc_by_symbol.items():
+        if df is None or df.empty or "ts" not in df.columns or "close" not in df.columns:
+            continue
+        local = df[["ts", "close"]].copy()
+        local["ts"] = pd.to_datetime(local["ts"], utc=True, errors="coerce")
+        local = local.dropna(subset=["ts", "close"]).sort_values("ts")
+        if local.empty:
+            continue
+        close = pd.to_numeric(local["close"], errors="coerce")
+        ret = close.pct_change().fillna(0.0)
+        returns_by_symbol[symbol] = pd.Series(ret.to_numpy(), index=local["ts"].dt.tz_convert(None))
+
+    if not returns_by_symbol:
+        return {"series": [], "underperformance": {"duration_windows": 0, "severity_pct_points": 0.0}}
+
+    combined = pd.concat(returns_by_symbol.values(), axis=1).fillna(0.0)
+    avg_returns = combined.mean(axis=1)
+    synthetic_dataset = [{"timestamp": ts.isoformat()} for ts in avg_returns.index.to_pydatetime()]
+
+    from ..validate.splitter import generate_dca_rolling_windows
+
+    windows = generate_dca_rolling_windows(
+        synthetic_dataset,
+        window_years=window_years,
+        step_months=step_months,
+    )
+    series: List[Dict[str, Any]] = []
+    rolling_returns: List[float] = []
+    for window in windows:
+        start = pd.to_datetime(window["start"])
+        end = pd.to_datetime(window["end"])
+        sl = avg_returns[(avg_returns.index >= start) & (avg_returns.index < end)]
+        if sl.empty:
+            continue
+        growth = float((1.0 + sl).prod() - 1.0)
+        years = int(window["window_years"])
+        irr = (1.0 + growth) ** (1.0 / max(years, 1)) - 1.0
+        r_pct = growth * 100.0
+        rolling_returns.append(r_pct)
+        series.append(
+            {
+                "index_ts": window["index_ts"],
+                "start": window["start"],
+                "end": window["end"],
+                "window_years": years,
+                "return_pct": r_pct,
+                "irr": irr,
+                "regime": _label_market_regime(r_pct),
+            }
+        )
+
+    longest = 0
+    current = 0
+    severity = 0.0
+    for value in rolling_returns:
+        if value < 0:
+            current += 1
+            longest = max(longest, current)
+            severity += abs(value)
+        else:
+            current = 0
+
+    return {
+        "series": series,
+        "regime_definition": {
+            "version": "v1",
+            "bull_min_return_pct": 20.0,
+            "bear_max_return_pct": -20.0,
+            "sideways_between": [-20.0, 20.0],
+        },
+        "underperformance": {
+            "duration_windows": longest,
+            "severity_pct_points": severity,
+        },
+    }
 def _start_end_from_signals(signals_by_symbol: Mapping[str, Iterable[SignalLike]]) -> Tuple[Optional[datetime], Optional[datetime]]:
     timestamps: List[datetime] = []
     for sigs in signals_by_symbol.values():
@@ -359,6 +462,18 @@ def build_dca_performance_from_signals(
     if win_vals and loss_vals:
         rr_moyen = (sum(win_vals) / len(win_vals)) / (sum(loss_vals) / len(loss_vals))
 
+    rolling_cfg = config.get("rolling_windows", {}) if isinstance(config.get("rolling_windows"), Mapping) else {}
+    rolling_years_raw = rolling_cfg.get("years", [3, 5, 10])
+    if not isinstance(rolling_years_raw, list):
+        rolling_years_raw = [3, 5, 10]
+    rolling_years = [int(y) for y in rolling_years_raw if int(y) > 0]
+    rolling_step_months = int(rolling_cfg.get("step_months", 1) or 1)
+    rolling_analytics = _rolling_window_analytics(
+        ohlc_by_symbol,
+        window_years=rolling_years or [3, 5, 10],
+        step_months=rolling_step_months,
+    )
+
     run = StrategyRunResult(
         strategy_id=strategy_id,
         run_id=run_id,
@@ -400,6 +515,7 @@ def build_dca_performance_from_signals(
             "max_drawdown_on_contributed_capital": max_drawdown_pct_value,
             "time_under_water": time_under_water_periods,
             "contributed_capital": contributed_capital,
+            "rolling_windows": rolling_analytics,
         },
     )
 

--- a/src/quant_engine/persistence/models.py
+++ b/src/quant_engine/persistence/models.py
@@ -67,5 +67,23 @@ class SeasonalityRun:
     created_at: str | None = None
 
 
-__all__ = ["MarketStat", "SeasonalityProfile", "SeasonalityRun"]
+@dataclass
+class DcaRollingWindowMetric:
+    """Represents persisted rolling-window analytics for DCA runs."""
+
+    id: Optional[int] = None
+    run_id: str | None = None
+    index_ts: str | None = None
+    start: str | None = None
+    end: str | None = None
+    window_years: int | None = None
+    return_pct: float | None = None
+    irr: float | None = None
+    regime: str | None = None
+    underperformance_duration_windows: int | None = None
+    underperformance_severity_pct_points: float | None = None
+    created_at: str | None = None
+
+
+__all__ = ["MarketStat", "SeasonalityProfile", "SeasonalityRun", "DcaRollingWindowMetric"]
 

--- a/src/quant_engine/validate/splitter.py
+++ b/src/quant_engine/validate/splitter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Sequence
 
 
 def _add_months(dt: datetime, months: int) -> datetime:
@@ -41,4 +41,56 @@ def generate_folds(
         if not test_rows:
             break
         out.append({"train": train_rows, "test": test_rows})
+    return out
+
+
+def generate_dca_rolling_windows(
+    dataset: List[Dict[str, Any]],
+    window_years: Sequence[int] = (3, 5, 10),
+    step_months: int = 1,
+) -> List[Dict[str, Any]]:
+    """Build rolling windows for DCA analyses with temporal indexing.
+
+    Each element contains:
+    - ``window_years``
+    - ``start`` / ``end`` (ISO timestamps)
+    - ``index_ts``: temporal index of the window (window end)
+    - ``rows``: dataset rows inside ``[start, end)``
+    """
+    if not dataset:
+        return []
+
+    if step_months <= 0:
+        raise ValueError("step_months must be > 0")
+
+    dates: List[datetime] = []
+    for row in dataset:
+        dt = datetime.fromisoformat(row["timestamp"])
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        dates.append(dt)
+
+    start = min(dates)
+    end = max(dates)
+    ordered_windows = sorted({int(y) for y in window_years if int(y) > 0})
+    out: List[Dict[str, Any]] = []
+
+    for years in ordered_windows:
+        cursor = start
+        months = years * 12
+        while cursor <= end:
+            window_end = _add_months(cursor, months)
+            if window_end > end:
+                break
+            rows = [r for r, d in zip(dataset, dates) if cursor <= d < window_end]
+            out.append(
+                {
+                    "window_years": years,
+                    "start": cursor.isoformat(),
+                    "end": window_end.isoformat(),
+                    "index_ts": window_end.isoformat(),
+                    "rows": rows,
+                }
+            )
+            cursor = _add_months(cursor, step_months)
     return out

--- a/tests/test_performance_dca_builder.py
+++ b/tests/test_performance_dca_builder.py
@@ -291,3 +291,40 @@ def test_to_backend_payload_has_non_null_required_fields() -> None:
         assert trade_payload[key] is not None
 
     assert trade_payload["grossPnlPct"] == pytest.approx(trades[0].gross_pnl_pct)
+
+
+def test_build_dca_performance_includes_rolling_regimes_and_underperformance() -> None:
+    base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    signals = [
+        _make_signal(cycle_id=1, side="BUY", ts=base, qty=1.0),
+        _make_signal(cycle_id=1, side="SELL", ts=base.replace(year=2021), action="take_profit"),
+    ]
+
+    dates = pd.date_range(start="2020-01-01", periods=365 * 4, freq="D", tz="UTC")
+    # alternating positive/negative yearly blocks to force regime and underperformance detection
+    closes = []
+    price = 100.0
+    for i, _ in enumerate(dates):
+        if i < 365 * 2:
+            price *= 0.9998
+        else:
+            price *= 1.0004
+        closes.append(price)
+
+    run, _trades = build_dca_performance_from_signals(
+        strategy_id="dca",
+        run_id="run-rolling",
+        asset_class="EQUITY",
+        universe="ABC",
+        timeframe="1D",
+        signals_by_symbol={"ABC": signals},
+        ohlc_by_symbol={"ABC": pd.DataFrame({"ts": dates, "close": closes})},
+        config={"rolling_windows": {"years": [3], "step_months": 12}},
+    )
+
+    rolling = run.extra["rolling_windows"]
+    assert rolling["series"]
+    assert rolling["series"][0]["window_years"] == 3
+    assert rolling["series"][0]["regime"] in {"bull", "bear", "sideways"}
+    assert "duration_windows" in rolling["underperformance"]
+    assert "severity_pct_points" in rolling["underperformance"]

--- a/tests/validate/test_dca_rolling_windows.py
+++ b/tests/validate/test_dca_rolling_windows.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta, timezone
+
+from quant_engine.validate.splitter import generate_dca_rolling_windows
+
+
+def _dataset(start: datetime, days: int, tz: timezone | None = None) -> list[dict]:
+    out = []
+    current = start
+    for _ in range(days):
+        ts = current.replace(tzinfo=tz) if tz else current
+        out.append({"timestamp": ts.isoformat()})
+        current = current + timedelta(days=1)
+    return out
+
+
+def test_rolling_windows_overlap_and_boundaries() -> None:
+    data = _dataset(datetime(2020, 1, 1), days=365 * 7)
+    windows = generate_dca_rolling_windows(data, window_years=[3], step_months=12)
+
+    assert windows
+    assert windows[0]["start"].startswith("2020-01-01")
+    assert windows[0]["end"].startswith("2023-01-01")
+    assert windows[1]["start"].startswith("2021-01-01")
+    assert windows[1]["end"].startswith("2024-01-01")
+
+
+def test_rolling_windows_timezone_neutral() -> None:
+    start = datetime(2020, 1, 1, 0, 30)
+    tz = timezone(timedelta(hours=2))
+    data_tz = _dataset(start, days=365 * 4, tz=tz)
+    data_naive = _dataset(start, days=365 * 4, tz=None)
+
+    windows_tz = generate_dca_rolling_windows(data_tz, window_years=[3], step_months=12)
+    windows_naive = generate_dca_rolling_windows(data_naive, window_years=[3], step_months=12)
+
+    assert [w["start"] for w in windows_tz] == [w["start"] for w in windows_naive]
+    assert [w["end"] for w in windows_tz] == [w["end"] for w in windows_naive]
+
+
+def test_invalid_step_months_raises() -> None:
+    data = _dataset(datetime(2020, 1, 1), days=20)
+    try:
+        generate_dca_rolling_windows(data, window_years=[3], step_months=0)
+        assert False, "expected ValueError"
+    except ValueError:
+        assert True


### PR DESCRIPTION
### Motivation
- Provide configurable rolling-window support for DCA analysis to measure temporal stability (3/5/10 yrs), produce time-indexed series and enable visualization-ready exports.
- Surface an IRR proxy per window and label market regimes to support regime-aware analytics and downstream reporting.
- Detect structural underperformance (duration + severity) across rolling windows so runs can be flagged for prolonged negative environments.

### Description
- Added `generate_dca_rolling_windows` in `src/quant_engine/validate/splitter.py` to build timezone-neutral rolling windows with `start`/`end`/`index_ts` and configurable `window_years` and `step_months`.
- Implemented `_rolling_window_analytics` and `_label_market_regime` in `src/quant_engine/performance/dca_builder.py` and integrated results into `run.extra["rolling_windows"]`, computing per-window `return_pct`, annualized `irr`, regime labels (`bull`/`bear`/`sideways`) and aggregate underperformance metrics.
- Added persistence dataclass `DcaRollingWindowMetric` to `src/quant_engine/persistence/models.py` to represent rolling-window rows for storage/ETL consumers.
- Added unit tests `tests/validate/test_dca_rolling_windows.py` and extended `tests/test_performance_dca_builder.py` to assert the presence and structure of rolling/regime/underperformance outputs.

### Testing
- Ran `poetry run pytest -q tests/validate/test_dca_rolling_windows.py` which passed (`3 passed`).
- Ran `poetry run pytest -q tests/test_validation_splitter.py` which passed (`6 passed`).
- Ran `poetry run pytest -q tests/test_performance_dca_builder.py` which passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58c9b708c832387d56557d1ea1cf3)