### PR TITLE
PY-DCA-EPIC-8: Add AssetUniverseAdapter to mutualize DCA across ETF/Equity/Crypto

### DIFF
--- a/specs/examples/strategy_dca_crypto_cross_universe_example.json
+++ b/specs/examples/strategy_dca_crypto_cross_universe_example.json
@@ -1,0 +1,38 @@
+{
+  "strategy": {
+    "strategy_id": "DCA_CRYPTO_CROSS_UNIVERSE",
+    "type": "dca_equity",
+    "params": {
+      "asset_class": "CRYPTO",
+      "drawdown_reference": "6M",
+      "grid": [
+        { "dd": -20.0, "weight": 0.5 },
+        { "dd": -30.0, "weight": 0.5 }
+      ],
+      "tp_sl": { "enabled": false },
+      "require_crossing": false
+    }
+  },
+  "data": {
+    "source": "csv",
+    "path": "tests/data/ohlcv_ts.csv",
+    "timeframe": "1D",
+    "start": "2025-01-01",
+    "end": "2025-01-20",
+    "universe": {
+      "calendar": "24x7",
+      "lot_mode": "fractional",
+      "fees_bps": 15.0,
+      "corporate_actions": "none",
+      "timezone": "UTC"
+    }
+  },
+  "universe": [
+    { "symbol": "BTC", "asset_class": "CRYPTO" }
+  ],
+  "performance": {
+    "initial_capital": 10000,
+    "capital_per_unit": 100,
+    "universe_rules_version": "asset-universe-rules-v1"
+  }
+}

--- a/specs/examples/strategy_dca_equity_cross_universe_example.json
+++ b/specs/examples/strategy_dca_equity_cross_universe_example.json
@@ -1,0 +1,38 @@
+{
+  "strategy": {
+    "strategy_id": "DCA_EQUITY_CROSS_UNIVERSE",
+    "type": "dca_equity",
+    "params": {
+      "asset_class": "EQUITY",
+      "drawdown_reference": "ATH",
+      "grid": [
+        { "dd": -5.0, "weight": 1.0 },
+        { "dd": -10.0, "weight": 1.0 }
+      ],
+      "tp_sl": { "enabled": false },
+      "require_crossing": false
+    }
+  },
+  "data": {
+    "source": "csv",
+    "path": "tests/data/ohlcv_ts.csv",
+    "timeframe": "1D",
+    "start": "2025-01-01",
+    "end": "2025-01-20",
+    "universe": {
+      "calendar": "nyse_business_days",
+      "lot_mode": "integer",
+      "fees_bps": 10.0,
+      "corporate_actions": "adjusted_splits_dividends",
+      "timezone": "America/New_York"
+    }
+  },
+  "universe": [
+    { "symbol": "SPY", "asset_class": "EQUITY" }
+  ],
+  "performance": {
+    "initial_capital": 10000,
+    "capital_per_unit": 100,
+    "universe_rules_version": "asset-universe-rules-v1"
+  }
+}

--- a/specs/examples/strategy_dca_etf_delta_2024_2026.json
+++ b/specs/examples/strategy_dca_etf_delta_2024_2026.json
@@ -5,11 +5,26 @@
     "params": {
       "asset_class": "ETF",
       "grid": [
-        { "dd": -10.0, "weight": 0.2 },
-        { "dd": -15.0, "weight": 0.2 },
-        { "dd": -20.0, "weight": 0.2 },
-        { "dd": -25.0, "weight": 0.2 },
-        { "dd": -30.0, "weight": 0.2 }
+        {
+          "dd": -10.0,
+          "weight": 0.2
+        },
+        {
+          "dd": -15.0,
+          "weight": 0.2
+        },
+        {
+          "dd": -20.0,
+          "weight": 0.2
+        },
+        {
+          "dd": -25.0,
+          "weight": 0.2
+        },
+        {
+          "dd": -30.0,
+          "weight": 0.2
+        }
       ],
       "reset_on_new_high": true,
       "rearm_on_rebound_pct": 10.0,
@@ -30,28 +45,86 @@
     "delta_broker": "IBKR",
     "delta_market_type": "SPOT",
     "delta_exchange": "AEB,BVME.ETF,IBIS2,LSEETF,SBF",
-    "delta_quotes": "EUR,USD"
+    "delta_quotes": "EUR,USD",
+    "universe": {
+      "calendar": "xetra_business_days",
+      "lot_mode": "integer",
+      "fees_bps": 7.0,
+      "corporate_actions": "adjusted_dividends_splits",
+      "timezone": "Europe/Berlin"
+    }
   },
   "universe": [
-    { "symbol": "INFR", "asset_class": "ETF" },
-    { "symbol": "TRET", "asset_class": "ETF" },
-    { "symbol": "WENS", "asset_class": "ETF" },
-    { "symbol": "IWQU", "asset_class": "ETF" },
-    { "symbol": "CEBL", "asset_class": "ETF" },
-    { "symbol": "IUSN", "asset_class": "ETF" },
-    { "symbol": "XAXJ", "asset_class": "ETF" },
-    { "symbol": "XRS2", "asset_class": "ETF" },
-    { "symbol": "DGTL", "asset_class": "ETF" },
-    { "symbol": "AEEM", "asset_class": "ETF" },
-    { "symbol": "ESE", "asset_class": "ETF" },
-    { "symbol": "ETZ", "asset_class": "ETF" },
-    { "symbol": "INRE", "asset_class": "ETF" },
-    { "symbol": "TPXE", "asset_class": "ETF" },
-    { "symbol": "UNIC", "asset_class": "ETF" },
-    { "symbol": "UST", "asset_class": "ETF" }
+    {
+      "symbol": "INFR",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "TRET",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "WENS",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "IWQU",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "CEBL",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "IUSN",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "XAXJ",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "XRS2",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "DGTL",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "AEEM",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "ESE",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "ETZ",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "INRE",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "TPXE",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "UNIC",
+      "asset_class": "ETF"
+    },
+    {
+      "symbol": "UST",
+      "asset_class": "ETF"
+    }
   ],
   "output": {
     "path": "runs/dca_etf_delta_2024_2026.json",
     "format": "json"
+  },
+  "performance": {
+    "universe_rules_version": "asset-universe-rules-v1"
   }
 }

--- a/src/quant_engine/datafeeds/__init__.py
+++ b/src/quant_engine/datafeeds/__init__.py
@@ -1,3 +1,3 @@
 """Data feed helpers for loading market data."""
 
-__all__ = ["mysql_feed"]
+__all__ = ["mysql_feed", "asset_universe_adapter"]

--- a/src/quant_engine/datafeeds/asset_universe_adapter.py
+++ b/src/quant_engine/datafeeds/asset_universe_adapter.py
@@ -1,0 +1,130 @@
+"""Asset-universe adapters for DCA multi-universe mutualization.
+
+The adapter layer centralizes universe-specific rules (calendar, lot sizing,
+fees, corporate actions handling) so the DCA core runner can stay generic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Protocol
+
+
+UNIVERSE_RULES_VERSION = "asset-universe-rules-v1"
+
+
+@dataclass(frozen=True)
+class UniverseRules:
+    calendar: str
+    lot_mode: str
+    fees_bps: float
+    corporate_actions: str
+    metadata: Dict[str, Any]
+
+
+class AssetUniverseAdapter(Protocol):
+    """Contract for transforming a generic spec into universe-specific defaults."""
+
+    universe_type: str
+    rules_version: str
+
+    def get_rules(self, *, data_spec: Mapping[str, Any], instrument: Mapping[str, Any]) -> UniverseRules:
+        ...
+
+    def adapt_data_spec(self, data_spec: Mapping[str, Any], instrument: Mapping[str, Any]) -> Dict[str, Any]:
+        ...
+
+    def adapt_context(self, context: Mapping[str, Any], rules: UniverseRules) -> Dict[str, Any]:
+        ...
+
+
+class _BaseUniverseAdapter:
+    universe_type = "GENERIC"
+    rules_version = UNIVERSE_RULES_VERSION
+    default_calendar = "weekday_business_days"
+    default_lot_mode = "fractional"
+    default_fees_bps = 10.0
+    default_corporate_actions = "none"
+
+    def get_rules(self, *, data_spec: Mapping[str, Any], instrument: Mapping[str, Any]) -> UniverseRules:
+        cfg = self._extract_universe_config(data_spec, instrument)
+        metadata = {
+            "timezone": cfg.get("timezone", data_spec.get("timezone", "UTC")),
+            "trading_hours": cfg.get("trading_hours", "regular"),
+        }
+        return UniverseRules(
+            calendar=str(cfg.get("calendar", self.default_calendar)),
+            lot_mode=str(cfg.get("lot_mode", self.default_lot_mode)),
+            fees_bps=float(cfg.get("fees_bps", self.default_fees_bps)),
+            corporate_actions=str(cfg.get("corporate_actions", self.default_corporate_actions)),
+            metadata=metadata,
+        )
+
+    def adapt_data_spec(self, data_spec: Mapping[str, Any], instrument: Mapping[str, Any]) -> Dict[str, Any]:
+        adapted = dict(data_spec)
+        rules = self.get_rules(data_spec=data_spec, instrument=instrument)
+        adapted.setdefault("calendar", rules.calendar)
+        adapted.setdefault("lot_mode", rules.lot_mode)
+        adapted.setdefault("fees_bps", rules.fees_bps)
+        adapted.setdefault("corporate_actions", rules.corporate_actions)
+        return adapted
+
+    def adapt_context(self, context: Mapping[str, Any], rules: UniverseRules) -> Dict[str, Any]:
+        adapted = dict(context)
+        adapted["universe_rules"] = {
+            "version": self.rules_version,
+            "calendar": rules.calendar,
+            "lot_mode": rules.lot_mode,
+            "fees_bps": rules.fees_bps,
+            "corporate_actions": rules.corporate_actions,
+            **rules.metadata,
+        }
+        return adapted
+
+    @staticmethod
+    def _extract_universe_config(data_spec: Mapping[str, Any], instrument: Mapping[str, Any]) -> Mapping[str, Any]:
+        raw = instrument.get("universe")
+        if isinstance(raw, Mapping):
+            return raw
+        raw = data_spec.get("universe")
+        if isinstance(raw, Mapping):
+            return raw
+        return {}
+
+
+class EtfUniverseAdapter(_BaseUniverseAdapter):
+    universe_type = "ETF"
+    default_calendar = "xetra_business_days"
+    default_lot_mode = "integer"
+    default_fees_bps = 7.0
+    default_corporate_actions = "adjusted_dividends_splits"
+
+
+class EquityUniverseAdapter(_BaseUniverseAdapter):
+    universe_type = "EQUITY"
+    default_calendar = "nyse_business_days"
+    default_lot_mode = "integer"
+    default_fees_bps = 10.0
+    default_corporate_actions = "adjusted_splits_dividends"
+
+
+class CryptoUniverseAdapter(_BaseUniverseAdapter):
+    universe_type = "CRYPTO"
+    default_calendar = "24x7"
+    default_lot_mode = "fractional"
+    default_fees_bps = 15.0
+    default_corporate_actions = "none"
+
+
+_REGISTRY: Dict[str, AssetUniverseAdapter] = {
+    "ETF": EtfUniverseAdapter(),
+    "EQUITY": EquityUniverseAdapter(),
+    "ACTION": EquityUniverseAdapter(),
+    "CRYPTO": CryptoUniverseAdapter(),
+}
+
+
+def resolve_asset_universe_adapter(asset_class: Optional[str]) -> AssetUniverseAdapter:
+    key = str(asset_class or "").strip().upper() or "EQUITY"
+    return _REGISTRY.get(key, EquityUniverseAdapter())
+

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -488,6 +488,8 @@ def build_dca_performance_from_signals(
         weights=score_weights,
     )
 
+    universe_rules_version = str(config.get("universe_rules_version", "asset-universe-rules-v1"))
+
     run = StrategyRunResult(
         strategy_id=strategy_id,
         run_id=run_id,
@@ -522,6 +524,7 @@ def build_dca_performance_from_signals(
             "capital_per_unit": capital_per_unit,
             "note": "DCA performance computed from pct PnL with cashflow-aware metrics.",
             "metrics_version": "dca-grid-process-v1",
+            "universe_rules_version": universe_rules_version,
             "final_performance_normalized": final_perf_norm,
             "twr": twr_value,
             "xirr": xirr_value,

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -21,6 +21,7 @@ from ..integrations import java_client
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
 from ..performance.dca_builder import build_backend_payload_for_java
+from ..datafeeds.asset_universe_adapter import resolve_asset_universe_adapter
 from pandas.tseries.holiday import USFederalHolidayCalendar
 from pandas.tseries.offsets import CustomBusinessDay
 try:
@@ -132,8 +133,11 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
             "asset_class",
             getattr(strategy, "asset_class", None) or strategy_cfg.get("asset_class"),
         )
+        universe_adapter = resolve_asset_universe_adapter(asset_class)
+        universe_rules = universe_adapter.get_rules(data_spec=data_spec, instrument=instrument)
+        adapted_data_spec = universe_adapter.adapt_data_spec(data_spec, instrument)
         t_fetch = time.monotonic()
-        df = _fetch_ohlc_for_symbol(symbol, asset_class, data_spec, instrument)
+        df = _fetch_ohlc_for_symbol(symbol, asset_class, adapted_data_spec, instrument)
         _perf_log(f"strategy.fetch_ohlc {symbol} rows={len(df)}", t_fetch)
         if isinstance(screening_cfg, Mapping) and screening_cfg.get("enabled"):
             window_start = screening_cfg.get("window_start")
@@ -217,6 +221,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
         ohlc_by_symbol[symbol] = df.copy()
         t_signals = time.monotonic()
         context = {"symbol": symbol, "asset_class": asset_class, "screening": screening_cfg}
+        context = universe_adapter.adapt_context(context, universe_rules)
         signals = strategy.backtest(df, context)
         serialized = [_serialize_signal(sig) for sig in signals]
         signals_by_symbol[symbol] = serialized
@@ -1484,6 +1489,10 @@ def _build_payload_for_result(
     for sym, records in (result.get("signals") or {}).items():
         signals_by_symbol[sym] = [_DictSignal(r) for r in records]
 
+    universe_adapter = resolve_asset_universe_adapter(asset_class)
+    performance_cfg = dict(spec.get("performance", {}) or {})
+    performance_cfg.setdefault("universe_rules_version", universe_adapter.rules_version)
+
     return build_backend_payload_for_java(
         strategy_id=strategy_id,
         run_id=run_id,
@@ -1492,5 +1501,5 @@ def _build_payload_for_result(
         timeframe=timeframe,
         signals_by_symbol=signals_by_symbol,
         ohlc_by_symbol=ohlc_by_symbol,
-        config=spec.get("performance", {}) or {},
+        config=performance_cfg,
     )

--- a/tests/integration/test_dca_cross_universe_specs.py
+++ b/tests/integration/test_dca_cross_universe_specs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pandas as pd
+
+if "pymysql" not in sys.modules:
+    pymysql_mod = types.ModuleType("pymysql")
+    cursors_mod = types.ModuleType("pymysql.cursors")
+
+    class _DictCursor:  # pragma: no cover - import shim
+        pass
+
+    cursors_mod.DictCursor = _DictCursor
+    pymysql_mod.cursors = cursors_mod
+    sys.modules["pymysql"] = pymysql_mod
+    sys.modules["pymysql.cursors"] = cursors_mod
+
+from quant_engine.strategies import runner as strategies_runner
+
+
+def _ohlc() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=40, freq="D", tz="UTC")
+    close = pd.Series([100.0, 102.0, 101.0, 98.0, 95.0] * 8, dtype=float)
+    return pd.DataFrame(
+        {
+            "ts": idx,
+            "open": close,
+            "high": close + 1.0,
+            "low": close - 1.0,
+            "close": close,
+            "volume": 1000,
+        }
+    )
+
+
+def _spec(asset_class: str) -> dict:
+    return {
+        "strategy": {
+            "strategy_id": f"DCA_{asset_class}",
+            "type": "dca_equity",
+            "params": {
+                "asset_class": asset_class,
+                "drawdown_reference": "ATH",
+                "grid": [{"dd": -2.0, "weight": 1.0}, {"dd": -4.0, "weight": 1.0}],
+                "tp_sl": {"enabled": False},
+                "require_crossing": False,
+            },
+        },
+        "data": {"timeframe": "1D", "start": "2024-01-01", "end": "2024-02-29"},
+        "universe": [{"symbol": "TEST", "asset_class": asset_class}],
+        "performance": {"initial_capital": 10000, "capital_per_unit": 100},
+    }
+
+
+def test_cross_universe_adapter_non_regression(monkeypatch) -> None:
+    monkeypatch.delenv("DB_DSN", raising=False)
+    captured_data_specs: list[dict] = []
+
+    def _fake_fetch(symbol: str, asset_class: str, data_spec: dict, instrument: dict) -> pd.DataFrame:
+        captured_data_specs.append(dict(data_spec))
+        return _ohlc()
+
+    monkeypatch.setattr(strategies_runner, "_fetch_ohlc_for_symbol", _fake_fetch)
+
+    cases = {
+        "ETF": "xetra_business_days",
+        "EQUITY": "nyse_business_days",
+        "CRYPTO": "24x7",
+    }
+    for asset_class, expected_calendar in cases.items():
+        result = strategies_runner.run_backtest_with_payload(_spec(asset_class))
+        run_extra = result["payload"]["run"].get("extra", {})
+        assert run_extra.get("universe_rules_version") == "asset-universe-rules-v1"
+        assert captured_data_specs[-1]["calendar"] == expected_calendar

--- a/tests/strategies/test_asset_universe_adapter.py
+++ b/tests/strategies/test_asset_universe_adapter.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from quant_engine.datafeeds.asset_universe_adapter import (
+    UNIVERSE_RULES_VERSION,
+    resolve_asset_universe_adapter,
+)
+
+
+def test_adapter_resolution_and_defaults() -> None:
+    etf = resolve_asset_universe_adapter("ETF")
+    equity = resolve_asset_universe_adapter("EQUITY")
+    crypto = resolve_asset_universe_adapter("CRYPTO")
+
+    etf_rules = etf.get_rules(data_spec={}, instrument={})
+    equity_rules = equity.get_rules(data_spec={}, instrument={})
+    crypto_rules = crypto.get_rules(data_spec={}, instrument={})
+
+    assert etf_rules.calendar == "xetra_business_days"
+    assert equity_rules.calendar == "nyse_business_days"
+    assert crypto_rules.calendar == "24x7"
+    assert crypto_rules.lot_mode == "fractional"
+
+
+def test_adapter_overrides_from_spec_and_context() -> None:
+    adapter = resolve_asset_universe_adapter("CRYPTO")
+    instrument = {
+        "universe": {
+            "calendar": "24x7",
+            "lot_mode": "fractional",
+            "fees_bps": 5.0,
+            "corporate_actions": "none",
+            "timezone": "UTC",
+        }
+    }
+    adapted_data = adapter.adapt_data_spec({"timeframe": "1D"}, instrument)
+    rules = adapter.get_rules(data_spec={}, instrument=instrument)
+    adapted_ctx = adapter.adapt_context({"symbol": "BTC"}, rules)
+
+    assert adapted_data["fees_bps"] == 5.0
+    assert adapted_ctx["universe_rules"]["version"] == UNIVERSE_RULES_VERSION
+    assert adapted_ctx["universe_rules"]["calendar"] == "24x7"


### PR DESCRIPTION
### Motivation
- Centralize universe-specific rules (calendar, lot sizing, fees, corporate actions) so the DCA core runner can be reused across ETF / Equity / Crypto without duplicating logic.
- Externalize universe parameters in specs and persist a `universe_rules_version` in run artifacts to enable consistent cross-universe analysis and UI integration.

### Description
- Add an adapter layer in `src/quant_engine/datafeeds/asset_universe_adapter.py` defining `AssetUniverseAdapter`, `UniverseRules`, and concrete `EtfUniverseAdapter` / `EquityUniverseAdapter` / `CryptoUniverseAdapter` plus `resolve_asset_universe_adapter`.
- Wire adapter resolution into the DCA runner (`src/quant_engine/strategies/runner.py`) so each instrument: resolves adapter by `asset_class`, calls `adapt_data_spec` before loading OHLC, and injects `universe_rules` into strategy `context` via `adapt_context`.
- Ensure `universe_rules_version` is written into performance payload configuration in `_build_payload_for_result` and persisted into the DCA run `extra` via `src/quant_engine/performance/dca_builder.py`.
- Export the new module via `src/quant_engine/datafeeds/__init__.py` and add example specs (`specs/examples/*_cross_universe_example.json`) with externalized `universe` parameters and version flag.
- Add tests: unit tests for adapter defaults/overrides (`tests/strategies/test_asset_universe_adapter.py`) and an integration non-regression test validating calendar propagation and `universe_rules_version` (`tests/integration/test_dca_cross_universe_specs.py`).

### Testing
- Ran `poetry run pytest -q tests/strategies/test_asset_universe_adapter.py` which succeeded (`2 passed`).
- Ran `poetry run pytest -q tests/integration/test_dca_cross_universe_specs.py` which succeeded (`1 passed`).
- Tests exercise adapter resolution, data-spec adaptation, context injection, and persistence of `universe_rules_version` into DCA run artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59537ab34832398a656bb473c58de)