### PR TITLE
Persist universe_rules_version in DCA contract artifacts metadata (EPIC-8)

### DIFF
--- a/docs/spec_builders_reference.md
+++ b/docs/spec_builders_reference.md
@@ -253,6 +253,16 @@ Chaque builder suit la meme pipeline:
 }
 ```
 
+### 6.5 Contrat artefacts DCA (EPIC-8)
+
+Quand `artifacts.out_dir` est fourni, les artefacts contractuels DCA JSON/Parquet doivent persister `metadata.universe_rules_version`.
+
+Source de la valeur:
+1. `performance.universe_rules_version` si present dans la requete canonique.
+2. fallback stable: `asset-universe-rules-v1`.
+
+Ce champ est versionne dans le bloc metadata du contrat et ne remplace aucun champ existant.
+
 ## 7) Builder: Seasonality
 
 ### 7.1 Classe conseillee

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -1362,6 +1362,10 @@ def _canonical_market_stats_to_spec(request: Dict[str, Any]) -> Dict[str, Any]:
             "dataset_id": persistence_block.get("dataset_id"),
         }
 
+    performance_block = request.get("performance")
+    if isinstance(performance_block, dict):
+        mapped["performance"] = dict(performance_block)
+
     return mapped
 
 
@@ -1538,6 +1542,10 @@ def _canonical_seasonality_to_spec(request: Dict[str, Any]) -> Dict[str, Any]:
             "spec_id": persistence_block.get("spec_id"),
             "dataset_id": persistence_block.get("dataset_id"),
         }
+
+    performance_block = request.get("performance")
+    if isinstance(performance_block, dict):
+        mapped["performance"] = dict(performance_block)
 
     return mapped
 

--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -196,6 +196,7 @@ class StatsSpec(BaseModel):
     validation: CoreValidationSpec | None = None
     artifacts: CoreArtifactsSpec | None = None
     persistence: StatsPersistenceSpec | None = None
+    performance: Dict[str, Any] | None = None
 
 
 class ExecutionSpec(BaseModel):

--- a/src/quant_engine/io/dca_artifacts.py
+++ b/src/quant_engine/io/dca_artifacts.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 SCHEMA_VERSION = "dca-grid-process-v1"
 CONTRACT_VERSION = "1.0.0"
+DEFAULT_UNIVERSE_RULES_VERSION = "asset-universe-rules-v1"
 
 
 class ReproducibilityMetadata(BaseModel):
@@ -22,6 +23,7 @@ class ReproducibilityMetadata(BaseModel):
 class ContractMetadata(BaseModel):
     schema_version: str = SCHEMA_VERSION
     contract_version: str = CONTRACT_VERSION
+    universe_rules_version: str = DEFAULT_UNIVERSE_RULES_VERSION
     generated_at: str
     reproducibility: ReproducibilityMetadata
 
@@ -39,8 +41,16 @@ def compute_dataset_hash(rows: List[Dict[str, Any]]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def build_metadata(*, generated_at: str, seed: int, dataset_hash: str, config_version: str) -> ContractMetadata:
+def build_metadata(
+    *,
+    generated_at: str,
+    seed: int,
+    dataset_hash: str,
+    config_version: str,
+    universe_rules_version: str | None = None,
+) -> ContractMetadata:
     return ContractMetadata(
+        universe_rules_version=str(universe_rules_version or DEFAULT_UNIVERSE_RULES_VERSION),
         generated_at=generated_at,
         reproducibility=ReproducibilityMetadata(seed=seed, dataset_hash=dataset_hash, config_version=config_version),
     )
@@ -66,6 +76,7 @@ def write_dca_contract_artifacts(
     seed: int,
     dataset_rows: List[Dict[str, Any]],
     config_version: str,
+    universe_rules_version: str | None = None,
     stats_summary: pd.DataFrame,
     robustness: Dict[str, Any],
 ) -> Dict[str, Dict[str, str]]:
@@ -76,6 +87,7 @@ def write_dca_contract_artifacts(
         seed=seed,
         dataset_hash=dataset_hash,
         config_version=config_version,
+        universe_rules_version=universe_rules_version,
     )
 
     rows = stats_summary.to_dict("records")

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -13,7 +13,11 @@ from ..core.dataset import load_ohlcv
 from ..core.features import atr
 from ..validate import splitter
 from ..io import artifacts
-from ..io.dca_artifacts import SCHEMA_VERSION, write_dca_contract_artifacts
+from ..io.dca_artifacts import (
+    DEFAULT_UNIVERSE_RULES_VERSION,
+    SCHEMA_VERSION,
+    write_dca_contract_artifacts,
+)
 from . import conditions as cond_mod
 from . import events as event_mod
 from . import targets as tgt_mod
@@ -435,6 +439,17 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
 
     out = out.reindex(columns=final_columns)
 
+    universe_rules_version = DEFAULT_UNIVERSE_RULES_VERSION
+    if getattr(spec, "performance", None) is not None:
+        performance_block = getattr(spec, "performance")
+        candidate = None
+        if isinstance(performance_block, dict):
+            candidate = performance_block.get("universe_rules_version")
+        else:
+            candidate = getattr(performance_block, "universe_rules_version", None)
+        if candidate is not None and str(candidate).strip():
+            universe_rules_version = str(candidate).strip()
+
     if spec.artifacts and spec.artifacts.out_dir:
         out_dir = Path(spec.artifacts.out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -450,6 +465,7 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
             seed=seed,
             dataset_rows=dataset,
             config_version=SCHEMA_VERSION,
+            universe_rules_version=universe_rules_version,
             stats_summary=out,
             robustness=robustness,
         )

--- a/tests/api/test_dca_artifact_endpoints.py
+++ b/tests/api/test_dca_artifact_endpoints.py
@@ -51,3 +51,24 @@ def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
     assert payload["out_dir"] == str(out_dir)
     names = {item["name"] for item in payload["files"]}
     assert {"metrics.json", "metrics.parquet"}.issubset(names)
+
+
+def test_canonical_market_stats_mapping_includes_performance_universe_rules_version(api_db):
+    mapped = api_app._canonical_market_stats_to_spec(
+        {
+            "data": {
+                "symbol": "AAPL",
+                "timeframe": "1D",
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-31",
+            },
+            "stats": {
+                "event": {"id": "k_consecutive", "params": {"k": 2}},
+                "condition": {"id": "session", "params": {}},
+                "target": {"id": "up_next_bar", "params": {}},
+            },
+            "performance": {"universe_rules_version": "asset-universe-rules-v3"},
+        }
+    )
+
+    assert mapped["performance"]["universe_rules_version"] == "asset-universe-rules-v3"

--- a/tests/io/test_dca_artifact_contract.py
+++ b/tests/io/test_dca_artifact_contract.py
@@ -3,7 +3,12 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
-from quant_engine.io.dca_artifacts import SCHEMA_VERSION, ArtifactEnvelope, write_dca_contract_artifacts
+from quant_engine.io.dca_artifacts import (
+    DEFAULT_UNIVERSE_RULES_VERSION,
+    SCHEMA_VERSION,
+    ArtifactEnvelope,
+    write_dca_contract_artifacts,
+)
 
 
 def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
@@ -33,6 +38,7 @@ def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
         seed=7,
         dataset_rows=dataset,
         config_version=SCHEMA_VERSION,
+        universe_rules_version="asset-universe-rules-v2",
         stats_summary=summary,
         robustness=robustness,
     )
@@ -45,5 +51,27 @@ def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
         parsed = ArtifactEnvelope.model_validate(payload)
         assert parsed.metadata.schema_version == SCHEMA_VERSION
         assert parsed.metadata.reproducibility.seed == 7
+        assert parsed.metadata.universe_rules_version == "asset-universe-rules-v2"
         assert paths["json"].endswith(f"{name}.json")
         assert paths["parquet"].endswith(f"{name}.parquet")
+
+
+def test_artifact_envelope_back_compat_without_universe_rules_version():
+    payload = {
+        "artifact": "metrics",
+        "metadata": {
+            "schema_version": SCHEMA_VERSION,
+            "contract_version": "1.0.0",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "reproducibility": {
+                "seed": 42,
+                "dataset_hash": "abc",
+                "config_version": SCHEMA_VERSION,
+            },
+        },
+        "rows": [],
+    }
+
+    parsed = ArtifactEnvelope.model_validate(payload)
+
+    assert parsed.metadata.universe_rules_version == DEFAULT_UNIVERSE_RULES_VERSION


### PR DESCRIPTION
### Motivation

- Ensure DCA contract artifacts include a versioned `universe_rules_version` in the metadata so consumers can rely on the universe rules used when the artifacts were produced.
- Propagate the value from the execution pipeline (`performance.universe_rules_version`) and provide a stable fallback to avoid breaking existing consumers.

### Description

- Added `DEFAULT_UNIVERSE_RULES_VERSION = "asset-universe-rules-v1"` and `universe_rules_version` to `ContractMetadata`, and updated `build_metadata` and `write_dca_contract_artifacts` to accept and persist this value (`src/quant_engine/io/dca_artifacts.py`).
- Read `performance.universe_rules_version` (if present) in the stats pipeline and pass it to the contract writer, falling back to the stable default (`src/quant_engine/stats/runner.py`).
- Extended `StatsSpec` to carry an optional `performance` block and updated canonical mapping to include `performance` so API requests can supply `universe_rules_version` (`src/quant_engine/api/schemas.py`, `src/quant_engine/api/app.py`).
- Updated unit and API tests and documentation to cover the new metadata field and backward compatibility (`tests/io/test_dca_artifact_contract.py`, `tests/api/test_dca_artifact_endpoints.py`, `docs/spec_builders_reference.md`).

### Testing

- Ran the targeted test suite with `poetry run pytest -q tests/io/test_dca_artifact_contract.py tests/api/test_dca_artifact_endpoints.py` which completed successfully with `4 passed`.
- Tests verify that each artifact JSON contains `metadata.universe_rules_version`, that the field is propagated from `performance` during canonical mapping, and that reading legacy payloads without the field uses the default value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59cebf47c8323b1ece1f19c71e329)