### PR TITLE
PY-DCA-DATA-1: Persist risk-adjusted DCA metrics for Java API consumption

### DIFF
--- a/docs/dca_grid_implementation_process.md
+++ b/docs/dca_grid_implementation_process.md
@@ -140,6 +140,18 @@ Pour exécuter proprement, il faut découpler en deux streams :
 - **PY-6.3** Exports synthèse par période testée.
 - **PY-6.4** Pipeline reproductible (config + seed + hash dataset).
 
+### Contrat de données DCA inter-repo (MySQL -> API Spring -> Angular)
+
+- **Canal principal**: payload Python `run.extra` persisté en SQL (`run_metrics`) puis exposé par API Java/Spring.
+- **Canal secondaire**: artefacts JSON/Parquet conservés pour debug/audit uniquement.
+- **Champs risque-ajustés obligatoires**:
+  - `capital_efficiency_index`
+  - `return_over_stress_ratio` (`version`, `ratio`, `numerator`, `denominator`, `denominator_raw`, `epsilon`)
+- **Versionnement contrat**:
+  - `metrics_version`: `dca-grid-process-v1` (compat historique maintenue)
+  - `data_contract_version`: `dca-java-import-v2` (extension non cassante)
+- **Compatibilité**: les consommateurs existants continuent de lire `metrics_version` et les métriques déjà disponibles; les nouveaux champs sont additifs.
+
 ### DoD
 
 - Contrat de données documenté et stable.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -33,7 +33,7 @@ from ..optimize.runner import run as run_optimisation
 from ..optimize import variants as optimize_variants
 from ..io import ids
 from ..io.dca_artifacts import SCHEMA_VERSION
-from ..persistence import db, RunsRepository, MetricsRepository, TrialsRepository
+from ..persistence import db, RunsRepository, MetricsRepository, TrialsRepository, extract_dca_run_metrics
 from ..stats import runner as stats_runner
 from ..stats import conditions as stats_conditions
 from ..stats.estimators import freq_with_wilson
@@ -1843,43 +1843,7 @@ def _persist_canonical_run_metrics(job_id: str, payload: Any | None, result: Any
     run = run_payload.get("run") if isinstance(run_payload.get("run"), dict) else {}
     extra = run.get("extra") if isinstance(run.get("extra"), dict) else {}
 
-    metrics_map: Dict[str, float] = {}
-    for key in (
-        "final_performance_normalized",
-        "capital_efficiency_index",
-        "twr",
-        "xirr",
-        "max_drawdown_on_contributed_capital",
-        "time_under_water",
-    ):
-        value = extra.get(key)
-        if isinstance(value, (int, float)):
-            metrics_map[key] = float(value)
-
-    ros_ratio = extra.get("return_over_stress_ratio") if isinstance(extra.get("return_over_stress_ratio"), dict) else {}
-    for key in ("ratio", "numerator", "denominator", "denominator_raw", "epsilon"):
-        value = ros_ratio.get(key)
-        if isinstance(value, (int, float)):
-            metrics_map[f"return_over_stress_ratio_{key}"] = float(value)
-
-    xirr_status = extra.get("xirr_status")
-    if isinstance(xirr_status, str):
-        metrics_map["xirr_converged"] = 1.0 if xirr_status == "ok" else 0.0
-
-    composite = extra.get("dca_composite_score") if isinstance(extra.get("dca_composite_score"), dict) else {}
-    score_value = composite.get("score")
-    if isinstance(score_value, (int, float)):
-        metrics_map["dca_score"] = float(score_value)
-    edge_value = composite.get("edge")
-    if isinstance(edge_value, str):
-        edge = edge_value.strip().lower()
-        edge_map = {"weak": 1.0, "medium": 2.0, "strong": 3.0}
-        if edge in edge_map:
-            metrics_map["dca_edge_level"] = edge_map[edge]
-    components = composite.get("components") if isinstance(composite.get("components"), dict) else {}
-    for name, value in components.items():
-        if isinstance(value, (int, float)):
-            metrics_map[f"dca_score_component_{name}"] = float(value)
+    metrics_map = extract_dca_run_metrics(extra)
 
     if not metrics_map:
         return

--- a/src/quant_engine/integrations/java_client.py
+++ b/src/quant_engine/integrations/java_client.py
@@ -120,6 +120,14 @@ def request_historical_ingestion(
     return request_json("POST", url, json=payload, session=session, timeout=DEFAULT_TIMEOUT)
 
 
+def import_strategy_result(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Forward a precomputed Python strategy payload to Java import API."""
+
+    url = BASE_URL + "/api/strategy-results/import"
+    session = get_shared_session()
+    return request_json("POST", url, json=payload, session=session, timeout=DEFAULT_TIMEOUT)
+
+
 def get_positions() -> List[Dict[str, Any]]:
     """Return live positions if the Java backend exposes them."""
 
@@ -140,5 +148,6 @@ __all__ = [
     "get_ohlc",
     "request_historical_ingestion",
     "get_positions",
+    "import_strategy_result",
     "BASE_URL",
 ]

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -529,6 +529,7 @@ def build_dca_performance_from_signals(
             "capital_per_unit": capital_per_unit,
             "note": "DCA performance computed from pct PnL with cashflow-aware metrics.",
             "metrics_version": "dca-grid-process-v1",
+            "data_contract_version": "dca-java-import-v2",
             "universe_rules_version": universe_rules_version,
             "final_performance_normalized": final_perf_norm,
             "capital_efficiency_index": capital_efficiency_index,

--- a/src/quant_engine/persistence/__init__.py
+++ b/src/quant_engine/persistence/__init__.py
@@ -1,7 +1,7 @@
 """Persistence layer for experiment runs and trials."""
 
 from .db import connect, init_db, session
-from .repositories import RunsRepository, MetricsRepository, TrialsRepository
+from .repositories import RunsRepository, MetricsRepository, TrialsRepository, extract_dca_run_metrics
 from .repo import (
     MarketStatsRepository,
     SeasonalityProfilesRepository,
@@ -15,6 +15,7 @@ __all__ = [
     "RunsRepository",
     "MetricsRepository",
     "TrialsRepository",
+    "extract_dca_run_metrics",
     "MarketStatsRepository",
     "SeasonalityProfilesRepository",
     "SeasonalityRunsRepository",

--- a/src/quant_engine/persistence/repositories.py
+++ b/src/quant_engine/persistence/repositories.py
@@ -1,11 +1,59 @@
-"""Repository helpers for the SQLite persistence layer."""
+"""Repository helpers for the SQLite/MySQL persistence layer."""
 
 from __future__ import annotations
 
 import json
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Mapping
 
 import sqlite3
+
+
+def extract_dca_run_metrics(extra: Mapping[str, Any]) -> Dict[str, float]:
+    """Flatten DCA run ``extra`` payload to SQL metric rows.
+
+    Keeps the contract stable for API consumers by persisting precomputed
+    Python metrics directly (no recomputation in downstream services).
+    """
+
+    metrics_map: Dict[str, float] = {}
+    for key in (
+        "final_performance_normalized",
+        "capital_efficiency_index",
+        "twr",
+        "xirr",
+        "max_drawdown_on_contributed_capital",
+        "time_under_water",
+    ):
+        value = extra.get(key)
+        if isinstance(value, (int, float)):
+            metrics_map[key] = float(value)
+
+    ros_ratio = extra.get("return_over_stress_ratio") if isinstance(extra.get("return_over_stress_ratio"), dict) else {}
+    for key in ("ratio", "numerator", "denominator", "denominator_raw", "epsilon"):
+        value = ros_ratio.get(key)
+        if isinstance(value, (int, float)):
+            metrics_map[f"return_over_stress_ratio_{key}"] = float(value)
+
+    xirr_status = extra.get("xirr_status")
+    if isinstance(xirr_status, str):
+        metrics_map["xirr_converged"] = 1.0 if xirr_status == "ok" else 0.0
+
+    composite = extra.get("dca_composite_score") if isinstance(extra.get("dca_composite_score"), dict) else {}
+    score_value = composite.get("score")
+    if isinstance(score_value, (int, float)):
+        metrics_map["dca_score"] = float(score_value)
+    edge_value = composite.get("edge")
+    if isinstance(edge_value, str):
+        edge = edge_value.strip().lower()
+        edge_map = {"weak": 1.0, "medium": 2.0, "strong": 3.0}
+        if edge in edge_map:
+            metrics_map["dca_edge_level"] = edge_map[edge]
+    components = composite.get("components") if isinstance(composite.get("components"), dict) else {}
+    for name, value in components.items():
+        if isinstance(value, (int, float)):
+            metrics_map[f"dca_score_component_{name}"] = float(value)
+
+    return metrics_map
 
 
 class RunsRepository:
@@ -122,5 +170,5 @@ __all__ = [
     "RunsRepository",
     "MetricsRepository",
     "TrialsRepository",
+    "extract_dca_run_metrics",
 ]
-

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -22,6 +22,7 @@ from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
 from ..performance.dca_builder import build_backend_payload_for_java
 from ..datafeeds.asset_universe_adapter import resolve_asset_universe_adapter
+from ..persistence.repositories import extract_dca_run_metrics
 from pandas.tseries.holiday import USFederalHolidayCalendar
 from pandas.tseries.offsets import CustomBusinessDay
 try:
@@ -1276,6 +1277,21 @@ def persist_payload_to_db(
         perf_row = _filter_row_for_table(engine, "performance", perf_row)
         pd.DataFrame([perf_row]).to_sql("performance", engine, if_exists="append", index=False)
         LOGGER.info("Persisted performance row for run %s to DB", run_id)
+
+        extra = run.get("extra", {}) if isinstance(run.get("extra"), Mapping) else {}
+        dca_metrics = extract_dca_run_metrics(extra) if strategy_type.startswith("dca") else {}
+        if dca_metrics:
+            metric_rows = [
+                {"run_id": run_id, "fold": None, "metric_name": name, "metric_value": value}
+                for name, value in dca_metrics.items()
+            ]
+            filtered_metric_rows = [_filter_row_for_table(engine, "run_metrics", row) for row in metric_rows]
+            metric_df = pd.DataFrame(filtered_metric_rows)
+            if not metric_df.empty:
+                with engine.begin() as conn:
+                    conn.execute(text("DELETE FROM run_metrics WHERE run_id = :run_id AND fold IS NULL"), {"run_id": run_id})
+                metric_df.to_sql("run_metrics", engine, if_exists="append", index=False)
+                LOGGER.info("Persisted %d DCA run metrics for run %s", len(filtered_metric_rows), run_id)
     except Exception as exc:
         LOGGER.warning("Failed to persist performance for run %s: %s", run_id, exc)
 

--- a/tests/api/test_runs_metrics_dca.py
+++ b/tests/api/test_runs_metrics_dca.py
@@ -53,6 +53,7 @@ def test_runs_metrics_endpoint_exposes_dca_metrics(tmp_path, monkeypatch) -> Non
                     "status": "ok",
                     "extra": {
                         "final_performance_normalized": 0.12,
+                        "data_contract_version": "dca-java-import-v2",
                         "capital_efficiency_index": 1.2,
                         "twr": 0.10,
                         "xirr": 0.08,

--- a/tests/test_performance_dca_builder.py
+++ b/tests/test_performance_dca_builder.py
@@ -102,6 +102,9 @@ def test_build_dca_performance_from_signals_handles_cycles_and_metrics() -> None
     assert isinstance(dca_score, dict)
     assert 0.0 <= dca_score["score"] <= 1.0
     assert dca_score["edge"] in {"weak", "medium", "strong"}
+    assert run.extra["capital_efficiency_index"] is not None
+    assert run.extra["return_over_stress_ratio"]["version"] == "return_over_stress_ratio_v1"
+    assert run.extra["data_contract_version"] == "dca-java-import-v2"
 
 
 def test_build_dca_performance_multiple_buys_and_tp_metrics() -> None:
@@ -206,6 +209,9 @@ def test_build_backend_payload_for_java_structure_and_meta() -> None:
         "totalReturn",
     ):
         assert key in run
+    assert run["extra"]["capital_efficiency_index"] is not None
+    assert run["extra"]["return_over_stress_ratio"]["version"] == "return_over_stress_ratio_v1"
+    assert run["extra"]["data_contract_version"] == "dca-java-import-v2"
     for key in (
         "strategyId",
         "runId",

--- a/tests/test_persistence_db.py
+++ b/tests/test_persistence_db.py
@@ -1,9 +1,21 @@
 import sqlite3
+import sys
+import types
 
 import pytest
 
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_stub.connect = lambda *args, **kwargs: None
+    cursors_stub = types.ModuleType("pymysql.cursors")
+    cursors_stub.DictCursor = object
+    pymysql_stub.cursors = cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = cursors_stub
+
 from quant_engine.config import reset_settings_cache
 from quant_engine.persistence import db
+from quant_engine.persistence.repositories import extract_dca_run_metrics
 
 
 def test_init_db_creates_tables(monkeypatch):
@@ -48,8 +60,52 @@ def test_run_id_unique_constraint(monkeypatch):
         conn.close()
 
 
-def test_non_sqlite_dsn_raises(monkeypatch):
+def test_mysql_dsn_uses_mysql_connector(monkeypatch):
+    class _FakeCursor:
+        def execute(self, *_args, **_kwargs):
+            return None
+
+    class _FakeConn:
+        def cursor(self):
+            return _FakeCursor()
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+        def close(self):
+            return None
+
     monkeypatch.setenv("DB_DSN", "mysql://localhost/db")
     reset_settings_cache()
-    with pytest.raises(RuntimeError, match="Only sqlite DSNs are supported"):
-        db.connect()
+    monkeypatch.setattr(db.pymysql, "connect", lambda **_kwargs: _FakeConn())
+    conn = db.connect()
+    try:
+        assert conn.dialect == "mysql"
+    finally:
+        conn.close()
+
+
+def test_extract_dca_run_metrics_flattens_ratio_and_efficiency() -> None:
+    extra = {
+        "capital_efficiency_index": 1.2,
+        "return_over_stress_ratio": {
+            "version": "return_over_stress_ratio_v1",
+            "ratio": 0.8,
+            "numerator": 0.12,
+            "denominator": 0.15,
+            "denominator_raw": 0.15,
+            "epsilon": 1e-9,
+        },
+        "xirr_status": "ok",
+    }
+    metrics = extract_dca_run_metrics(extra)
+    assert metrics["capital_efficiency_index"] == 1.2
+    assert metrics["return_over_stress_ratio_ratio"] == 0.8
+    assert metrics["return_over_stress_ratio_numerator"] == 0.12
+    assert metrics["return_over_stress_ratio_denominator"] == 0.15
+    assert metrics["return_over_stress_ratio_denominator_raw"] == 0.15
+    assert metrics["return_over_stress_ratio_epsilon"] == 1e-9
+    assert metrics["xirr_converged"] == 1.0


### PR DESCRIPTION
### Motivation
- Align Python DCA payloads with the real downstream flow (MySQL -> Spring/Java API -> Angular) by persisting Python-computed risk-adjusted metrics so Java/Angular consume precomputed values and do not recalculate them.
- Surface two required risk-adjusted fields (`capital_efficiency_index`, `return_over_stress_ratio`) and related components in the SQL contract so they are directly queryable by the backend and UI.
- Maintain backward compatibility and keep JSON/Parquet artefacts as secondary debug/audit channels rather than the primary UI ingestion path.

### Description
- Added a shared flattener `extract_dca_run_metrics` in `src/quant_engine/persistence/repositories.py` to convert `run.extra` into SQL-metric name/value pairs (including `capital_efficiency_index` and `return_over_stress_ratio_*`).
- Reused the flattener in the API canonical persistence `_persist_canonical_run_metrics` to upsert DCA metrics into `run_metrics` via `MetricsRepository.bulk_upsert_metrics` (no recomputation in Java). 
- Extended `persist_payload_to_db` in `src/quant_engine/strategies/runner.py` to write DCA aggregated metrics into `run_metrics` (purging previous fold=NULL metrics for the run before inserting) so the MySQL table is the authoritative channel for Java/Angular.
- Bumped the DCA payload contract with `data_contract_version: dca-java-import-v2` while keeping `metrics_version: dca-grid-process-v1`, added `import_strategy_result` client helper in `src/quant_engine/integrations/java_client.py`, and updated docs `docs/dca_grid_implementation_process.md` to describe the inter-repo contract.
- Updated and added unit tests to assert presence and flattening of the new fields in payloads and DB helpers (`tests/test_performance_dca_builder.py`, `tests/test_persistence_db.py`, `tests/api/test_runs_metrics_dca.py`).

### Testing
- Ran the focused test suite with `poetry run pytest -q tests/test_performance_dca_builder.py tests/test_persistence_db.py tests/api/test_runs_metrics_dca.py` and all tests passed (`11 passed`).
- The new persistence helper `extract_dca_run_metrics` has dedicated assertions in `tests/test_persistence_db.py` to validate flattening of `return_over_stress_ratio` and `capital_efficiency_index`.
- Integration points exercised by tests confirm metrics are present in the backend payload (`run.extra`) and exposed through the run metrics endpoint aggregated view.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a712f6dec883239abf5755fb29cbca)