### PR TITLE
feat(audit): generate run_manifest.json and checksums.txt for stats/canonical runs

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -4064,11 +4064,16 @@ def get_run_artifacts(run_id: str) -> Dict[str, Any]:
             if item.is_file():
                 files.append({"name": item.name, "path": str(item), "size_bytes": item.stat().st_size})
 
+    file_names = {entry["name"] for entry in files}
     return {
         "run_id": run_id,
         "schema_version": SCHEMA_VERSION,
         "out_dir": str(out_dir) if out_dir is not None else None,
         "files": files,
+        "audit_trail": {
+            "run_manifest": "run_manifest.json" if "run_manifest.json" in file_names else None,
+            "checksums": "checksums.txt" if "checksums.txt" in file_names else None,
+        },
     }
 
 @fastapi_app.get('/runs/{run_id}/result', response_model=Dict[str, Any])

--- a/src/quant_engine/io/artifacts.py
+++ b/src/quant_engine/io/artifacts.py
@@ -1,6 +1,9 @@
 """Utilities to persist backtest and statistics results."""
 from __future__ import annotations
+import hashlib
 import json
+import platform
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, TYPE_CHECKING
 
@@ -63,3 +66,61 @@ def write_stats_details(path: str | Path, df: "pd.DataFrame") -> None:
 
     df.to_parquet(path, index=False)
 
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def sha256_file(path: str | Path) -> str:
+    file_path = Path(path)
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(8192)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_dataset_hash(dataset_rows: List[Dict[str, Any]]) -> str:
+    payload = json.dumps(dataset_rows, sort_keys=True, default=_json_default).encode("utf-8")
+    return sha256_bytes(payload)
+
+
+def compute_spec_hash(spec: Any) -> str:
+    if hasattr(spec, "model_dump"):
+        spec_payload = spec.model_dump(mode="json")
+    elif isinstance(spec, dict):
+        spec_payload = spec
+    else:
+        spec_payload = str(spec)
+    encoded = json.dumps(spec_payload, sort_keys=True, default=_json_default).encode("utf-8")
+    return sha256_bytes(encoded)
+
+
+def get_runtime_versions() -> Dict[str, str]:
+    import pandas as pd
+
+    return {
+        "python": platform.python_version(),
+        "pandas": pd.__version__,
+    }
+
+
+def get_git_commit() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def write_run_manifest(path: str | Path, manifest: Dict[str, Any]) -> None:
+    Path(path).write_text(json.dumps(manifest, indent=2, sort_keys=True, default=_json_default))
+
+
+def write_checksums(path: str | Path, files: List[str | Path]) -> None:
+    out_lines: List[str] = []
+    for file_path in sorted(Path(f) for f in files):
+        out_lines.append(f"{sha256_file(file_path)}  {file_path.name}")
+    Path(path).write_text("\n".join(out_lines) + "\n")

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -453,12 +453,18 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
     if spec.artifacts and spec.artifacts.out_dir:
         out_dir = Path(spec.artifacts.out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
-        artifacts.write_stats_summary(out_dir / "stats_summary.parquet", out)
-        artifacts.write_stats_details(out_dir / "stats_details.parquet", pd.DataFrame())
+
+        stats_summary_path = out_dir / "stats_summary.parquet"
+        stats_details_path = out_dir / "stats_details.parquet"
+        robustness_json_path = out_dir / "dca_robustness_v1.json"
+        robustness_parquet_path = out_dir / "dca_robustness_v1.parquet"
+
+        artifacts.write_stats_summary(stats_summary_path, out)
+        artifacts.write_stats_details(stats_details_path, pd.DataFrame())
         seed = 42
         robustness = _compute_robustness_artifacts(out, seed=seed)
-        (out_dir / "dca_robustness_v1.json").write_text(json.dumps(robustness, indent=2))
-        pd.DataFrame([robustness]).to_parquet(out_dir / "dca_robustness_v1.parquet", index=False)
+        robustness_json_path.write_text(json.dumps(robustness, indent=2))
+        pd.DataFrame([robustness]).to_parquet(robustness_parquet_path, index=False)
         contract_written = write_dca_contract_artifacts(
             out_dir,
             generated_at=datetime.now(timezone.utc).isoformat(),
@@ -469,7 +475,36 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
             stats_summary=out,
             robustness=robustness,
         )
-        logger.info("MarketStats artifacts written | out_dir=%s contract_artifacts=%s", out_dir, sorted(contract_written.keys()))
+
+        run_manifest_path = out_dir / "run_manifest.json"
+        checksums_path = out_dir / "checksums.txt"
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "seed": int(seed),
+            "commit": artifacts.get_git_commit(),
+            "spec_hash": artifacts.compute_spec_hash(spec),
+            "dataset_hash": artifacts.compute_dataset_hash(dataset),
+            "runtime_versions": artifacts.get_runtime_versions(),
+        }
+        artifacts.write_run_manifest(run_manifest_path, manifest)
+
+        checksum_targets = [
+            stats_summary_path,
+            stats_details_path,
+            robustness_json_path,
+            robustness_parquet_path,
+            run_manifest_path,
+        ]
+        for outputs in contract_written.values():
+            checksum_targets.extend(Path(path) for path in outputs.values())
+        artifacts.write_checksums(checksums_path, checksum_targets)
+
+        logger.info(
+            "MarketStats artifacts written | out_dir=%s contract_artifacts=%s audit_artifacts=%s",
+            out_dir,
+            sorted(contract_written.keys()),
+            [run_manifest_path.name, checksums_path.name],
+        )
 
     if spec.persistence and getattr(spec.persistence, "enabled", False):
         rows: List[Dict[str, Any]] = []

--- a/tests/api/test_dca_artifact_endpoints.py
+++ b/tests/api/test_dca_artifact_endpoints.py
@@ -30,6 +30,8 @@ def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
     out_dir.mkdir(parents=True)
     (out_dir / "metrics.json").write_text("{}")
     (out_dir / "metrics.parquet").write_text("parquet")
+    (out_dir / "run_manifest.json").write_text("{}")
+    (out_dir / "checksums.txt").write_text("abc  metrics.json\n")
 
     run_id = "run-artifacts-1"
     api_app._init_job(
@@ -50,7 +52,9 @@ def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
     assert payload["schema_version"] == "dca-grid-process-v1"
     assert payload["out_dir"] == str(out_dir)
     names = {item["name"] for item in payload["files"]}
-    assert {"metrics.json", "metrics.parquet"}.issubset(names)
+    assert {"metrics.json", "metrics.parquet", "run_manifest.json", "checksums.txt"}.issubset(names)
+    assert payload["audit_trail"]["run_manifest"] == "run_manifest.json"
+    assert payload["audit_trail"]["checksums"] == "checksums.txt"
 
 
 def test_canonical_market_stats_mapping_includes_performance_universe_rules_version(api_db):

--- a/tests/integration/test_dca_robustness_pipeline.py
+++ b/tests/integration/test_dca_robustness_pipeline.py
@@ -56,3 +56,23 @@ def test_stats_pipeline_writes_dca_robustness_artifacts(tmp_path: Path) -> None:
     assert "percentile" in payload
     assert "dominance" in payload
     assert len(payload["stress_grid"]) == 3
+
+    run_manifest = out_dir / "run_manifest.json"
+    checksums = out_dir / "checksums.txt"
+    assert run_manifest.exists()
+    assert checksums.exists()
+
+    manifest_payload = json.loads(run_manifest.read_text())
+    assert manifest_payload["schema_version"] == "dca-grid-process-v1"
+    assert manifest_payload["seed"] == 42
+    assert isinstance(manifest_payload.get("dataset_hash"), str)
+    assert len(manifest_payload["dataset_hash"]) == 64
+    assert isinstance(manifest_payload.get("spec_hash"), str)
+    assert len(manifest_payload["spec_hash"]) == 64
+    assert isinstance(manifest_payload.get("runtime_versions"), dict)
+    assert "python" in manifest_payload["runtime_versions"]
+
+    checksum_lines = [line for line in checksums.read_text().splitlines() if line.strip()]
+    assert checksum_lines
+    assert any(line.endswith("run_manifest.json") for line in checksum_lines)
+    assert any(line.endswith("dca_robustness_v1.json") for line in checksum_lines)


### PR DESCRIPTION
### Motivation
- Ensure a minimal, toolable audit trail is produced for DCA/canonical runs so runs are reproducible and artifact integrity can be verified.
- Provide deterministic identifiers for the spec and dataset and surface runtime/git metadata alongside generated artifacts.

### Description
- Added reusable artifact utilities in `src/quant_engine/io/artifacts.py` to compute SHA256 (`sha256_bytes`, `sha256_file`), deterministic `spec_hash` and `dataset_hash`, capture `runtime_versions` and the current git `commit`, and write `run_manifest.json` and `checksums.txt`.
- Updated the stats pipeline in `src/quant_engine/stats/runner.py` to emit audit artifacts to the `out_dir` when `spec.artifacts.out_dir` is set: `run_manifest.json` (containing `schema_version`, `seed`, `commit`, `spec_hash`, `dataset_hash`, `runtime_versions`) and `checksums.txt` (SHA256 lines for generated outputs and contract artifacts).
- Extended the run artifacts API payload in `src/quant_engine/api/app.py` to include an `audit_trail` section exposing presence of `run_manifest.json` and `checksums.txt` in the output directory.
- Updated tests to validate the new behavior: `tests/api/test_dca_artifact_endpoints.py` checks the audit files are listed and exposed via `audit_trail`, and `tests/integration/test_dca_robustness_pipeline.py` asserts the manifest and checksums are generated and contain minimal expected structure/format.

### Testing
- Ran the focused test command `poetry run pytest -q tests/api/test_dca_artifact_endpoints.py tests/integration/test_dca_robustness_pipeline.py` and the suite passed with `3 passed`.
- The new unit/integration assertions verify file presence, manifest fields (`schema_version`, `seed`, 64-char `spec_hash`/`dataset_hash`), and that `checksums.txt` contains entries for emitted artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59edd0528832394f352c27605871c)