### PR TITLE
Add best_plausible_passive_ex_ante artifact and expose in run artifacts API

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -4065,11 +4065,18 @@ def get_run_artifacts(run_id: str) -> Dict[str, Any]:
                 files.append({"name": item.name, "path": str(item), "size_bytes": item.stat().st_size})
 
     file_names = {entry["name"] for entry in files}
+    contract_artifacts = {
+        "best_plausible_passive_ex_ante": {
+            "json": "best_plausible_passive_ex_ante.json" if "best_plausible_passive_ex_ante.json" in file_names else None,
+            "parquet": "best_plausible_passive_ex_ante.parquet" if "best_plausible_passive_ex_ante.parquet" in file_names else None,
+        }
+    }
     return {
         "run_id": run_id,
         "schema_version": SCHEMA_VERSION,
         "out_dir": str(out_dir) if out_dir is not None else None,
         "files": files,
+        "contract_artifacts": contract_artifacts,
         "audit_trail": {
             "run_manifest": "run_manifest.json" if "run_manifest.json" in file_names else None,
             "checksums": "checksums.txt" if "checksums.txt" in file_names else None,

--- a/src/quant_engine/io/dca_artifacts.py
+++ b/src/quant_engine/io/dca_artifacts.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 SCHEMA_VERSION = "dca-grid-process-v1"
@@ -24,8 +24,21 @@ class ContractMetadata(BaseModel):
     schema_version: str = SCHEMA_VERSION
     contract_version: str = CONTRACT_VERSION
     universe_rules_version: str = DEFAULT_UNIVERSE_RULES_VERSION
+    seed: int | None = None
+    dataset_hash: str | None = None
+    config_version: str | None = None
     generated_at: str
     reproducibility: ReproducibilityMetadata
+
+    @model_validator(mode="after")
+    def _populate_flat_reproducibility_fields(self) -> "ContractMetadata":
+        if self.seed is None:
+            self.seed = self.reproducibility.seed
+        if self.dataset_hash is None:
+            self.dataset_hash = self.reproducibility.dataset_hash
+        if self.config_version is None:
+            self.config_version = self.reproducibility.config_version
+        return self
 
 
 class ArtifactEnvelope(BaseModel):
@@ -51,6 +64,9 @@ def build_metadata(
 ) -> ContractMetadata:
     return ContractMetadata(
         universe_rules_version=str(universe_rules_version or DEFAULT_UNIVERSE_RULES_VERSION),
+        seed=seed,
+        dataset_hash=dataset_hash,
+        config_version=config_version,
         generated_at=generated_at,
         reproducibility=ReproducibilityMetadata(seed=seed, dataset_hash=dataset_hash, config_version=config_version),
     )
@@ -132,12 +148,52 @@ def write_dca_contract_artifacts(
         }
     ]
 
+    plausibility_constraints = {
+        "min_percentile": 0.50,
+        "min_perf_dominance_prob": 0.60,
+        "min_drawdown_dominance_prob": 0.60,
+        "requires_dominance_flag": True,
+    }
+    best_candidate: Dict[str, Any] = {}
+    if metrics_rows:
+        best_candidate = max(metrics_rows, key=lambda item: float(item.get("lift_freq", 0.0) or 0.0))
+    percentile_value = float(robustness.get("percentile", 0.0) or 0.0)
+    dominance_payload = robustness.get("dominance") or {}
+    perf_prob = float(dominance_payload.get("perf_dominance_prob", 0.0) or 0.0)
+    drawdown_prob = float(dominance_payload.get("drawdown_dominance_prob", 0.0) or 0.0)
+    is_dominant = bool(dominance_payload.get("is_dominant", False))
+    passes_constraints = (
+        bool(best_candidate)
+        and percentile_value >= plausibility_constraints["min_percentile"]
+        and perf_prob >= plausibility_constraints["min_perf_dominance_prob"]
+        and drawdown_prob >= plausibility_constraints["min_drawdown_dominance_prob"]
+        and is_dominant
+    )
+    best_plausible_passive_ex_ante_rows = [
+        {
+            "selection_method": "max_lift_freq_under_plausibility",
+            "symbol": best_candidate.get("symbol"),
+            "target": best_candidate.get("target"),
+            "n": int(best_candidate.get("n", 0) or 0),
+            "successes": int(best_candidate.get("successes", 0) or 0),
+            "lift_freq": float(best_candidate.get("lift_freq", 0.0) or 0.0),
+            "lift_bayes": float(best_candidate.get("lift_bayes", 0.0) or 0.0),
+            "percentile": percentile_value,
+            "perf_dominance_prob": perf_prob,
+            "drawdown_dominance_prob": drawdown_prob,
+            "is_dominant": is_dominant,
+            "constraints": plausibility_constraints,
+            "passes_constraints": passes_constraints,
+        }
+    ]
+
     artifacts = {
         "metrics": metrics_rows,
         "distributions": distributions_rows,
         "capital_curves": capital_curve,
         "rolling": rolling_rows,
         "score": score_rows,
+        "best_plausible_passive_ex_ante": best_plausible_passive_ex_ante_rows,
     }
 
     written: Dict[str, Dict[str, str]] = {}

--- a/tests/api/test_dca_artifact_endpoints.py
+++ b/tests/api/test_dca_artifact_endpoints.py
@@ -32,6 +32,8 @@ def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
     (out_dir / "metrics.parquet").write_text("parquet")
     (out_dir / "run_manifest.json").write_text("{}")
     (out_dir / "checksums.txt").write_text("abc  metrics.json\n")
+    (out_dir / "best_plausible_passive_ex_ante.json").write_text("{}")
+    (out_dir / "best_plausible_passive_ex_ante.parquet").write_text("parquet")
 
     run_id = "run-artifacts-1"
     api_app._init_job(
@@ -52,7 +54,9 @@ def test_run_artifacts_endpoint_lists_files(api_db, tmp_path):
     assert payload["schema_version"] == "dca-grid-process-v1"
     assert payload["out_dir"] == str(out_dir)
     names = {item["name"] for item in payload["files"]}
-    assert {"metrics.json", "metrics.parquet", "run_manifest.json", "checksums.txt"}.issubset(names)
+    assert {"metrics.json", "metrics.parquet", "run_manifest.json", "checksums.txt", "best_plausible_passive_ex_ante.json", "best_plausible_passive_ex_ante.parquet"}.issubset(names)
+    assert payload["contract_artifacts"]["best_plausible_passive_ex_ante"]["json"] == "best_plausible_passive_ex_ante.json"
+    assert payload["contract_artifacts"]["best_plausible_passive_ex_ante"]["parquet"] == "best_plausible_passive_ex_ante.parquet"
     assert payload["audit_trail"]["run_manifest"] == "run_manifest.json"
     assert payload["audit_trail"]["checksums"] == "checksums.txt"
 

--- a/tests/integration/test_dca_robustness_pipeline.py
+++ b/tests/integration/test_dca_robustness_pipeline.py
@@ -79,6 +79,26 @@ def test_stats_pipeline_writes_dca_robustness_artifacts(tmp_path: Path) -> None:
     assert checksum_lines
     assert any(line.endswith("run_manifest.json") for line in checksum_lines)
     assert any(line.endswith("dca_robustness_v1.json") for line in checksum_lines)
+    assert any(line.endswith("best_plausible_passive_ex_ante.json") for line in checksum_lines)
+
+    ex_ante_json = out_dir / "best_plausible_passive_ex_ante.json"
+    ex_ante_parquet = out_dir / "best_plausible_passive_ex_ante.parquet"
+    assert ex_ante_json.exists()
+    assert ex_ante_parquet.exists()
+
+    ex_ante_payload = json.loads(ex_ante_json.read_text())
+    metadata = ex_ante_payload["metadata"]
+    assert metadata["schema_version"] == "dca-grid-process-v1"
+    assert metadata["seed"] == 42
+    assert isinstance(metadata["dataset_hash"], str)
+    assert len(metadata["dataset_hash"]) == 64
+    assert metadata["config_version"] == "dca-grid-process-v1"
+    assert "universe_rules_version" in metadata
+
+    row = ex_ante_payload["rows"][0]
+    assert row["percentile"] == payload["percentile"]
+    assert row["perf_dominance_prob"] == payload["dominance"]["perf_dominance_prob"]
+    assert row["drawdown_dominance_prob"] == payload["dominance"]["drawdown_dominance_prob"]
 
 
 def test_optimize_runner_bridge_maps_to_stats_robustness() -> None:

--- a/tests/io/test_dca_artifact_contract.py
+++ b/tests/io/test_dca_artifact_contract.py
@@ -43,7 +43,7 @@ def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
         robustness=robustness,
     )
 
-    assert set(written.keys()) == {"metrics", "distributions", "capital_curves", "rolling", "score"}
+    assert set(written.keys()) == {"metrics", "distributions", "capital_curves", "rolling", "score", "best_plausible_passive_ex_ante"}
     for name, paths in written.items():
         assert out_dir.joinpath(f"{name}.json").exists()
         assert out_dir.joinpath(f"{name}.parquet").exists()
@@ -51,6 +51,10 @@ def test_dca_artifact_contract_writes_json_and_parquet(tmp_path):
         parsed = ArtifactEnvelope.model_validate(payload)
         assert parsed.metadata.schema_version == SCHEMA_VERSION
         assert parsed.metadata.reproducibility.seed == 7
+        assert parsed.metadata.seed == 7
+        assert isinstance(parsed.metadata.dataset_hash, str)
+        assert len(parsed.metadata.dataset_hash) == 64
+        assert parsed.metadata.config_version == SCHEMA_VERSION
         assert parsed.metadata.universe_rules_version == "asset-universe-rules-v2"
         assert paths["json"].endswith(f"{name}.json")
         assert paths["parquet"].endswith(f"{name}.parquet")
@@ -75,3 +79,45 @@ def test_artifact_envelope_back_compat_without_universe_rules_version():
     parsed = ArtifactEnvelope.model_validate(payload)
 
     assert parsed.metadata.universe_rules_version == DEFAULT_UNIVERSE_RULES_VERSION
+
+
+def test_best_plausible_passive_ex_ante_consistent_with_percentile_and_dominance(tmp_path):
+    out_dir = tmp_path / "artifacts"
+    dataset = [{"timestamp": "2024-01-01T00:00:00Z", "symbol": "AAPL", "close": 100.0}]
+    summary = pd.DataFrame(
+        [
+            {"symbol": "AAPL", "target": "up_next_bar", "n": 10, "successes": 6, "lift_freq": 0.12, "lift_bayes": 0.11},
+            {"symbol": "MSFT", "target": "up_next_bar", "n": 12, "successes": 8, "lift_freq": 0.20, "lift_bayes": 0.19},
+        ]
+    )
+    robustness = {
+        "quantiles": {"p50": 0.5},
+        "percentile": 0.75,
+        "dominance": {
+            "perf_dominance_prob": 0.82,
+            "drawdown_dominance_prob": 0.76,
+            "is_dominant": True,
+        },
+    }
+
+    write_dca_contract_artifacts(
+        out_dir,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        seed=7,
+        dataset_rows=dataset,
+        config_version=SCHEMA_VERSION,
+        stats_summary=summary,
+        robustness=robustness,
+    )
+
+    payload = json.loads((out_dir / "best_plausible_passive_ex_ante.json").read_text())
+    parsed = ArtifactEnvelope.model_validate(payload)
+    row = parsed.rows[0]
+
+    assert row["symbol"] == "MSFT"
+    assert row["lift_freq"] == 0.2
+    assert row["percentile"] == 0.75
+    assert row["perf_dominance_prob"] == 0.82
+    assert row["drawdown_dominance_prob"] == 0.76
+    assert row["is_dominant"] is True
+    assert row["passes_constraints"] is True


### PR DESCRIPTION
### Motivation
- Materialize the conceptual “best plausible passive ex-ante” selection as a concrete, versioned artifact emitted by the DCA pipeline so downstream consumers can access the ex-ante choice and its constraints.
- Ensure artifact metadata includes explicit reproducibility fields (`seed`, `dataset_hash`, `config_version`) for easier validation and compatibility with older payload shapes.
- Surface the new contract artifact in the run artifact listing so API clients can discover JSON/Parquet outputs programmatically.

### Description
- Added a new `best_plausible_passive_ex_ante` artifact emitted as JSON and Parquet from `write_dca_contract_artifacts` with selection logic that picks the candidate with maximum `lift_freq` and records plausibility constraints and percentile/dominance metrics (`src/quant_engine/io/dca_artifacts.py`).
- Extended `ContractMetadata` to include flattened fields `seed`, `dataset_hash`, and `config_version`, and added a `@model_validator(mode="after")` to backfill those from nested `reproducibility` for backward compatibility, and updated `build_metadata` to set the flattened fields.
- Included the new artifact into the artifacts writer loop so it is produced alongside `metrics`, `distributions`, `capital_curves`, `rolling`, and `score` outputs.
- Exposed the artifact in the API by adding a `contract_artifacts.best_plausible_passive_ex_ante` entry to the payload returned by `get_run_artifacts` at `/runs/{run_id}/artifacts` (`src/quant_engine/api/app.py`).
- Expanded and updated tests to validate writing, metadata completeness, endpoint exposure, and coherence between the ex-ante row and robustness percentile/dominance values (`tests/io/test_dca_artifact_contract.py`, `tests/integration/test_dca_robustness_pipeline.py`, `tests/api/test_dca_artifact_endpoints.py`).

### Testing
- Ran `poetry run pytest -q tests/io/test_dca_artifact_contract.py tests/integration/test_dca_robustness_pipeline.py tests/api/test_dca_artifact_endpoints.py` and all tests passed. 
- Test summary: `7 passed` (integration, IO and API assertions for artifact files, metadata fields, endpoint exposure, and percentile/dominance coherence).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c33525c883239bfa9e38da26c249)