### PR TITLE
PY-MI-1.4: add legacy adapters for filters and stats outputs

### DIFF
--- a/src/quant_engine/market_intelligence/__init__.py
+++ b/src/quant_engine/market_intelligence/__init__.py
@@ -1,0 +1,2 @@
+"""Market intelligence adapters and helpers."""
+

--- a/src/quant_engine/market_intelligence/adapters/__init__.py
+++ b/src/quant_engine/market_intelligence/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters bridging legacy analytics outputs to normalized contracts."""
+
+from .legacy_filters_adapter import LegacyFiltersAdapter
+from .legacy_stats_adapter import LegacyStatsAdapter
+
+__all__ = ["LegacyFiltersAdapter", "LegacyStatsAdapter"]

--- a/src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py
+++ b/src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py
@@ -1,0 +1,78 @@
+"""Adapter from legacy filter service outputs to normalized dataframes."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+
+_FILTER_COLUMNS = ("hard_mask", "score", "score_pct", "final_mask")
+
+
+def _default_runner(*args: Any, **kwargs: Any) -> Mapping[str, Any]:
+    from quant_engine.filters.trade_filter_service import score_filter_rules
+
+    return score_filter_rules(*args, **kwargs)
+
+
+def _utc_indexed(ohlcv: pd.DataFrame) -> pd.DatetimeIndex:
+    if isinstance(ohlcv.index, pd.DatetimeIndex):
+        idx = ohlcv.index
+        if idx.tz is None:
+            return idx.tz_localize("UTC")
+        return idx.tz_convert("UTC")
+
+    if "ts" not in ohlcv.columns:
+        raise ValueError("ohlcv must expose a DatetimeIndex or a 'ts' column")
+    return pd.to_datetime(ohlcv["ts"], utc=True)
+
+
+class LegacyFiltersAdapter:
+    """Execute legacy filter rules and return a normalized UTC-indexed frame."""
+
+    def __init__(
+        self,
+        runner: Callable[..., Mapping[str, Any]] = _default_runner,
+    ) -> None:
+        self._runner = runner
+
+    def run(
+        self,
+        ohlcv: pd.DataFrame,
+        rules: Sequence[Mapping[str, Any]],
+        *,
+        symbol: str | None = None,
+        strict: bool = True,
+        min_score: float | None = None,
+        min_score_pct: float | None = None,
+    ) -> pd.DataFrame:
+        """Run legacy filters and normalize output shape/columns for contracts."""
+        result = self._runner(
+            ohlcv,
+            rules,
+            symbol=symbol,
+            strict=strict,
+            min_score=min_score,
+            min_score_pct=min_score_pct,
+        )
+        idx = _utc_indexed(ohlcv)
+
+        normalized = pd.DataFrame(index=idx)
+        normalized.index.name = "ts"
+        for col in _FILTER_COLUMNS:
+            values = result.get(col)
+            if values is None:
+                normalized[col] = pd.NA
+                continue
+            series = pd.Series(values, index=ohlcv.index if len(values) == len(ohlcv) else None)
+            normalized[col] = series.to_numpy()
+
+        for bool_col in ("hard_mask", "final_mask"):
+            normalized[bool_col] = normalized[bool_col].fillna(False).astype(bool)
+        for float_col in ("score", "score_pct"):
+            normalized[float_col] = pd.to_numeric(normalized[float_col], errors="coerce")
+
+        return normalized
+
+
+__all__ = ["LegacyFiltersAdapter"]

--- a/src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py
+++ b/src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py
@@ -1,0 +1,94 @@
+"""Adapter from legacy market stats outputs to normalized dataframes."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+
+_DEFAULT_COLUMNS = [
+    "symbol",
+    "event",
+    "condition_name",
+    "condition_value",
+    "target",
+    "n",
+    "successes",
+    "p_hat",
+    "ci_low",
+    "ci_high",
+    "p_mean",
+    "p_map",
+    "hdi_low",
+    "hdi_high",
+    "lift_freq",
+    "lift_bayes",
+    "insufficient",
+    "split",
+    "p_value",
+    "q_value",
+    "significant",
+]
+
+_RENAME_MAP = {
+    "p": "p_hat",
+    "probability": "p_hat",
+    "count": "n",
+    "wins": "successes",
+}
+
+
+def _default_runner(spec: Any) -> pd.DataFrame:
+    from quant_engine.stats.runner import run_stats
+
+    return run_stats(spec)
+
+
+class LegacyStatsAdapter:
+    """Execute legacy stats runner and normalize output for market-intelligence consumers."""
+
+    def __init__(self, runner: Callable[[Any], pd.DataFrame] = _default_runner) -> None:
+        self._runner = runner
+
+    def run(self, spec: Any) -> pd.DataFrame:
+        """Run legacy stats and return a UTC-indexed dataframe with canonical columns."""
+        out = self._runner(spec)
+        df = out.copy() if isinstance(out, pd.DataFrame) else pd.DataFrame(out)
+
+        if "ts" in df.columns:
+            idx = pd.to_datetime(df["ts"], utc=True)
+        elif isinstance(df.index, pd.DatetimeIndex):
+            idx = df.index.tz_localize("UTC") if df.index.tz is None else df.index.tz_convert("UTC")
+        else:
+            idx = pd.DatetimeIndex([pd.Timestamp("1970-01-01", tz="UTC")] * len(df))
+
+        df = df.rename(columns=_RENAME_MAP)
+        df = df.reindex(columns=_DEFAULT_COLUMNS, fill_value=pd.NA)
+        df.index = idx
+        df.index.name = "ts"
+
+        for numeric_col in (
+            "n",
+            "successes",
+            "p_hat",
+            "ci_low",
+            "ci_high",
+            "p_mean",
+            "p_map",
+            "hdi_low",
+            "hdi_high",
+            "lift_freq",
+            "lift_bayes",
+            "p_value",
+            "q_value",
+        ):
+            df[numeric_col] = pd.to_numeric(df[numeric_col], errors="coerce")
+
+        for bool_col in ("insufficient", "significant"):
+            bool_series = df[bool_col].astype("boolean")
+            df[bool_col] = bool_series.fillna(False).astype(bool)
+
+        return df
+
+
+__all__ = ["LegacyStatsAdapter"]

--- a/tests/market_intelligence/test_legacy_adapters.py
+++ b/tests/market_intelligence/test_legacy_adapters.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from quant_engine.market_intelligence.adapters.legacy_filters_adapter import LegacyFiltersAdapter
+from quant_engine.market_intelligence.adapters.legacy_stats_adapter import LegacyStatsAdapter
+
+
+def test_legacy_filters_adapter_normalizes_shape_and_columns() -> None:
+    index = pd.date_range("2026-01-01", periods=4, freq="h")
+    ohlcv = pd.DataFrame(
+        {
+            "open": [1.0, 2.0, 3.0, 4.0],
+            "high": [1.1, 2.1, 3.1, 4.1],
+            "low": [0.9, 1.9, 2.9, 3.9],
+            "close": [1.0, 2.0, 3.0, 4.0],
+            "volume": [100, 110, 120, 130],
+        },
+        index=index,
+    )
+
+    def _fake_runner(*_args, **_kwargs):
+        return {
+            "hard_mask": pd.Series([True, True, False, False], index=ohlcv.index),
+            "score": pd.Series([1.0, 0.8, 0.2, 0.0], index=ohlcv.index),
+            "score_pct": pd.Series([1.0, 0.8, 0.2, 0.0], index=ohlcv.index),
+            "final_mask": pd.Series([True, True, False, False], index=ohlcv.index),
+        }
+
+    adapter = LegacyFiltersAdapter(runner=_fake_runner)
+    out = adapter.run(ohlcv, rules=[{"type": "atr", "params": {"period": 14}}])
+
+    assert out.shape == (4, 4)
+    assert list(out.columns) == ["hard_mask", "score", "score_pct", "final_mask"]
+    assert isinstance(out.index, pd.DatetimeIndex)
+    assert str(out.index.tz) == "UTC"
+
+
+def test_legacy_stats_adapter_normalizes_shape_and_columns() -> None:
+    legacy = pd.DataFrame(
+        {
+            "ts": ["2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z"],
+            "symbol": ["BTC-USD", "BTC-USD"],
+            "event": ["cross", "cross"],
+            "target": ["up_1", "up_1"],
+            "count": [20, 30],
+            "wins": [11, 17],
+            "p": [0.55, 0.57],
+            "split": ["test", "test"],
+        }
+    )
+
+    adapter = LegacyStatsAdapter(runner=lambda _spec: legacy)
+    out = adapter.run(spec={"ignored": True})
+
+    assert out.shape[0] == 2
+    assert list(out.columns) == [
+        "symbol",
+        "event",
+        "condition_name",
+        "condition_value",
+        "target",
+        "n",
+        "successes",
+        "p_hat",
+        "ci_low",
+        "ci_high",
+        "p_mean",
+        "p_map",
+        "hdi_low",
+        "hdi_high",
+        "lift_freq",
+        "lift_bayes",
+        "insufficient",
+        "split",
+        "p_value",
+        "q_value",
+        "significant",
+    ]
+    assert str(out.index.tz) == "UTC"
+    assert out["n"].tolist() == [20, 30]
+    assert out["successes"].tolist() == [11, 17]
+    assert out["p_hat"].tolist() == [0.55, 0.57]


### PR DESCRIPTION
### Motivation
- Provide lightweight adapters that adapt legacy `filters` / `stats` outputs to the new market-intelligence contract without breaking existing flows.
- Ensure outputs are canonical DataFrames: UTC-indexed and exposing stable column names and types for downstream consumers.
- Avoid import-time side-effects (optional dependency errors) by resolving legacy runner implementations lazily.

### Description
- Add `src/quant_engine/market_intelligence/adapters` package and export `LegacyFiltersAdapter` and `LegacyStatsAdapter`.
- Implement `LegacyFiltersAdapter` which wraps a (injectable) legacy runner, normalizes index to UTC, and produces canonical columns `hard_mask`, `score`, `score_pct`, `final_mask` with proper boolean/numeric coercions.
- Implement `LegacyStatsAdapter` which wraps a (injectable) legacy stats runner, renames legacy column keys (`p`→`p_hat`, `count`→`n`, `wins`→`successes`), reindexes to a canonical stats column set, casts numeric columns, and ensures a UTC `DatetimeIndex`.
- Use lazy imports for the default runners and adjust boolean filling (`astype("boolean")` then `fillna`) to avoid deprecation warnings and import-time dependency problems.
- Add tests in `tests/market_intelligence/test_legacy_adapters.py` verifying shape, columns and UTC index behavior for both adapters.

### Testing
- Ran `poetry run pytest -q tests/market_intelligence/test_legacy_adapters.py` after fixes and the final run passed: `2 passed`.
- An earlier test collection run exposed an import-time failure (`ModuleNotFoundError: No module named 'pymysql'`) caused by legacy imports; this was addressed by making the adapters import their legacy runners lazily, after which tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a851033bdc8323a35d967e94012383)