### PR TITLE
Add API submit tests for DCA benchmark variants

### DIFF
--- a/tests/api/test_dca_benchmark_submit_api.py
+++ b/tests/api/test_dca_benchmark_submit_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from typing import Any
+
+import pytest
+
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_stub.connect = lambda *args, **kwargs: None
+    cursors_stub = types.ModuleType("pymysql.cursors")
+    cursors_stub.DictCursor = object
+    pymysql_stub.cursors = cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = cursors_stub
+
+from quant_engine.api import app as api_app
+from quant_engine.api import worker as worker_module
+from quant_engine.config import reset_settings_cache
+
+
+_REQUIRED_BENCHMARK_FIELDS = {
+    "variant",
+    "planned_date",
+    "effective_date",
+    "fallback",
+    "cashflow",
+    "invested_capital",
+    "capital_curve",
+    "timezone",
+}
+
+
+@pytest.fixture
+def api_db(tmp_path):
+    os.environ["DB_SQLITE_PATH"] = str(tmp_path / "quant.db")
+    reset_settings_cache()
+    yield
+    os.environ.pop("DB_SQLITE_PATH", None)
+    reset_settings_cache()
+
+
+def _submit_benchmark_run(variant: str, **params: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "spec_type": "dca",
+        "catalog_version": "v1",
+        "data": {
+            "symbol": "SPY",
+            "timeframe": "1D",
+            "start_date": "2024-01-01",
+            "end_date": "2024-04-30",
+            "path": "tests/data/ohlcv_dca_benchmark_daily.csv",
+        },
+        "strategy": {
+            "type": "dca_benchmark",
+            "grid": [],
+            "params": {
+                "variant": variant,
+                "amount": 100.0,
+                "fallback": "next_business_day",
+                "timezone": "UTC",
+                **params,
+            },
+        },
+    }
+
+    enqueue = api_app.enqueue_run_request(payload)
+    worker_module.process_next_job()
+    result_payload = api_app.run_result_endpoint(enqueue.run_id)
+
+    assert result_payload["status"] == "SUCCEEDED"
+    return result_payload["result"]["result"]
+
+
+@pytest.mark.parametrize(
+    ("variant", "params"),
+    [
+        ("monthly_fixed", {"day_of_month": 15}),
+        ("monthly_randomized", {"seed": 7}),
+        ("mid_month", {"start_day": 10, "end_day": 20, "day_of_month": 15}),
+        ("turn_of_month", {"offset": -1}),
+        ("weekly_fixed", {"weekday": 2}),
+    ],
+)
+def test_submit_api_dca_benchmark_variants_have_homogeneous_calendar_meta(api_db, variant, params) -> None:
+    result = _submit_benchmark_run(variant, **params)
+
+    signals = result["signals"]["SPY"]
+    assert signals
+
+    for signal in signals:
+        benchmark_meta = signal["meta"]["benchmark"]
+        assert _REQUIRED_BENCHMARK_FIELDS.issubset(benchmark_meta.keys())
+        assert benchmark_meta["variant"] == variant
+        assert benchmark_meta["planned_date"]
+        assert benchmark_meta["effective_date"]
+        assert benchmark_meta["timezone"] == "UTC"
+        assert isinstance(benchmark_meta["cashflow"], (int, float))
+        assert isinstance(benchmark_meta["invested_capital"], (int, float))
+        assert isinstance(benchmark_meta["capital_curve"], (int, float))
+
+
+def test_submit_api_monthly_randomized_is_deterministic_with_fixed_seed(api_db) -> None:
+    first = _submit_benchmark_run("monthly_randomized", seed=42)
+    second = _submit_benchmark_run("monthly_randomized", seed=42)
+
+    first_effective_dates = [s["meta"]["benchmark"]["effective_date"] for s in first["signals"]["SPY"]]
+    second_effective_dates = [s["meta"]["benchmark"]["effective_date"] for s in second["signals"]["SPY"]]
+
+    assert first_effective_dates == second_effective_dates


### PR DESCRIPTION
### Motivation
- Provide dedicated API-level integration coverage for canonical DCA benchmark runs submitted via `/submit`/queue path to ensure the HTTP surface produces the same calendar metadata as the runner-level tests. 
- Ensure all five passive benchmark variants expose a homogeneous `meta.benchmark` schema and verify determinism of the `monthly_randomized` variant when a fixed seed is provided.

### Description
- Add new test module `tests/api/test_dca_benchmark_submit_api.py` which submits canonical DCA benchmark runs through the API enqueue path and inspects completed run output. 
- Include a lightweight `pymysql` shim and an `api_db` fixture to isolate DB state via `DB_SQLITE_PATH` for CI-friendly execution. 
- Implement a reusable helper `_submit_benchmark_run` that enqueues, processes the next job, and fetches results via `api_app.enqueue_run_request`, `worker.process_next_job()` and `api_app.run_result_endpoint`. 
- Add parameterized tests covering `monthly_fixed`, `monthly_randomized`, `mid_month`, `turn_of_month`, and `weekly_fixed` that assert required `meta.benchmark` fields and a separate test asserting deterministic `effective_date` sequences for `monthly_randomized` with a fixed seed.

### Testing
- Ran `PYTHONPATH=src poetry run pytest -q tests/api/test_dca_benchmark_submit_api.py` and the new tests passed (`6 passed`).
- Ran `PYTHONPATH=src poetry run pytest -q tests/integration/test_dca_benchmark_specs.py tests/strategies/test_dca_benchmark_calendars.py` to validate existing spec and calendar behavior and both passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ba50a6708323b35c8ddca2563a6f)