### PR TITLE
PY-DCA-RISK-2: Add capital_efficiency_index for DCA runs

### DIFF
--- a/docs/backtest_metrics.md
+++ b/docs/backtest_metrics.md
@@ -16,6 +16,10 @@ Si le timeframe est fourni, l'annualisation utilise un nombre de périodes par a
 Pour les runs `spec_type=dca`, le moteur expose aussi :
 
 - `final_performance_normalized` : performance finale normalisée par le capital réellement contribué.
+- `capital_efficiency_index` : indice d'efficacité du capital immobilisé, défini (v1) par
+  `final_value / max_contributed_capital`.
+  - quand `max_contributed_capital <= 0`, la métrique retourne `0.0`.
+  - variante future possible: utiliser le capital moyen immobilisé (au lieu du maximum).
 - `twr` : time-weighted return basé sur les rendements de cycles.
 - `xirr` : rendement annualisé sur cashflows irréguliers (statut séparé `xirr_status` pour non-convergence).
 - `max_drawdown_on_contributed_capital` : drawdown max rapporté au capital contribué au fil de l'eau.
@@ -36,3 +40,5 @@ Pour les runs `spec_type=dca`, le moteur expose aussi :
 - Quand `max_drawdown_on_contributed_capital` est nul (ou très proche de 0),
   `return_over_stress_ratio` utilise `epsilon` comme borne inférieure du dénominateur
   pour garantir un calcul déterministe sans division par zéro.
+
+- `capital_efficiency_index` dépend fortement de l'horizon étudié et de la fréquence des contributions (plus elles sont denses, plus le maximum de capital immobilisé peut augmenter).

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -1846,6 +1846,7 @@ def _persist_canonical_run_metrics(job_id: str, payload: Any | None, result: Any
     metrics_map: Dict[str, float] = {}
     for key in (
         "final_performance_normalized",
+        "capital_efficiency_index",
         "twr",
         "xirr",
         "max_drawdown_on_contributed_capital",

--- a/src/quant_engine/backtest/metrics.py
+++ b/src/quant_engine/backtest/metrics.py
@@ -142,6 +142,35 @@ def final_performance_normalized(final_value: float, contributed_capital: float)
     return (float(final_value) - contributed) / contributed
 
 
+def capital_efficiency_index(final_value: float, contributed_capital_series: Sequence[float] | None) -> float:
+    """Return DCA capital efficiency index (CEI).
+
+    v1 formula: ``CEI = final_value / max_contributed_capital`` where
+    ``max_contributed_capital`` is the maximum observed contributed capital.
+
+    Returns ``0.0`` when the contributed series is empty or when
+    ``max_contributed_capital <= 0``.
+
+    Note: a possible future variant can use average immobilized capital instead
+    of the maximum contributed capital.
+    """
+
+    if not contributed_capital_series:
+        return 0.0
+    numeric_values: List[float] = []
+    for value in contributed_capital_series:
+        try:
+            numeric_values.append(float(value))
+        except Exception:
+            continue
+    if not numeric_values:
+        return 0.0
+    max_contributed_capital = max(numeric_values)
+    if max_contributed_capital <= 0:
+        return 0.0
+    return float(final_value) / max_contributed_capital
+
+
 def return_over_stress_ratio(
     final_performance_normalized_value: float,
     max_drawdown_on_contributed_capital_value: float | None,

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -431,6 +431,7 @@ def build_dca_performance_from_signals(
     return_pct_value = ((equity_value - initial_capital) / initial_capital * 100.0) if initial_capital else None
 
     final_perf_norm = backtest_metrics.final_performance_normalized(equity_value, contributed_capital)
+    capital_efficiency_index = backtest_metrics.capital_efficiency_index(equity_value, contributed_values)
     return_over_stress = backtest_metrics.return_over_stress_ratio(
         final_perf_norm,
         (max_drawdown_pct_value / 100.0) if isinstance(max_drawdown_pct_value, (int, float)) else None,
@@ -530,6 +531,7 @@ def build_dca_performance_from_signals(
             "metrics_version": "dca-grid-process-v1",
             "universe_rules_version": universe_rules_version,
             "final_performance_normalized": final_perf_norm,
+            "capital_efficiency_index": capital_efficiency_index,
             "twr": twr_value,
             "xirr": xirr_value,
             "xirr_status": xirr_status,

--- a/tests/api/test_runs_metrics_dca.py
+++ b/tests/api/test_runs_metrics_dca.py
@@ -53,6 +53,7 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
                     "status": "ok",
                     "extra": {
                         "final_performance_normalized": 0.12,
+                        "capital_efficiency_index": 1.2,
                         "twr": 0.10,
                         "xirr": 0.08,
                         "xirr_status": "ok",
@@ -89,6 +90,7 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
     payload = api_app.run_metrics_endpoint(response.run_id)
     aggregated = payload["aggregated"]
     assert aggregated["final_performance_normalized"] == 0.12
+    assert aggregated["capital_efficiency_index"] == 1.2
     assert aggregated["twr"] == 0.10
     assert aggregated["xirr"] == 0.08
     assert aggregated["max_drawdown_on_contributed_capital"] == 15.0

--- a/tests/backtest/test_dca_metrics.py
+++ b/tests/backtest/test_dca_metrics.py
@@ -52,3 +52,18 @@ def test_return_over_stress_ratio_uses_epsilon_for_near_zero_drawdown() -> None:
     ratio = metrics.return_over_stress_ratio(0.1, 0.0, epsilon=1e-6)
     assert ratio["denominator"] == pytest.approx(1e-6)
     assert ratio["ratio"] == pytest.approx(100000.0)
+
+
+def test_capital_efficiency_index_nominal() -> None:
+    cei = metrics.capital_efficiency_index(1300.0, [100.0, 400.0, 1000.0])
+    assert cei == pytest.approx(1.3)
+
+
+def test_capital_efficiency_index_zero_or_negative_max_contributed_capital() -> None:
+    assert metrics.capital_efficiency_index(1000.0, []) == pytest.approx(0.0)
+    assert metrics.capital_efficiency_index(1000.0, [0.0, -10.0]) == pytest.approx(0.0)
+
+
+def test_capital_efficiency_index_short_series() -> None:
+    cei = metrics.capital_efficiency_index(950.0, [1000.0])
+    assert cei == pytest.approx(0.95)


### PR DESCRIPTION
### Motivation
- Provide an explicit metric to quantify how efficiently capital is immobilized during DCA runs (CEI) so strategies can be compared on capital usage. 
- Define a simple, safe v1 formula to make the metric deterministic and robust for short/irregular cashflow series. 
- Surface CEI end-to-end (backend, persisted metrics, API) so it is available to consumers and dashboards.

### Description
- Added `capital_efficiency_index(final_value, contributed_capital_series)` in `src/quant_engine/backtest/metrics.py` implementing v1: `CEI = final_value / max_contributed_capital` and returning `0.0` when the contributed series is empty/non-numeric or when `max_contributed_capital <= 0` (note in docstring about a possible future average-capital variant). 
- Wired CEI computation into the DCA aggregation in `src/quant_engine/performance/dca_builder.py` so it is computed from `contributed_values` and included in `run.extra`. 
- Exposed CEI in the canonical DCA metrics persistence path in `src/quant_engine/api/app.py` so aggregated `/runs/{run_id}/metrics` contains `capital_efficiency_index`. 
- Added unit/API tests and documentation updates: new tests in `tests/backtest/test_dca_metrics.py` (nominal, zero/negative max, short series), updated `tests/api/test_runs_metrics_dca.py` to assert CEI propagation, and documentation updated in `docs/backtest_metrics.md` describing CEI and interpretation caveats.

### Testing
- Ran `poetry run pytest -q tests/backtest/test_dca_metrics.py tests/api/test_runs_metrics_dca.py` and all tests passed. 
- Result: `11 passed` (both backtest unit tests and the API run-metrics test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70c7453448323a0eb7a762a5ffee4)