### PR TITLE
Formalize core Protocol contracts for market intelligence, feature store, and strategy

### DIFF
--- a/src/quant_engine/core/contracts/__init__.py
+++ b/src/quant_engine/core/contracts/__init__.py
@@ -1,0 +1,7 @@
+"""Core protocol contracts used across quant_engine services."""
+
+from quant_engine.core.contracts.feature_store import FeatureStore
+from quant_engine.core.contracts.market_intelligence import MarketIntelligenceService
+from quant_engine.core.contracts.strategy import StrategyContract
+
+__all__ = ["MarketIntelligenceService", "FeatureStore", "StrategyContract"]

--- a/src/quant_engine/core/contracts/feature_store.py
+++ b/src/quant_engine/core/contracts/feature_store.py
@@ -1,0 +1,28 @@
+"""Contract for feature-store components used to cache and retrieve engineered features."""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class FeatureStore(Protocol):
+    """Store and retrieve computed feature vectors.
+
+    Inputs:
+        name: Feature name (e.g. ``"ema_20"``).
+        dataset: Source rows used to compute feature values.
+        params: Deterministic feature parameters.
+        compute_fn: Callable used when values are not already available.
+
+    Output:
+        Ordered sequence of numeric feature values aligned with ``dataset``.
+    """
+
+    def get_or_compute(
+        self,
+        name: str,
+        dataset: Sequence[Mapping[str, Any]],
+        params: Mapping[str, Any],
+        compute_fn: Callable[[Sequence[Mapping[str, Any]], Mapping[str, Any]], Sequence[float]],
+    ) -> Sequence[float]:
+        """Return cached values or compute and persist them."""

--- a/src/quant_engine/core/contracts/market_intelligence.py
+++ b/src/quant_engine/core/contracts/market_intelligence.py
@@ -1,0 +1,27 @@
+"""Contract for market-intelligence adapters used by strategies and screening flows."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    DataFrame = pd.DataFrame
+else:
+    DataFrame = Any
+
+
+@runtime_checkable
+class MarketIntelligenceService(Protocol):
+    """Provide a normalized market snapshot from OHLCV data.
+
+    Inputs:
+        symbol: Canonical instrument identifier (e.g. ``"BTC-USD"``).
+        ohlcv: Time-indexed OHLCV dataframe sorted in ascending timestamp order.
+
+    Output:
+        A mapping with analytics ready to consume by strategies, filters, or risk checks.
+    """
+
+    def build_snapshot(self, symbol: str, ohlcv: DataFrame) -> Mapping[str, Any]:
+        """Compute and return a market-intelligence snapshot for ``symbol``."""

--- a/src/quant_engine/core/contracts/strategy.py
+++ b/src/quant_engine/core/contracts/strategy.py
@@ -1,0 +1,27 @@
+"""Contract for executable strategy implementations."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence, runtime_checkable
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    DataFrame = pd.DataFrame
+else:
+    DataFrame = Any
+
+
+@runtime_checkable
+class StrategyContract(Protocol):
+    """Generate strategy decisions from historical bars and execution context.
+
+    Inputs:
+        ohlcv: Historical bars including the latest closed bar, sorted by timestamp.
+        context: Runtime metadata such as open positions, risk limits, and config overrides.
+
+    Output:
+        Sequence of signal payloads ready for execution/backtest layers.
+    """
+
+    def evaluate(self, ohlcv: DataFrame, context: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+        """Produce zero or more normalized signals for the current evaluation call."""

--- a/tests/core/test_contracts_imports.py
+++ b/tests/core/test_contracts_imports.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from quant_engine.core.contracts import FeatureStore, MarketIntelligenceService, StrategyContract
+
+
+class FakeMarketIntelligence:
+    def build_snapshot(self, symbol: str, ohlcv: Any) -> Mapping[str, Any]:
+        return {"symbol": symbol, "rows": len(ohlcv)}
+
+
+class FakeFeatureStore:
+    def get_or_compute(self, name: str, dataset: Sequence[Mapping[str, Any]], params: Mapping[str, Any], compute_fn):
+        return list(compute_fn(dataset, params))
+
+
+class FakeStrategy:
+    def evaluate(self, ohlcv: Any, context: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+        return [{"signal": "BUY", "rows": len(ohlcv), "context": dict(context)}]
+
+
+def test_contracts_are_importable() -> None:
+    assert MarketIntelligenceService is not None
+    assert FeatureStore is not None
+    assert StrategyContract is not None
+
+
+def test_fake_implementations_conform_to_contracts() -> None:
+    mi = FakeMarketIntelligence()
+    fs = FakeFeatureStore()
+    st = FakeStrategy()
+
+    assert isinstance(mi, MarketIntelligenceService)
+    assert isinstance(fs, FeatureStore)
+    assert isinstance(st, StrategyContract)
+
+    snapshot = mi.build_snapshot("BTC-USD", [{"close": 1.0}, {"close": 2.0}])
+    assert snapshot["symbol"] == "BTC-USD"
+    assert snapshot["rows"] == 2
+
+    values = fs.get_or_compute(
+        "ema_2",
+        [{"close": 1.0}, {"close": 2.0}],
+        {"period": 2},
+        lambda dataset, _: [float(row["close"]) for row in dataset],
+    )
+    assert values == [1.0, 2.0]
+
+    signals = st.evaluate([{"close": 1.0}], {"mode": "backtest"})
+    assert signals[0]["signal"] == "BUY"


### PR DESCRIPTION
### Motivation
- Provide minimal, well-documented protocol contracts so adapters and strategies can rely on stable, importable interfaces.
- Enable runtime structural checks for simple adapters and test doubles via `typing.Protocol` + `@runtime_checkable`.
- Avoid heavy runtime dependencies by keeping `pandas` typing behind `TYPE_CHECKING` in contracts that accept dataframes.

### Description
- Add `src/quant_engine/core/contracts/market_intelligence.py` implementing `MarketIntelligenceService` with a `build_snapshot` signature and input/output docstring.
- Add `src/quant_engine/core/contracts/feature_store.py` implementing `FeatureStore` with a `get_or_compute` signature and input/output docstring.
- Add `src/quant_engine/core/contracts/strategy.py` implementing `StrategyContract` with an `evaluate` signature and input/output docstring.
- Export the three contracts from `src/quant_engine/core/contracts/__init__.py` and add `tests/core/test_contracts_imports.py` which defines fake implementations and asserts importability and `isinstance` conformance.

### Testing
- Ran `poetry run pytest -q tests/core/test_contracts_imports.py` and the test suite completed successfully.
- The test run reported `2 passed` for the added contract tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84892f16c8323af77267660b7f829)