### PR TITLE
Align DCA robustness entrypoint between optimize and stats runner

### DIFF
--- a/docs/dca_grid_implementation_process.md
+++ b/docs/dca_grid_implementation_process.md
@@ -342,3 +342,14 @@ Seules certaines briques doivent être spécialisées par classe d’actifs.
 ### 7.5 Règle méthodologique clé
 
 - **Comparer une stratégie uniquement contre des benchmarks plausibles du même univers** (pas de conclusion “crypto > ETF” sans normalisation stricte du risque, des frais et du calendrier).
+
+## 8) Mapping point d’entrée robustesse (clarification architecture)
+
+Pour EPIC-3/P1, le **calcul canonique** des artefacts de robustesse DCA reste implémenté dans `quant_engine.stats.runner` via `compute_dca_robustness_artifacts`.
+
+Afin d’éviter toute ambiguïté côté point d’entrée ticket `optimize/runner.py`, un pont explicite est exposé:
+
+- `quant_engine.optimize.runner.compute_dca_robustness_from_stats(out_df, seed)`
+- ce helper délègue directement à `quant_engine.stats.runner.compute_dca_robustness_artifacts(...)`
+
+Conséquence: la logique métier de robustesse n’est pas dupliquée; `optimize` fournit uniquement un point d’accès aligné pour les workflows qui partent de l’optimisation.

--- a/src/quant_engine/optimize/__init__.py
+++ b/src/quant_engine/optimize/__init__.py
@@ -1,3 +1,16 @@
-from .variants import run_backtest_optimization, run_strategy_optimization
+from __future__ import annotations
+
+
+def run_backtest_optimization(*args, **kwargs):
+    from .variants import run_backtest_optimization as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def run_strategy_optimization(*args, **kwargs):
+    from .variants import run_strategy_optimization as _impl
+
+    return _impl(*args, **kwargs)
+
 
 __all__ = ["run_backtest_optimization", "run_strategy_optimization"]

--- a/src/quant_engine/optimize/runner.py
+++ b/src/quant_engine/optimize/runner.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any, List
 
+import pandas as pd
+
 from ..core import dataset
 from ..core.spec import Spec
 from ..signals.ema_cross import EmaCross
@@ -50,6 +52,14 @@ def _bounded_stress_grid(base_params: Dict[str, int]) -> List[Dict[str, int]]:
         seen.add(key)
         out.append(c)
     return out
+
+
+def compute_dca_robustness_from_stats(out_df: "pd.DataFrame", seed: int = 42) -> Dict[str, Any]:
+    """Bridge helper to compute DCA robustness via the stats runner implementation."""
+
+    from ..stats.runner import compute_dca_robustness_artifacts
+
+    return compute_dca_robustness_artifacts(out_df, seed=seed)
 
 
 def run(spec: Spec, out_dir: str | Path = Path(".")) -> Dict[str, Any]:

--- a/src/quant_engine/stats/runner.py
+++ b/src/quant_engine/stats/runner.py
@@ -340,6 +340,17 @@ def _compute_robustness_artifacts(out: pd.DataFrame, seed: int = 42) -> Dict[str
     }
 
 
+def compute_dca_robustness_artifacts(out: pd.DataFrame, seed: int = 42) -> Dict[str, Any]:
+    """Public helper for DCA robustness payload generation.
+
+    This function is the canonical code entry point for robustness artifacts so
+    other runners (for example optimize) can delegate without duplicating the
+    implementation.
+    """
+
+    return _compute_robustness_artifacts(out, seed=seed)
+
+
 def run_stats(spec: StatsSpec) -> pd.DataFrame:
     logger.info(
         "MarketStats run started | symbols=%s timeframe=%s source_path=%s mysql=%s persistence=%s artifacts=%s",
@@ -462,7 +473,7 @@ def run_stats(spec: StatsSpec) -> pd.DataFrame:
         artifacts.write_stats_summary(stats_summary_path, out)
         artifacts.write_stats_details(stats_details_path, pd.DataFrame())
         seed = 42
-        robustness = _compute_robustness_artifacts(out, seed=seed)
+        robustness = compute_dca_robustness_artifacts(out, seed=seed)
         robustness_json_path.write_text(json.dumps(robustness, indent=2))
         pd.DataFrame([robustness]).to_parquet(robustness_parquet_path, index=False)
         contract_written = write_dca_contract_artifacts(

--- a/tests/integration/test_dca_robustness_pipeline.py
+++ b/tests/integration/test_dca_robustness_pipeline.py
@@ -2,8 +2,11 @@ import json
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import pandas as pd
+
 from quant_engine.api import schemas
 from quant_engine.core.spec import ArtifactsSpec
+from quant_engine.optimize import runner as optimize_runner
 from quant_engine.stats import runner
 
 
@@ -76,3 +79,19 @@ def test_stats_pipeline_writes_dca_robustness_artifacts(tmp_path: Path) -> None:
     assert checksum_lines
     assert any(line.endswith("run_manifest.json") for line in checksum_lines)
     assert any(line.endswith("dca_robustness_v1.json") for line in checksum_lines)
+
+
+def test_optimize_runner_bridge_maps_to_stats_robustness() -> None:
+    stats_out = pd.DataFrame(
+        [
+            {"p_hat": 0.55, "lift_freq": 0.10},
+            {"p_hat": 0.45, "lift_freq": 0.05},
+            {"p_hat": 0.60, "lift_freq": 0.12},
+        ]
+    )
+
+    via_stats = runner.compute_dca_robustness_artifacts(stats_out, seed=77)
+    via_optimize = optimize_runner.compute_dca_robustness_from_stats(stats_out, seed=77)
+
+    assert via_optimize == via_stats
+    assert len(via_optimize["stress_grid"]) == 3


### PR DESCRIPTION
### Motivation
- Remove architectural ambiguity by providing a single canonical entrypoint for DCA robustness computation so `optimize` workflows can reuse `stats` logic instead of duplicating it.
- Ensure integration workflows can access robustness artifacts without importing heavy optimization dependencies at package import time.

### Description
- Added a public helper `compute_dca_robustness_artifacts(out: pd.DataFrame, seed: int = 42)` in `src/quant_engine/stats/runner.py` and switched the stats artifact pipeline to call it.
- Added a bridge helper `compute_dca_robustness_from_stats(out_df: pd.DataFrame, seed: int = 42)` in `src/quant_engine/optimize/runner.py` that delegates to the stats helper to keep robustness logic centralized.
- Added an integration test `test_optimize_runner_bridge_maps_to_stats_robustness` in `tests/integration/test_dca_robustness_pipeline.py` that asserts the bridge returns identical payloads to the stats implementation for the same input and seed.
- Documented the mapping in `docs/dca_grid_implementation_process.md` and changed `src/quant_engine/optimize/__init__.py` to use lazy wrapper exports to avoid importing heavy modules at package import time.

### Testing
- Ran `poetry run pytest -q tests/stats/test_dca_robustness.py tests/integration/test_dca_robustness_pipeline.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a591a5188323a38d65c828d6dc16)