### PR TITLE
PY-DCA-RISK-1: Add versioned return_over_stress_ratio metric

### DIFF
--- a/docs/backtest_metrics.md
+++ b/docs/backtest_metrics.md
@@ -19,9 +19,20 @@ Pour les runs `spec_type=dca`, le moteur expose aussi :
 - `twr` : time-weighted return basé sur les rendements de cycles.
 - `xirr` : rendement annualisé sur cashflows irréguliers (statut séparé `xirr_status` pour non-convergence).
 - `max_drawdown_on_contributed_capital` : drawdown max rapporté au capital contribué au fil de l'eau.
+- `return_over_stress_ratio` : ratio versionné rendement/stress, défini par
+  `final_performance_normalized / max(max_drawdown_on_contributed_capital, epsilon)`.
+  - `version`: `return_over_stress_ratio_v1`
+  - `numerator`: valeur de `final_performance_normalized`
+  - `denominator_raw`: drawdown brut (décimal)
+  - `epsilon`: plancher numérique anti-division-par-zéro (par défaut `1e-9`)
+  - `denominator`: `max(denominator_raw, epsilon)`
+  - `ratio`: `numerator / denominator`
 - `time_under_water` : plus longue durée passée sous le dernier plus haut de la courbe de valeur.
 
 ### Limites connues
 
 - Les cashflows très irréguliers peuvent entraîner des non-convergences `xirr` (`xirr_status=non_convergent`).
 - Certaines séries de cashflows peuvent admettre plusieurs racines IRR; l'algorithme retourne une solution numérique locale si convergence.
+- Quand `max_drawdown_on_contributed_capital` est nul (ou très proche de 0),
+  `return_over_stress_ratio` utilise `epsilon` comme borne inférieure du dénominateur
+  pour garantir un calcul déterministe sans division par zéro.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -1855,6 +1855,12 @@ def _persist_canonical_run_metrics(job_id: str, payload: Any | None, result: Any
         if isinstance(value, (int, float)):
             metrics_map[key] = float(value)
 
+    ros_ratio = extra.get("return_over_stress_ratio") if isinstance(extra.get("return_over_stress_ratio"), dict) else {}
+    for key in ("ratio", "numerator", "denominator", "denominator_raw", "epsilon"):
+        value = ros_ratio.get(key)
+        if isinstance(value, (int, float)):
+            metrics_map[f"return_over_stress_ratio_{key}"] = float(value)
+
     xirr_status = extra.get("xirr_status")
     if isinstance(xirr_status, str):
         metrics_map["xirr_converged"] = 1.0 if xirr_status == "ok" else 0.0

--- a/src/quant_engine/backtest/metrics.py
+++ b/src/quant_engine/backtest/metrics.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Any, Mapping, Sequence, Tuple
 CashflowPoint = Tuple[datetime, float]
 
 DCA_COMPOSITE_SCORE_VERSION = "dca_composite_v1"
+RETURN_OVER_STRESS_RATIO_VERSION = "return_over_stress_ratio_v1"
 DEFAULT_DCA_SCORE_WEIGHTS: Dict[str, float] = {
     "performance": 0.35,
     "irr": 0.25,
@@ -139,6 +140,38 @@ def final_performance_normalized(final_value: float, contributed_capital: float)
     if contributed <= 0:
         return 0.0
     return (float(final_value) - contributed) / contributed
+
+
+def return_over_stress_ratio(
+    final_performance_normalized_value: float,
+    max_drawdown_on_contributed_capital_value: float | None,
+    *,
+    epsilon: float = 1e-9,
+) -> Dict[str, Any]:
+    """Return a versioned rendement/stress ratio for DCA runs.
+
+    Formula:
+    - numerator = ``final_performance_normalized``
+    - denominator = ``max(max_drawdown_on_contributed_capital, epsilon)``
+    - ratio = ``numerator / denominator``
+    """
+
+    numerator = float(final_performance_normalized_value)
+    denominator_raw = (
+        float(max_drawdown_on_contributed_capital_value)
+        if isinstance(max_drawdown_on_contributed_capital_value, (int, float))
+        else 0.0
+    )
+    epsilon_safe = max(float(epsilon), 1e-12)
+    denominator = max(denominator_raw, epsilon_safe)
+    return {
+        "version": RETURN_OVER_STRESS_RATIO_VERSION,
+        "numerator": numerator,
+        "denominator_raw": denominator_raw,
+        "epsilon": epsilon_safe,
+        "denominator": denominator,
+        "ratio": numerator / denominator,
+    }
 
 
 def twr(period_returns: Sequence[float]) -> float:

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -431,6 +431,10 @@ def build_dca_performance_from_signals(
     return_pct_value = ((equity_value - initial_capital) / initial_capital * 100.0) if initial_capital else None
 
     final_perf_norm = backtest_metrics.final_performance_normalized(equity_value, contributed_capital)
+    return_over_stress = backtest_metrics.return_over_stress_ratio(
+        final_perf_norm,
+        (max_drawdown_pct_value / 100.0) if isinstance(max_drawdown_pct_value, (int, float)) else None,
+    )
     twr_value = backtest_metrics.twr([t.gross_pnl_pct / 100.0 for t in sorted_trades])
     xirr_value, xirr_status = backtest_metrics.xirr(cashflows) if cashflows else (None, "invalid_cashflows")
     time_under_water_periods = backtest_metrics.time_under_water(equity_values)
@@ -530,6 +534,7 @@ def build_dca_performance_from_signals(
             "xirr": xirr_value,
             "xirr_status": xirr_status,
             "max_drawdown_on_contributed_capital": max_drawdown_pct_value,
+            "return_over_stress_ratio": return_over_stress,
             "time_under_water": time_under_water_periods,
             "contributed_capital": contributed_capital,
             "rolling_windows": rolling_analytics,

--- a/tests/api/test_runs_metrics_dca.py
+++ b/tests/api/test_runs_metrics_dca.py
@@ -57,6 +57,14 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
                         "xirr": 0.08,
                         "xirr_status": "ok",
                         "max_drawdown_on_contributed_capital": 15.0,
+                        "return_over_stress_ratio": {
+                            "version": "return_over_stress_ratio_v1",
+                            "numerator": 0.12,
+                            "denominator_raw": 0.15,
+                            "epsilon": 1e-9,
+                            "denominator": 0.15,
+                            "ratio": 0.8,
+                        },
                         "time_under_water": 3,
                         "dca_composite_score": {
                             "score": 0.66,
@@ -84,6 +92,11 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
     assert aggregated["twr"] == 0.10
     assert aggregated["xirr"] == 0.08
     assert aggregated["max_drawdown_on_contributed_capital"] == 15.0
+    assert aggregated["return_over_stress_ratio_ratio"] == 0.8
+    assert aggregated["return_over_stress_ratio_numerator"] == 0.12
+    assert aggregated["return_over_stress_ratio_denominator"] == 0.15
+    assert aggregated["return_over_stress_ratio_denominator_raw"] == 0.15
+    assert aggregated["return_over_stress_ratio_epsilon"] == 1e-9
     assert aggregated["time_under_water"] == 3.0
     assert aggregated["xirr_converged"] == 1.0
     assert aggregated["dca_score"] == 0.66

--- a/tests/backtest/test_dca_metrics.py
+++ b/tests/backtest/test_dca_metrics.py
@@ -37,3 +37,18 @@ def test_drawdown_and_time_under_water_on_contributed_capital() -> None:
     contributed = [100.0, 120.0, 120.0, 140.0, 140.0]
     assert metrics.max_drawdown_on_contributed_capital(equity, contributed) == pytest.approx(0.25)
     assert metrics.time_under_water(equity) == 2
+
+
+def test_return_over_stress_ratio_uses_drawdown_denominator() -> None:
+    ratio = metrics.return_over_stress_ratio(0.3, 0.15)
+    assert ratio["version"] == "return_over_stress_ratio_v1"
+    assert ratio["numerator"] == pytest.approx(0.3)
+    assert ratio["denominator_raw"] == pytest.approx(0.15)
+    assert ratio["denominator"] == pytest.approx(0.15)
+    assert ratio["ratio"] == pytest.approx(2.0)
+
+
+def test_return_over_stress_ratio_uses_epsilon_for_near_zero_drawdown() -> None:
+    ratio = metrics.return_over_stress_ratio(0.1, 0.0, epsilon=1e-6)
+    assert ratio["denominator"] == pytest.approx(1e-6)
+    assert ratio["ratio"] == pytest.approx(100000.0)


### PR DESCRIPTION
### Motivation

- Provide an explicit DCA risk/return ratio to complement existing DCA metrics and make risk-adjusted comparisons deterministic. 
- Ensure the ratio is safe from division-by-zero and well-defined when drawdown is zero or near-zero.

### Description

- Add a versioned metric `return_over_stress_ratio` in `src/quant_engine/backtest/metrics.py` that returns numerator, raw denominator, an `epsilon` floor, the effective denominator, and the computed ratio according to `numerator / max(denominator_raw, epsilon)`.
- Compute and attach the metric in the DCA pipeline in `src/quant_engine/performance/dca_builder.py` and emit it inside `run.extra` as `return_over_stress_ratio`.
- Persist numeric fields from the payload into canonical run metrics in `src/quant_engine/api/app.py` as `return_over_stress_ratio_{ratio,numerator,denominator,denominator_raw,epsilon}` so they are available through the existing metrics endpoints.
- Add unit and integration coverage and documentation updates: tests in `tests/backtest/test_dca_metrics.py` and `tests/api/test_runs_metrics_dca.py`, and docs updated in `docs/backtest_metrics.md` describing the formula, fields, and epsilon behavior.

### Testing

- Added unit tests `test_return_over_stress_ratio_uses_drawdown_denominator` and `test_return_over_stress_ratio_uses_epsilon_for_near_zero_drawdown` in `tests/backtest/test_dca_metrics.py` which assert formula correctness and epsilon fallback behavior.
- Added integration test assertions in `tests/api/test_runs_metrics_dca.py` to verify the persisted `return_over_stress_ratio_*` fields are exposed by the run metrics endpoint.
- Ran `poetry run pytest -q tests/backtest/test_dca_metrics.py tests/api/test_runs_metrics_dca.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70752b2288323b0531fd3fbec2cf8)