### PR TITLE
docs: PY-DCA-EPIC-7 — audit framework, reproducibility & anti data‑snooping

### DIFF
--- a/docs/canonical_runs_dca_source_of_truth_2026-02-20.md
+++ b/docs/canonical_runs_dca_source_of_truth_2026-02-20.md
@@ -169,6 +169,24 @@ After:
 }
 ```
 
+
+## Audit trail requis (PY-DCA-EPIC-7)
+
+Pour qu’un run canonique soit auditable et rejouable, les artefacts suivants sont obligatoires:
+
+- `run_manifest.json` (spec figée, commit, versions runtime, seed(s), hash dataset)
+- `metrics.json` (métriques principales + distribution stats)
+- `trades.parquet` ou `trades.csv` (journal d’exécution)
+- `logs.txt` (journal runtime horodaté)
+- `checksums.txt` (hash SHA256 des artefacts)
+
+### Procédure de comparaison baseline vs rerun
+
+1. Rejouer avec la même spec et les mêmes seeds.
+2. Vérifier l’égalité des checksums pour les artefacts déterministes.
+3. Appliquer tolérance numérique définie pour les métriques flottantes.
+4. Consigner un statut: `REPRODUCIBLE`, `DRIFT_MINEUR`, `NON_CONFORME`.
+
 ## Frontend guidance
 
 - Prefer sending explicit `strategy.params.grid` instead of `strategy.grid` presets.

--- a/docs/dca_grid_implementation_process.md
+++ b/docs/dca_grid_implementation_process.md
@@ -156,6 +156,56 @@ Pour exécuter proprement, il faut découpler en deux streams :
 - **PY-7.3** Gel des règles benchmark ex-ante.
 - **PY-7.4** Rapport de reproductibilité.
 
+### Cadre d’audit vérifiable (à appliquer avant toute conclusion)
+
+#### 1) Checklist anti-snooping (revue obligatoire)
+
+- [ ] **Préréglage ex-ante**: paramètres de grille, dates, univers, métriques et seuils go/no-go gelés avant exécution.
+- [ ] **Aucune optimisation post-hoc**: interdiction d’ajuster les paramètres sur la même période d’évaluation finale.
+- [ ] **Split temporel respecté**: calibration/validation/test strictement ordonnés dans le temps (pas de mélange).
+- [ ] **Zéro fuite de features**: tout indicateur utilise uniquement l’historique disponible à `t`.
+- [ ] **Calendrier explicite**: jours non ouvrés, décalages d’exécution et fuseau horodatés et documentés.
+- [ ] **Cashflows comparables**: budgets et règles d’investissement identiques entre stratégie DCA Grid et benchmarks.
+- [ ] **Jeu de seeds traçable**: seeds Monte Carlo figées et archivées pour rerun bit-à-bit.
+- [ ] **Versionning complet**: commit, spec, dataset hash, config runtime et artefacts signés dans le run manifest.
+- [ ] **Comparaison canonique**: run de contrôle rejoué contre le baseline de référence et diff documenté.
+- [ ] **Revue pairée**: validation indépendante signée avant communication d’un “edge”.
+
+#### 2) Matrice des risques méthodologiques + mitigations
+
+| Risque | Symptôme observable | Impact | Mitigation obligatoire | Evidence attendue |
+|---|---|---|---|---|
+| Data snooping | Perf excellente seulement après multiples tweaks | Surestimation de l’alpha | Gel ex-ante + journal des changements paramétriques | Changelog de specs + run manifest |
+| Look-ahead bias | Signaux basés sur données futures | Résultats non réplicables en réel | Tests no-lookahead + audit des colonnes dérivées | Rapport tests + revue code |
+| Survivorship bias | Univers actuel appliqué au passé | Biais positif structurel | Universe daté et versionné par période | Snapshot univers + dates effectives |
+| Leakage calendrier | Exécutions sur dates impossibles | Biais opérationnel | Règles de trading calendar explicites | Trace d’exécution journalière |
+| Overfitting de grille | Variance extrême hors échantillon | Robustesse faible | Validation OOS + stress tests paramètres | Table de sensibilité et quantiles |
+| Non-reproductibilité | Résultats différents à spec identique | Audit impossible | Seeds, versions, hash datasets, artefacts figés | Manifest + checksum artefacts |
+
+#### 3) Procédure de rerun reproductible
+
+1. Sélectionner un identifiant de run canonique validé (baseline).  
+2. Récupérer la **spec figée**, le **hash dataset**, le **commit git**, la version Python/poetry et les variables d’environnement requises.  
+3. Exécuter le rerun avec la commande standardisée (`qe run-local`) sans modification locale de la spec.  
+4. Générer les artefacts d’audit minimaux: `run_manifest.json`, `metrics.json`, `trades.parquet/csv`, `logs.txt`, `checksums.txt`.  
+5. Comparer baseline vs rerun via diff déterministe: métriques principales, nombre de trades, distributions MC, checksums.  
+6. Classer l’issue: **REPRODUCIBLE** (diffs dans tolérance), **DRIFT MINEUR**, ou **NON CONFORME** (investigation bloquante).  
+
+#### 4) Critères go/no-go (formalisation)
+
+- **GO** si toutes les conditions suivantes sont vraies:
+  - Checklist anti-snooping: 100% validée.
+  - Rerun canonique: statut `REPRODUCIBLE`.
+  - Aucune fuite d’information détectée (tests + revue).
+  - Performances DCA Grid supérieures au percentile ex-ante visé sur l’intervalle test.
+  - Rapport méthodologique signé par 2 reviewers.
+- **NO-GO** si au moins une condition suivante est observée:
+  - Règles ex-ante modifiées après observation des résultats test.
+  - Échec de reproductibilité non expliqué.
+  - Divergence majeure entre benchmark calculé et baseline canonique.
+  - Artefacts d’audit incomplets ou checksum manquant.
+  - Fuite d’information non corrigée.
+
 ### DoD
 
 - Audit trail complet (inputs, code version, paramètres, outputs).

--- a/docs/dca_methodology_audit_report_template.md
+++ b/docs/dca_methodology_audit_report_template.md
@@ -1,0 +1,66 @@
+# Template — Rapport méthodologique DCA Grid (PY-DCA-EPIC-7)
+
+## 1) Métadonnées run
+
+- Run ID:
+- Date/heure:
+- Reviewer 1:
+- Reviewer 2:
+- Commit git:
+- Version spec:
+- Hash dataset:
+- Seed(s):
+
+## 2) Checklist anti data-snooping
+
+- [ ] Règles ex-ante gelées avant run.
+- [ ] Split temporel calibration/validation/test respecté.
+- [ ] Vérification no-lookahead validée.
+- [ ] Pas d’optimisation post-hoc sur période test.
+- [ ] Paramètres et hypothèses calendaires documentés.
+
+## 3) Matrice risques & mitigations
+
+| Risque | Contrôle appliqué | Résultat | Preuve |
+|---|---|---|---|
+| Data snooping |  |  |  |
+| Look-ahead bias |  |  |  |
+| Survivorship bias |  |  |  |
+| Leakage calendrier |  |  |  |
+| Non-reproductibilité |  |  |  |
+
+## 4) Rejeu reproductible
+
+- Commande exécutée:
+- Artefacts produits:
+  - [ ] run_manifest.json
+  - [ ] metrics.json
+  - [ ] trades.parquet/csv
+  - [ ] logs.txt
+  - [ ] checksums.txt
+- Résultat comparaison baseline vs rerun:
+  - Statut: `REPRODUCIBLE` | `DRIFT_MINEUR` | `NON_CONFORME`
+  - Écarts observés:
+
+## 5) Critères go/no-go
+
+### GO (toutes les conditions vraies)
+
+- [ ] Checklist anti-snooping complète.
+- [ ] Rejeu canonique reproductible.
+- [ ] Aucune fuite d’information détectée.
+- [ ] Critères de performance ex-ante atteints.
+- [ ] Signature de revue pairée.
+
+### NO-GO (au moins un point vrai)
+
+- [ ] Changement ex-post des règles ou seuils.
+- [ ] Artefacts incomplets/non traçables.
+- [ ] Échec de reproductibilité.
+- [ ] Fuite d’information non corrigée.
+
+## 6) Décision finale
+
+- Décision: GO / NO-GO
+- Rationale synthétique:
+- Actions de suivi:

--- a/docs/tests_plan.md
+++ b/docs/tests_plan.md
@@ -130,3 +130,29 @@ No hard duplication found. Some intentional overlaps:
     - Tests: tests/test_large_dataset_perf.py
    - Notes: optional memory cap + throughput check + filters-on variant + optimize perf (grid/random, screening on/off)
     - Status: implemented (marked slow).
+
+## PY-DCA-EPIC-7 — Validation méthodologique (Audit/Discovery)
+
+### Objectif d’audit
+
+- Vérifier la non-fuite d’information (look-ahead, leakage calendrier, data snooping).
+- Garantir la reproductibilité d’un run canonique via artefacts et checksums.
+- Formaliser une décision go/no-go indépendante des ajustements post-hoc.
+
+### Protocole d’intégration (rejeu canonique)
+
+1. Exécuter un run local avec une spec canonique figée.
+2. Capturer les artefacts minimaux d’audit (`run_manifest`, métriques, trades, logs, checksums).
+3. Comparer les sorties au baseline canonique (`docs/canonical_runs_dca_source_of_truth_2026-02-20.md`).
+4. Classer le run: `REPRODUCIBLE` / `DRIFT_MINEUR` / `NON_CONFORME`.
+
+### Commande de validation
+
+- `poetry run qe run-local --spec specs/examples/strategy_dca_etf_delta_2024_2026.json`
+
+### Critères d’acceptation (gate reviewer)
+
+- Scope conforme à PY-DCA-EPIC-7 et DoD documentaire.
+- Vérification explicite de la checklist anti-snooping.
+- Matrice risques + mitigations renseignée avec preuves.
+- Rejeu canonique effectué et comparaison d’artefacts documentée.


### PR DESCRIPTION
### Motivation

- Provide a verifiable audit framework for DCA Grid runs to prevent data‑snooping and ensure reproducibility before reporting any claimed edge.
- Make the required artefacts, rerun procedure and go/no‑go criteria explicit so runs can be independently audited and compared to a canonical baseline.

### Description

- Add a `Cadre d’audit vérifiable` to `docs/dca_grid_implementation_process.md` including an anti‑snooping checklist, a methodological risk matrix with mitigations, a reproducible rerun procedure, and formalized go/no‑go criteria.  
- Extend `docs/tests_plan.md` with a `PY-DCA-EPIC-7` section that defines the canonical replay protocol and the validation command `poetry run qe run-local --spec specs/examples/strategy_dca_etf_delta_2024_2026.json`.  
- Update `docs/canonical_runs_dca_source_of_truth_2026-02-20.md` to require audit artefacts (`run_manifest.json`, `metrics.json`, `trades.parquet/csv`, `logs.txt`, `checksums.txt`) and to describe the baseline vs rerun comparison procedure and status labels (`REPRODUCIBLE`, `DRIFT_MINEUR`, `NON_CONFORME`).  
- Add a reusable report template `docs/dca_methodology_audit_report_template.md` to capture run metadata, checklist results, risk matrix evidence, rerun outputs and the GO/NO‑GO decision form.  

### Testing

- Executed the canonical validation command `poetry run qe run-local --spec specs/examples/strategy_dca_etf_delta_2024_2026.json` which failed due to an environment error (`ModuleNotFoundError: No module named 'quant_engine'`), preventing an end‑to‑end run and artefact generation in this environment.  
- No new unit or integration test code was added since this change is documentation only, so there are no automated test results to report beyond the attempted validation command above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5931c4d9883238f07747fcef45534)