### PR TITLE
PY-DCA-EPIC-5: add composite DCA score and edge classification

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -1849,6 +1849,21 @@ def _persist_canonical_run_metrics(job_id: str, payload: Any | None, result: Any
     if isinstance(xirr_status, str):
         metrics_map["xirr_converged"] = 1.0 if xirr_status == "ok" else 0.0
 
+    composite = extra.get("dca_composite_score") if isinstance(extra.get("dca_composite_score"), dict) else {}
+    score_value = composite.get("score")
+    if isinstance(score_value, (int, float)):
+        metrics_map["dca_score"] = float(score_value)
+    edge_value = composite.get("edge")
+    if isinstance(edge_value, str):
+        edge = edge_value.strip().lower()
+        edge_map = {"weak": 1.0, "medium": 2.0, "strong": 3.0}
+        if edge in edge_map:
+            metrics_map["dca_edge_level"] = edge_map[edge]
+    components = composite.get("components") if isinstance(composite.get("components"), dict) else {}
+    for name, value in components.items():
+        if isinstance(value, (int, float)):
+            metrics_map[f"dca_score_component_{name}"] = float(value)
+
     if not metrics_map:
         return
 

--- a/src/quant_engine/backtest/metrics.py
+++ b/src/quant_engine/backtest/metrics.py
@@ -3,10 +3,129 @@ from __future__ import annotations
 
 from datetime import datetime
 import math
-from typing import List, Dict, Any, Sequence, Tuple
+from typing import List, Dict, Any, Mapping, Sequence, Tuple
 
 
 CashflowPoint = Tuple[datetime, float]
+
+DCA_COMPOSITE_SCORE_VERSION = "dca_composite_v1"
+DEFAULT_DCA_SCORE_WEIGHTS: Dict[str, float] = {
+    "performance": 0.35,
+    "irr": 0.25,
+    "drawdown": 0.25,
+    "robustness": 0.15,
+}
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _normalize_weights(weights: Mapping[str, Any] | None = None) -> Dict[str, float]:
+    merged: Dict[str, float] = {key: float(value) for key, value in DEFAULT_DCA_SCORE_WEIGHTS.items()}
+    if isinstance(weights, Mapping):
+        for key in merged:
+            raw_value = weights.get(key)
+            if raw_value is None:
+                continue
+            try:
+                merged[key] = max(0.0, float(raw_value))
+            except Exception:
+                continue
+    total = sum(merged.values())
+    if total <= 0:
+        return {key: float(value) for key, value in DEFAULT_DCA_SCORE_WEIGHTS.items()}
+    return {key: value / total for key, value in merged.items()}
+
+
+def _weighted_score(weights: Mapping[str, float], components: Mapping[str, float]) -> float:
+    return sum(float(weights.get(key, 0.0)) * float(components.get(key, 0.0)) for key in DEFAULT_DCA_SCORE_WEIGHTS)
+
+
+def dca_composite_score(
+    *,
+    final_performance_normalized_value: float,
+    xirr_value: float | None,
+    max_drawdown_on_contributed_capital_value: float | None,
+    underperformance_duration_windows: int = 0,
+    underperformance_severity_pct_points: float = 0.0,
+    xirr_status: str | None = None,
+    weights: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Compute versioned and decomposable DCA composite score.
+
+    Component rules (all in [0, 1]):
+    - ``performance``: normalized performance in range [-20%, +80%].
+    - ``irr``: annualized XIRR in range [-5%, +30%].
+    - ``drawdown``: inverse penalty using max drawdown on contributed capital,
+      with full penalty at 60% drawdown.
+    - ``robustness``: combines rolling underperformance duration/severity and
+      XIRR convergence status.
+
+    Edge classes:
+    - ``strong``: score >= 0.70
+    - ``medium``: 0.40 <= score < 0.70
+    - ``weak``: score < 0.40
+    """
+
+    performance_component = _clamp01((float(final_performance_normalized_value) + 0.20) / 1.0)
+    irr_raw = float(xirr_value) if isinstance(xirr_value, (int, float)) else -0.05
+    irr_component = _clamp01((irr_raw + 0.05) / 0.35)
+
+    drawdown_raw = (
+        float(max_drawdown_on_contributed_capital_value)
+        if isinstance(max_drawdown_on_contributed_capital_value, (int, float))
+        else 0.60
+    )
+    if drawdown_raw > 1.0:
+        drawdown_raw /= 100.0
+    drawdown_component = _clamp01(1.0 - (drawdown_raw / 0.60))
+
+    duration_penalty = _clamp01(float(max(0, underperformance_duration_windows)) / 12.0)
+    severity_penalty = _clamp01(float(max(0.0, underperformance_severity_pct_points)) / 150.0)
+    convergence_bonus = 1.0 if str(xirr_status or "").strip().lower() == "ok" else 0.0
+    robustness_component = _clamp01(1.0 - (0.5 * duration_penalty + 0.4 * severity_penalty + 0.1 * (1.0 - convergence_bonus)))
+
+    components: Dict[str, float] = {
+        "performance": performance_component,
+        "irr": irr_component,
+        "drawdown": drawdown_component,
+        "robustness": robustness_component,
+    }
+    norm_weights = _normalize_weights(weights)
+    score = _clamp01(_weighted_score(norm_weights, components))
+
+    if score >= 0.70:
+        edge = "strong"
+    elif score >= 0.40:
+        edge = "medium"
+    else:
+        edge = "weak"
+
+    contributions = {key: norm_weights[key] * components[key] for key in components}
+    sensitivity: Dict[str, float] = {}
+    delta = 0.10
+    for key in components:
+        up_weights = dict(norm_weights)
+        up_weights[key] = up_weights.get(key, 0.0) + delta
+        up_weights = _normalize_weights(up_weights)
+        score_up = _weighted_score(up_weights, components)
+        sensitivity[key] = score_up - score
+
+    return {
+        "version": DCA_COMPOSITE_SCORE_VERSION,
+        "weights": norm_weights,
+        "components": components,
+        "contributions": contributions,
+        "score": score,
+        "edge": edge,
+        "edge_mapping": {
+            "weak_max_exclusive": 0.40,
+            "medium_max_exclusive": 0.70,
+            "strong_min_inclusive": 0.70,
+        },
+        "weight_sensitivity": sensitivity,
+    }
 
 
 def final_performance_normalized(final_value: float, contributed_capital: float) -> float:

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -473,6 +473,20 @@ def build_dca_performance_from_signals(
         window_years=rolling_years or [3, 5, 10],
         step_months=rolling_step_months,
     )
+    underperformance = rolling_analytics.get("underperformance", {}) if isinstance(rolling_analytics, dict) else {}
+    score_cfg = config.get("composite_score", {}) if isinstance(config.get("composite_score"), Mapping) else {}
+    score_weights = score_cfg.get("weights") if isinstance(score_cfg.get("weights"), Mapping) else None
+    dca_score = backtest_metrics.dca_composite_score(
+        final_performance_normalized_value=final_perf_norm,
+        xirr_value=xirr_value,
+        max_drawdown_on_contributed_capital_value=(
+            (max_drawdown_pct_value / 100.0) if isinstance(max_drawdown_pct_value, (int, float)) else None
+        ),
+        underperformance_duration_windows=int(underperformance.get("duration_windows", 0) or 0),
+        underperformance_severity_pct_points=float(underperformance.get("severity_pct_points", 0.0) or 0.0),
+        xirr_status=xirr_status,
+        weights=score_weights,
+    )
 
     run = StrategyRunResult(
         strategy_id=strategy_id,
@@ -516,6 +530,9 @@ def build_dca_performance_from_signals(
             "time_under_water": time_under_water_periods,
             "contributed_capital": contributed_capital,
             "rolling_windows": rolling_analytics,
+            "dca_composite_score": dca_score,
+            "dca_edge": dca_score.get("edge"),
+            "dca_score": dca_score.get("score"),
         },
     )
 

--- a/tests/api/test_runs_metrics_dca.py
+++ b/tests/api/test_runs_metrics_dca.py
@@ -58,6 +58,16 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
                         "xirr_status": "ok",
                         "max_drawdown_on_contributed_capital": 15.0,
                         "time_under_water": 3,
+                        "dca_composite_score": {
+                            "score": 0.66,
+                            "edge": "medium",
+                            "components": {
+                                "performance": 0.70,
+                                "irr": 0.60,
+                                "drawdown": 0.80,
+                                "robustness": 0.50,
+                            },
+                        },
                     },
                 }
             },
@@ -76,3 +86,6 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
     assert aggregated["max_drawdown_on_contributed_capital"] == 15.0
     assert aggregated["time_under_water"] == 3.0
     assert aggregated["xirr_converged"] == 1.0
+    assert aggregated["dca_score"] == 0.66
+    assert aggregated["dca_edge_level"] == 2.0
+    assert aggregated["dca_score_component_performance"] == 0.70

--- a/tests/backtest/test_dca_score.py
+++ b/tests/backtest/test_dca_score.py
@@ -1,0 +1,60 @@
+import pytest
+
+from quant_engine.backtest.metrics import dca_composite_score
+
+
+def test_dca_composite_score_is_bounded_and_decomposable() -> None:
+    payload = dca_composite_score(
+        final_performance_normalized_value=0.30,
+        xirr_value=0.12,
+        max_drawdown_on_contributed_capital_value=0.15,
+        underperformance_duration_windows=1,
+        underperformance_severity_pct_points=5.0,
+        xirr_status="ok",
+    )
+    assert 0.0 <= payload["score"] <= 1.0
+    assert payload["edge"] in {"weak", "medium", "strong"}
+    assert set(payload["components"].keys()) == {"performance", "irr", "drawdown", "robustness"}
+    assert payload["score"] == pytest.approx(sum(payload["contributions"].values()))
+
+
+def test_dca_composite_score_local_monotonicity() -> None:
+    base = dca_composite_score(
+        final_performance_normalized_value=0.10,
+        xirr_value=0.08,
+        max_drawdown_on_contributed_capital_value=0.20,
+        underperformance_duration_windows=3,
+        underperformance_severity_pct_points=15.0,
+        xirr_status="ok",
+    )
+    better_perf = dca_composite_score(
+        final_performance_normalized_value=0.25,
+        xirr_value=0.08,
+        max_drawdown_on_contributed_capital_value=0.20,
+        underperformance_duration_windows=3,
+        underperformance_severity_pct_points=15.0,
+        xirr_status="ok",
+    )
+    better_drawdown = dca_composite_score(
+        final_performance_normalized_value=0.10,
+        xirr_value=0.08,
+        max_drawdown_on_contributed_capital_value=0.10,
+        underperformance_duration_windows=3,
+        underperformance_severity_pct_points=15.0,
+        xirr_status="ok",
+    )
+    assert better_perf["score"] >= base["score"]
+    assert better_drawdown["score"] >= base["score"]
+
+
+def test_dca_composite_score_custom_weights_are_normalized() -> None:
+    payload = dca_composite_score(
+        final_performance_normalized_value=0.10,
+        xirr_value=0.08,
+        max_drawdown_on_contributed_capital_value=0.20,
+        weights={"performance": 2.0, "irr": 1.0, "drawdown": 1.0, "robustness": 0.0},
+    )
+    assert payload["weights"]["performance"] == pytest.approx(0.5)
+    assert payload["weights"]["irr"] == pytest.approx(0.25)
+    assert payload["weights"]["drawdown"] == pytest.approx(0.25)
+    assert payload["weights"]["robustness"] == pytest.approx(0.0)

--- a/tests/test_performance_dca_builder.py
+++ b/tests/test_performance_dca_builder.py
@@ -97,6 +97,11 @@ def test_build_dca_performance_from_signals_handles_cycles_and_metrics() -> None
     assert run.win_count == 1
     assert run.loss_count == 1
     assert run.total_return == pytest.approx(trades[0].gross_pnl_pct + trades[1].gross_pnl_pct)
+    assert isinstance(run.extra, dict)
+    dca_score = run.extra.get("dca_composite_score")
+    assert isinstance(dca_score, dict)
+    assert 0.0 <= dca_score["score"] <= 1.0
+    assert dca_score["edge"] in {"weak", "medium", "strong"}
 
 
 def test_build_dca_performance_multiple_buys_and_tp_metrics() -> None:


### PR DESCRIPTION
### Motivation
- Provide a versioned, interpretable composite DCA score combining performance, IRR, drawdown and robustness to support downstream ranking and edge classification. 
- Make the score decomposable and configurable (weights) so consumers can explain contributions and tune sensitivity. 
- Expose the score and components through run payloads and canonical metrics so it is available for API aggregation and persistence.

### Description
- Added a versioned composite scoring model `dca_composite_v1` and helpers in `src/quant_engine/backtest/metrics.py`, including weight normalization, component computations, contribution breakdown and weight sensitivity (`dca_composite_score`).
- Wired composite scoring into DCA performance builder in `src/quant_engine/performance/dca_builder.py`, storing the detailed payload under `run.extra.dca_composite_score` and convenience fields `run.extra.dca_score` and `run.extra.dca_edge`.
- Extended canonical metrics persistence in `src/quant_engine/api/app.py` to persist `dca_score`, numeric `dca_edge_level` (weak=1/medium=2/strong=3) and per-component metrics `dca_score_component_*` when present.
- Added/updated tests: new unit tests at `tests/backtest/test_dca_score.py`, assertions in `tests/test_performance_dca_builder.py` to validate score presence/shape, and updated `tests/api/test_runs_metrics_dca.py` to verify API exposure of score/edge/components.

### Testing
- Ran `poetry run pytest -q tests/backtest/test_dca_score.py` and observed `3 passed` confirming score invariants and weight normalization.
- Ran `poetry run pytest -q tests/backtest/test_dca_score.py tests/test_performance_dca_builder.py tests/api/test_runs_metrics_dca.py` and observed `10 passed` confirming integration into the DCA payload and API persistence.
- No failing tests were observed for the modified areas; the new score is exercised by unit and integration tests listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58f2719cc8323a49a8f51f6ba382f)