### PR TITLE
PY-DCA-EPIC-6: versioned DCA artifact contract and run artifacts listing

### DIFF
--- a/docs/spec_builders_reference.md
+++ b/docs/spec_builders_reference.md
@@ -432,3 +432,26 @@ Approche pragmatique:
 6. Ajouter tests unitaires par builder (golden JSON).
 7. Integrer dans le service d'orchestration vers Python.
 
+
+## 10) Contrat de donnees versionne (DCA grid process v1)
+
+Pour les runs `market_stats` utilises par l'initiative `INIT-DCA-GRID-001`, les artefacts de reporting doivent exposer:
+
+- `schema_version`: `dca-grid-process-v1`
+- `contract_version`: version semantique du contrat (ex: `1.0.0`)
+- `metadata.reproducibility`: `seed`, `dataset_hash`, `config_version`
+
+Artefacts standards produits en JSON + Parquet:
+
+- `metrics`
+- `distributions`
+- `capital_curves`
+- `rolling`
+- `score`
+
+### Politique de backward compatibility
+
+- **Patch (`x.y.Z`)**: corrections sans changement de schema (retrocompatible).
+- **Minor (`x.Y.z`)**: ajout de champs optionnels uniquement (retrocompatible).
+- **Major (`X.y.z`)**: changement breaking (rename/suppression/type change), avec bump de `schema_version`.
+- Les consommateurs Angular/export doivent ignorer les champs inconnus et se baser sur `schema_version` pour le routage.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import time
 import threading
 import re
@@ -31,6 +32,7 @@ from ..levels.schemas import LevelsBuildSpec
 from ..optimize.runner import run as run_optimisation
 from ..optimize import variants as optimize_variants
 from ..io import ids
+from ..io.dca_artifacts import SCHEMA_VERSION
 from ..persistence import db, RunsRepository, MetricsRepository, TrialsRepository
 from ..stats import runner as stats_runner
 from ..stats import conditions as stats_conditions
@@ -4033,6 +4035,34 @@ def run_detail_endpoint(run_id: str) -> Dict[str, Any]:
     return payload
 
 
+
+
+def get_run_artifacts(run_id: str) -> Dict[str, Any]:
+    """Return artifact listing for a canonical run output directory."""
+
+    job = _get_job(run_id)
+    if not job or job.get("job_type") != JOB_TYPE_CANONICAL_RUN:
+        raise HTTPException(status_code=404, detail='Run not found')
+
+    payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
+    request = payload.get("request") if isinstance(payload.get("request"), dict) else {}
+    output = request.get("output") if isinstance(request.get("output"), dict) else {}
+    out_dir_raw = output.get("out_dir")
+    out_dir = Path(str(out_dir_raw)).expanduser() if isinstance(out_dir_raw, str) and out_dir_raw.strip() else None
+
+    files: List[Dict[str, Any]] = []
+    if out_dir and out_dir.exists() and out_dir.is_dir():
+        for item in sorted(out_dir.iterdir()):
+            if item.is_file():
+                files.append({"name": item.name, "path": str(item), "size_bytes": item.stat().st_size})
+
+    return {
+        "run_id": run_id,
+        "schema_version": SCHEMA_VERSION,
+        "out_dir": str(out_dir) if out_dir is not None else None,
+        "files": files,
+    }
+
 @fastapi_app.get('/runs/{run_id}/result', response_model=Dict[str, Any])
 def run_result_endpoint(run_id: str) -> Dict[str, Any]:
     """Return the result for a canonical run."""
@@ -4058,6 +4088,13 @@ def run_result_endpoint(run_id: str) -> Dict[str, Any]:
     if isinstance(result, dict) and "error" in result:
         payload["error"] = result.get("error")
     return payload
+
+
+@fastapi_app.get('/runs/{run_id}/artifacts', response_model=Dict[str, Any])
+def run_artifacts_endpoint(run_id: str) -> Dict[str, Any]:
+    """Return canonical run artifact listing."""
+
+    return get_run_artifacts(run_id)
 
 
 @fastapi_app.get('/runs/{run_id}/trials', response_model=List[Dict[str, Any]])

--- a/src/quant_engine/io/dca_artifacts.py
+++ b/src/quant_engine/io/dca_artifacts.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SCHEMA_VERSION = "dca-grid-process-v1"
+CONTRACT_VERSION = "1.0.0"
+
+
+class ReproducibilityMetadata(BaseModel):
+    seed: int
+    dataset_hash: str
+    config_version: str
+
+
+class ContractMetadata(BaseModel):
+    schema_version: str = SCHEMA_VERSION
+    contract_version: str = CONTRACT_VERSION
+    generated_at: str
+    reproducibility: ReproducibilityMetadata
+
+
+class ArtifactEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    artifact: str
+    metadata: ContractMetadata
+    rows: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+def compute_dataset_hash(rows: List[Dict[str, Any]]) -> str:
+    payload = json.dumps(rows, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_metadata(*, generated_at: str, seed: int, dataset_hash: str, config_version: str) -> ContractMetadata:
+    return ContractMetadata(
+        generated_at=generated_at,
+        reproducibility=ReproducibilityMetadata(seed=seed, dataset_hash=dataset_hash, config_version=config_version),
+    )
+
+
+def _write_json_and_parquet(out_dir: Path, envelope: ArtifactEnvelope) -> Dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / f"{envelope.artifact}.json"
+    parquet_path = out_dir / f"{envelope.artifact}.parquet"
+    json_path.write_text(envelope.model_dump_json(indent=2), encoding="utf-8")
+
+    df = pd.DataFrame(envelope.rows)
+    if df.empty:
+        df = pd.DataFrame([{}])
+    df.to_parquet(parquet_path, index=False)
+    return {"json": str(json_path), "parquet": str(parquet_path)}
+
+
+def write_dca_contract_artifacts(
+    out_dir: str | Path,
+    *,
+    generated_at: str,
+    seed: int,
+    dataset_rows: List[Dict[str, Any]],
+    config_version: str,
+    stats_summary: pd.DataFrame,
+    robustness: Dict[str, Any],
+) -> Dict[str, Dict[str, str]]:
+    out_path = Path(out_dir)
+    dataset_hash = compute_dataset_hash(dataset_rows)
+    meta = build_metadata(
+        generated_at=generated_at,
+        seed=seed,
+        dataset_hash=dataset_hash,
+        config_version=config_version,
+    )
+
+    rows = stats_summary.to_dict("records")
+    metrics_rows = [
+        {
+            "symbol": r.get("symbol"),
+            "target": r.get("target"),
+            "n": int(r.get("n", 0) or 0),
+            "successes": int(r.get("successes", 0) or 0),
+            "lift_freq": float(r.get("lift_freq", 0.0) or 0.0),
+            "lift_bayes": float(r.get("lift_bayes", 0.0) or 0.0),
+        }
+        for r in rows
+    ]
+    distributions_rows = [
+        {
+            "quantile": k,
+            "value": float(v),
+        }
+        for k, v in (robustness.get("quantiles") or {}).items()
+    ]
+
+    capital_curve = []
+    cumulative = 0.0
+    for idx, row in enumerate(metrics_rows):
+        cumulative += float(row.get("lift_freq", 0.0))
+        capital_curve.append({"step": idx, "equity_index": cumulative})
+
+    rolling_rows = []
+    window = 5
+    for idx in range(len(metrics_rows)):
+        start = max(0, idx - window + 1)
+        values = [float(m.get("lift_freq", 0.0)) for m in metrics_rows[start : idx + 1]]
+        rolling_rows.append({"step": idx, "window": window, "rolling_lift_freq": sum(values) / len(values) if values else 0.0})
+
+    score_rows = [
+        {
+            "percentile": float(robustness.get("percentile", 0.0) or 0.0),
+            "perf_dominance_prob": float((robustness.get("dominance") or {}).get("perf_dominance_prob", 0.0) or 0.0),
+            "drawdown_dominance_prob": float((robustness.get("dominance") or {}).get("drawdown_dominance_prob", 0.0) or 0.0),
+            "is_dominant": bool((robustness.get("dominance") or {}).get("is_dominant", False)),
+        }
+    ]
+
+    artifacts = {
+        "metrics": metrics_rows,
+        "distributions": distributions_rows,
+        "capital_curves": capital_curve,
+        "rolling": rolling_rows,
+        "score": score_rows,
+    }
+
+    written: Dict[str, Dict[str, str]] = {}
+    for name, artifact_rows in artifacts.items():
+        envelope = ArtifactEnvelope(artifact=name, metadata=meta, rows=artifact_rows)
+        written[name] = _write_json_and_parquet(out_path, envelope)
+    return written

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -12,6 +13,7 @@ from ..core.dataset import load_ohlcv
 from ..core.features import atr
 from ..validate import splitter
 from ..io import artifacts
+from ..io.dca_artifacts import SCHEMA_VERSION, write_dca_contract_artifacts
 from . import conditions as cond_mod
 from . import events as event_mod
 from . import targets as tgt_mod
@@ -263,7 +265,7 @@ def _compute_robustness_artifacts(out: pd.DataFrame, seed: int = 42) -> Dict[str
 
     if out.empty:
         return {
-            "version": "dca-grid-process-v1",
+            "version": SCHEMA_VERSION,
             "seed": int(seed),
             "n_runs": 0,
             "quantiles": {},
@@ -323,7 +325,7 @@ def _compute_robustness_artifacts(out: pd.DataFrame, seed: int = 42) -> Dict[str
         )
 
     return {
-        "version": "dca-grid-process-v1",
+        "version": SCHEMA_VERSION,
         "seed": int(seed),
         "n_runs": len(passive_perf_distribution),
         "quantiles": quantiles,
@@ -438,10 +440,20 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
         out_dir.mkdir(parents=True, exist_ok=True)
         artifacts.write_stats_summary(out_dir / "stats_summary.parquet", out)
         artifacts.write_stats_details(out_dir / "stats_details.parquet", pd.DataFrame())
-        robustness = _compute_robustness_artifacts(out, seed=42)
+        seed = 42
+        robustness = _compute_robustness_artifacts(out, seed=seed)
         (out_dir / "dca_robustness_v1.json").write_text(json.dumps(robustness, indent=2))
         pd.DataFrame([robustness]).to_parquet(out_dir / "dca_robustness_v1.parquet", index=False)
-        logger.info("MarketStats artifacts written | out_dir=%s", out_dir)
+        contract_written = write_dca_contract_artifacts(
+            out_dir,
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            seed=seed,
+            dataset_rows=dataset,
+            config_version=SCHEMA_VERSION,
+            stats_summary=out,
+            robustness=robustness,
+        )
+        logger.info("MarketStats artifacts written | out_dir=%s contract_artifacts=%s", out_dir, sorted(contract_written.keys()))
 
     if spec.persistence and getattr(spec.persistence, "enabled", False):
         rows: List[Dict[str, Any]] = []

--- a/tests/api/test_dca_artifact_endpoints.py
+++ b/tests/api/test_dca_artifact_endpoints.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import types
+
+import pytest
+
+pymysql_module = types.ModuleType("pymysql")
+pymysql_cursors = types.ModuleType("pymysql.cursors")
+setattr(pymysql_cursors, "DictCursor", object)
+setattr(pymysql_module, "cursors", pymysql_cursors)
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", pymysql_cursors)
+
+from quant_engine.api import app as api_app
+from quant_engine.config import reset_settings_cache
+
+
+@pytest.fixture
+def api_db(tmp_path):
+    db_path = tmp_path / "api.sqlite"
+    os.environ["DB_DSN"] = f"sqlite:///{db_path}"
+    reset_settings_cache()
+    yield db_path
+    os.environ.pop("DB_DSN", None)
+    reset_settings_cache()
+
+
+def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
+    out_dir = tmp_path / "run-artifacts"
+    out_dir.mkdir(parents=True)
+    (out_dir / "metrics.json").write_text("{}")
+    (out_dir / "metrics.parquet").write_text("parquet")
+
+    run_id = "run-artifacts-1"
+    api_app._init_job(
+        run_id,
+        api_app.JOB_TYPE_CANONICAL_RUN,
+        payload={
+            "request": {
+                "spec_type": "market_stats",
+                "output": {"out_dir": str(out_dir)},
+            }
+        },
+        status=api_app.JOB_STATUS_SUCCEEDED,
+    )
+
+    payload = api_app.run_artifacts_endpoint(run_id)
+
+    assert payload["run_id"] == run_id
+    assert payload["schema_version"] == "dca-grid-process-v1"
+    assert payload["out_dir"] == str(out_dir)
+    names = {item["name"] for item in payload["files"]}
+    assert {"metrics.json", "metrics.parquet"}.issubset(names)

--- a/tests/io/test_dca_artifact_contract.py
+++ b/tests/io/test_dca_artifact_contract.py
@@ -1,0 +1,49 @@
+import json
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from quant_engine.io.dca_artifacts import SCHEMA_VERSION, ArtifactEnvelope, write_dca_contract_artifacts
+
+
+def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
+    out_dir = tmp_path / "artifacts"
+    dataset = [{"timestamp": "2024-01-01T00:00:00Z", "symbol": "AAPL", "close": 100.0}]
+    summary = pd.DataFrame(
+        [
+            {
+                "symbol": "AAPL",
+                "target": "up_next_bar",
+                "n": 10,
+                "successes": 6,
+                "lift_freq": 0.12,
+                "lift_bayes": 0.11,
+            }
+        ]
+    )
+    robustness = {
+        "quantiles": {"p50": 0.5},
+        "percentile": 0.75,
+        "dominance": {"perf_dominance_prob": 0.8, "drawdown_dominance_prob": 0.7, "is_dominant": True},
+    }
+
+    written = write_dca_contract_artifacts(
+        out_dir,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        seed=7,
+        dataset_rows=dataset,
+        config_version=SCHEMA_VERSION,
+        stats_summary=summary,
+        robustness=robustness,
+    )
+
+    assert set(written.keys()) == {"metrics", "distributions", "capital_curves", "rolling", "score"}
+    for name, paths in written.items():
+        assert out_dir.joinpath(f"{name}.json").exists()
+        assert out_dir.joinpath(f"{name}.parquet").exists()
+        payload = json.loads(out_dir.joinpath(f"{name}.json").read_text())
+        parsed = ArtifactEnvelope.model_validate(payload)
+        assert parsed.metadata.schema_version == SCHEMA_VERSION
+        assert parsed.metadata.reproducibility.seed == 7
+        assert paths["json"].endswith(f"{name}.json")
+        assert paths["parquet"].endswith(f"{name}.parquet")


### PR DESCRIPTION
### Motivation
- Stabilise a versioned output contract (`schema_version`) for DCA/market-stats reporting to enable reproducible JSON/Parquet exports and consistent Angular consumption. 
- Provide standardized artifact envelopes with reproducibility metadata (seed, dataset hash, config version) and a clear backward-compatibility policy for downstream consumers.

### Description
- Add a new contract writer module `src/quant_engine/io/dca_artifacts.py` that defines Pydantic envelope types, computes a `dataset_hash`, and writes standardized JSON + Parquet artifacts for `metrics`, `distributions`, `capital_curves`, `rolling`, and `score` using `SCHEMA_VERSION = "dca-grid-process-v1"`.
- Integrate contract generation into market-stats runs in `src/quant_engine/stats/runner.py` so the runner emits the existing robustness artifacts plus the full contract artifact set with reproducibility metadata.
- Add a helper `get_run_artifacts(run_id)` and a new API endpoint `GET /runs/{run_id}/artifacts` in `src/quant_engine/api/app.py` that returns `schema_version`, `out_dir`, and a file inventory for canonical runs.
- Document the contract and backward-compatibility policy in `docs/spec_builders_reference.md` and add unit/tests: `tests/io/test_dca_artifact_contract.py` and `tests/api/test_dca_artifact_endpoints.py`.

### Testing
- Ran `poetry run pytest -q tests/io/test_dca_artifact_contract.py` which succeeded (`1 passed`).
- Ran `poetry run pytest -q tests/api/test_dca_artifact_endpoints.py` which succeeded (`1 passed`); the API test uses a small local `pymysql` stub to avoid an external MySQL client dependency.
- End-to-end verification confirms JSON and Parquet files are created and the `GET /runs/{run_id}/artifacts` helper returns the expected `schema_version`, `out_dir`, and file listing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a590a5e50c8323a65dc4d993dc6c67)