### PR TITLE
EPIC-1: Add immutable core domain models and unit tests

### DIFF
--- a/src/quant_engine/core/domain/__init__.py
+++ b/src/quant_engine/core/domain/__init__.py
@@ -1,0 +1,3 @@
+from quant_engine.core.domain.models import Candle, Portfolio, Position, Trade
+
+__all__ = ["Candle", "Trade", "Position", "Portfolio"]

--- a/src/quant_engine/core/domain/models.py
+++ b/src/quant_engine/core/domain/models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class Candle:
+    timestamp: datetime
+    symbol: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "symbol": self.symbol,
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+        }
+
+
+@dataclass(frozen=True)
+class Trade:
+    trade_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    timestamp: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "trade_id": self.trade_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "quantity": self.quantity,
+            "price": self.price,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    quantity: float
+    average_price: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "quantity": self.quantity,
+            "average_price": self.average_price,
+        }
+
+
+@dataclass(frozen=True)
+class Portfolio:
+    cash: float
+    equity: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "cash": self.cash,
+            "equity": self.equity,
+        }

--- a/tests/core/test_domain_models.py
+++ b/tests/core/test_domain_models.py
@@ -1,0 +1,46 @@
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+
+import pytest
+
+from quant_engine.core.domain import Candle, Portfolio, Position, Trade
+
+
+def test_domain_models_creation() -> None:
+    ts = datetime(2024, 1, 1, 12, 0)
+
+    candle = Candle(ts, "BTC-USD", 100.0, 110.0, 95.0, 105.0, 1000.0)
+    trade = Trade("t-1", "BTC-USD", "buy", 2.0, 101.0, ts)
+    position = Position("BTC-USD", 2.0, 101.0)
+    portfolio = Portfolio(5000.0, 5200.0)
+
+    assert candle.symbol == "BTC-USD"
+    assert trade.side == "buy"
+    assert position.average_price == 101.0
+    assert portfolio.equity == 5200.0
+
+
+def test_domain_models_are_immutable() -> None:
+    candle = Candle(datetime(2024, 1, 1), "BTC-USD", 1.0, 2.0, 0.5, 1.5, 10.0)
+
+    with pytest.raises(FrozenInstanceError):
+        candle.close = 2.5  # type: ignore[misc]
+
+
+def test_domain_models_require_mandatory_fields() -> None:
+    with pytest.raises(TypeError):
+        Candle(datetime(2024, 1, 1), "BTC-USD", 1.0, 2.0, 0.5, 1.5)  # type: ignore[call-arg]
+
+    with pytest.raises(TypeError):
+        Trade("t-1", "BTC-USD", "buy", 1.0, 100.0)  # type: ignore[call-arg]
+
+
+def test_domain_models_equality() -> None:
+    ts = datetime(2024, 1, 1)
+    left = Position("BTC-USD", 2.0, 100.0)
+    right = Position("BTC-USD", 2.0, 100.0)
+    portfolio = Portfolio(1000.0, 1200.0)
+
+    assert left == right
+    assert left != Position("ETH-USD", 2.0, 100.0)
+    assert portfolio == Portfolio(1000.0, 1200.0)


### PR DESCRIPTION
### Motivation
- Introduce a small, well-typed domain model layer for core entities used across the engine and ensure they are immutable by default.
- Provide a minimal import surface so these models can be referenced as `quant_engine.core.domain.*` from other modules.

### Description
- Added `src/quant_engine/core/domain/models.py` implementing four frozen dataclasses: `Candle`, `Trade`, `Position`, and `Portfolio`, each with explicit type annotations and a lightweight `to_dict()` helper.
- Added `src/quant_engine/core/domain/__init__.py` to re-export the four models and define the module's `__all__`.
- Added unit tests in `tests/core/test_domain_models.py` validating object creation, immutability, required-field behavior, and equality semantics.

### Testing
- Ran `poetry run pytest -q tests/core/test_domain_models.py` and all tests completed successfully.
- Test suite result: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a843798f988323aab19565e8609abb)