### PR TITLE
Strengthen canonical DCA regression coverage for calendar/timezone behavior

### DIFF
--- a/tests/api/test_dca_artifact_endpoints.py
+++ b/tests/api/test_dca_artifact_endpoints.py
@@ -80,3 +80,24 @@ def test_canonical_market_stats_mapping_includes_performance_universe_rules_vers
     )
 
     assert mapped["performance"]["universe_rules_version"] == "asset-universe-rules-v3"
+
+
+def test_canonical_market_stats_mapping_normalizes_timezone_to_utc(api_db):
+    mapped = api_app._canonical_market_stats_to_spec(
+        {
+            "data": {
+                "symbol": "AAPL",
+                "timeframe": "1D",
+                "start_date": "2025-01-06T09:00:00+01:00",
+                "end_date": "2025-01-07T18:00:00+01:00",
+            },
+            "stats": {
+                "event": {"id": "k_consecutive", "params": {"k": 2}},
+                "condition": {"id": "session", "params": {}},
+                "target": {"id": "up_next_bar", "params": {}},
+            },
+        }
+    )
+
+    assert mapped["data"]["start"] == "2025-01-06T08:00:00+00:00"
+    assert mapped["data"]["end"] == "2025-01-07T17:00:00+00:00"

--- a/tests/integration/test_dca_cross_universe_specs.py
+++ b/tests/integration/test_dca_cross_universe_specs.py
@@ -4,6 +4,7 @@ import sys
 import types
 
 import pandas as pd
+import pytest
 
 if "pymysql" not in sys.modules:
     pymysql_mod = types.ModuleType("pymysql")
@@ -35,7 +36,21 @@ def _ohlc() -> pd.DataFrame:
     )
 
 
-def _spec(asset_class: str) -> dict:
+def _spec(
+    asset_class: str,
+    *,
+    start: str = "2024-01-01",
+    timezone: str | None = None,
+    universe_overrides: dict | None = None,
+) -> dict:
+    data_spec: dict = {"timeframe": "1D", "start": start, "end": "2024-02-29"}
+    if timezone is not None:
+        data_spec["timezone"] = timezone
+
+    instrument = {"symbol": "TEST", "asset_class": asset_class}
+    if universe_overrides:
+        instrument["universe"] = dict(universe_overrides)
+
     return {
         "strategy": {
             "strategy_id": f"DCA_{asset_class}",
@@ -48,29 +63,78 @@ def _spec(asset_class: str) -> dict:
                 "require_crossing": False,
             },
         },
-        "data": {"timeframe": "1D", "start": "2024-01-01", "end": "2024-02-29"},
-        "universe": [{"symbol": "TEST", "asset_class": asset_class}],
+        "data": data_spec,
+        "universe": [instrument],
         "performance": {"initial_capital": 10000, "capital_per_unit": 100},
     }
 
 
-def test_cross_universe_adapter_non_regression(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("asset_class", "start", "timezone", "universe_overrides", "expected_calendar", "expected_timezone"),
+    [
+        ("ETF", "2024-01-01", "UTC", None, "xetra_business_days", "UTC"),
+        (
+            "ETF",
+            "2024-01-01",
+            "UTC",
+            {"timezone": "Europe/Paris"},
+            "xetra_business_days",
+            "Europe/Paris",
+        ),
+        ("EQUITY", "2024-01-06", "UTC", None, "nyse_business_days", "UTC"),
+        (
+            "EQUITY",
+            "2024-01-06",
+            "UTC",
+            {"timezone": "Europe/Paris"},
+            "nyse_business_days",
+            "Europe/Paris",
+        ),
+        ("CRYPTO", "2024-01-06", "UTC", None, "24x7", "UTC"),
+        (
+            "CRYPTO",
+            "2024-01-06",
+            "UTC",
+            {"timezone": "Europe/Paris"},
+            "24x7",
+            "Europe/Paris",
+        ),
+    ],
+)
+def test_cross_universe_adapter_non_regression(
+    monkeypatch,
+    asset_class: str,
+    start: str,
+    timezone: str,
+    universe_overrides: dict | None,
+    expected_calendar: str,
+    expected_timezone: str,
+) -> None:
     monkeypatch.delenv("DB_DSN", raising=False)
     captured_data_specs: list[dict] = []
+    captured_contexts: list[dict] = []
 
     def _fake_fetch(symbol: str, asset_class: str, data_spec: dict, instrument: dict) -> pd.DataFrame:
         captured_data_specs.append(dict(data_spec))
         return _ohlc()
 
-    monkeypatch.setattr(strategies_runner, "_fetch_ohlc_for_symbol", _fake_fetch)
+    class _StubStrategy:
+        def backtest(self, df: pd.DataFrame, context: dict) -> list:
+            captured_contexts.append(dict(context))
+            return []
 
-    cases = {
-        "ETF": "xetra_business_days",
-        "EQUITY": "nyse_business_days",
-        "CRYPTO": "24x7",
-    }
-    for asset_class, expected_calendar in cases.items():
-        result = strategies_runner.run_backtest_with_payload(_spec(asset_class))
-        run_extra = result["payload"]["run"].get("extra", {})
-        assert run_extra.get("universe_rules_version") == "asset-universe-rules-v1"
-        assert captured_data_specs[-1]["calendar"] == expected_calendar
+    def _fake_create_strategy(strategy_type: str, strategy_id: str, params: dict) -> _StubStrategy:
+        return _StubStrategy()
+
+    monkeypatch.setattr(strategies_runner, "_fetch_ohlc_for_symbol", _fake_fetch)
+    monkeypatch.setattr(strategies_runner, "create_strategy", _fake_create_strategy)
+
+    result = strategies_runner.run_backtest_with_payload(
+        _spec(asset_class, start=start, timezone=timezone, universe_overrides=universe_overrides)
+    )
+
+    run_extra = result["payload"]["run"].get("extra", {})
+    assert run_extra.get("universe_rules_version") == "asset-universe-rules-v1"
+    assert captured_data_specs[-1]["calendar"] == expected_calendar
+    assert captured_contexts[-1]["universe_rules"]["calendar"] == expected_calendar
+    assert captured_contexts[-1]["universe_rules"]["timezone"] == expected_timezone


### PR DESCRIPTION
### Motivation
- Harden non-regression of calendar/timezone/holiday rules for canonical DCA across multiple universes (ETF/EQUITY/CRYPTO) and ensure the effective calendar and timezone are propagated through the runner and payloads. 
- Guarantee strict coherence of `universe_rules_version` and the effective calendar used for performance outputs and canonical mappings. 

### Description
- Expanded `tests/integration/test_dca_cross_universe_specs.py` into a parameterized 6-case matrix covering ETF/EQUITY/CRYPTO with `UTC` vs `Europe/Paris` timezone variants and configurable `start`/`universe_overrides`. 
- Added capture points and assertions that validate the adapted `data_spec` calendar and the injected `context["universe_rules"]` fields (including `calendar` and `timezone`) and that the resulting payload contains `universe_rules_version == "asset-universe-rules-v1"`. 
- Added `test_canonical_market_stats_mapping_normalizes_timezone_to_utc` to `tests/api/test_dca_artifact_endpoints.py` to assert `_canonical_market_stats_to_spec` converts non-UTC ISO datetimes to UTC in the mapped spec. 
- Adjusted test harness to stub `_fetch_ohlc_for_symbol` and `create_strategy` to isolate universe/calendar/timezone behavior. 

### Testing
- Ran `poetry run pytest -q tests/integration/test_dca_cross_universe_specs.py tests/strategies/test_asset_universe_adapter.py` and the tests passed. 
- Ran `poetry run pytest -q tests/api/test_dca_artifact_endpoints.py` and the tests passed. 
- Ran the combined suite `poetry run pytest -q tests/integration/test_dca_cross_universe_specs.py tests/strategies/test_asset_universe_adapter.py tests/api/test_dca_artifact_endpoints.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c4957b28832398836914809b87ca)