### PR TITLE
PY-MI-2.2: Implement InMemoryFeatureStore with overwrite semantics

### DIFF
--- a/src/quant_engine/market_intelligence/feature_store_memory.py
+++ b/src/quant_engine/market_intelligence/feature_store_memory.py
@@ -1,0 +1,78 @@
+"""In-memory feature store keyed by feature metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+from threading import RLock
+from typing import Any
+
+FeatureStoreKey = tuple[str, str, str, str]
+
+
+class InMemoryFeatureStore:
+    """Simple thread-safe in-memory feature store.
+
+    Keys are normalized tuples: ``(feature_set, symbol, timeframe, version)``.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[FeatureStoreKey, Any] = {}
+        self._lock = RLock()
+
+    @staticmethod
+    def _build_key(feature_set: str, symbol: str, timeframe: str, version: str) -> FeatureStoreKey:
+        key: FeatureStoreKey = (feature_set, symbol, timeframe, version)
+        if not all(isinstance(part, Hashable) for part in key):
+            raise TypeError("All key components must be hashable")
+        return key
+
+    def get(self, feature_set: str, symbol: str, timeframe: str, version: str) -> Any:
+        """Return a stored payload for the exact key.
+
+        Raises:
+            KeyError: If the key is not present.
+        """
+
+        key = self._build_key(feature_set, symbol, timeframe, version)
+        with self._lock:
+            return self._data[key]
+
+    def put(
+        self,
+        feature_set: str,
+        symbol: str,
+        timeframe: str,
+        version: str,
+        payload: Any,
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        """Persist ``payload`` for a key.
+
+        Args:
+            overwrite: When ``False``, writing an existing key raises ``KeyError``.
+        """
+
+        key = self._build_key(feature_set, symbol, timeframe, version)
+        with self._lock:
+            if not overwrite and key in self._data:
+                raise KeyError(f"Feature key already exists: {key}")
+            self._data[key] = payload
+
+    def exists(self, feature_set: str, symbol: str, timeframe: str, version: str) -> bool:
+        """Return ``True`` when a key is present in the store."""
+
+        key = self._build_key(feature_set, symbol, timeframe, version)
+        with self._lock:
+            return key in self._data
+
+    def delete(self, feature_set: str, symbol: str, timeframe: str, version: str) -> bool:
+        """Delete a key.
+
+        Returns:
+            ``True`` when an entry existed and was removed, otherwise ``False``.
+        """
+
+        key = self._build_key(feature_set, symbol, timeframe, version)
+        with self._lock:
+            return self._data.pop(key, None) is not None

--- a/tests/market_intelligence/test_feature_store_memory.py
+++ b/tests/market_intelligence/test_feature_store_memory.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from quant_engine.market_intelligence.feature_store_memory import InMemoryFeatureStore
+
+
+@pytest.fixture
+def store() -> InMemoryFeatureStore:
+    return InMemoryFeatureStore()
+
+
+def test_put_get_exists_delete_roundtrip(store: InMemoryFeatureStore) -> None:
+    key = ("volatility", "BTC-USD", "1h", "1.0.0")
+    payload = {"feat_vol": [0.1, 0.2, 0.3]}
+
+    assert store.exists(*key) is False
+
+    store.put(*key, payload=payload)
+
+    assert store.exists(*key) is True
+    assert store.get(*key) == payload
+    assert store.delete(*key) is True
+    assert store.exists(*key) is False
+    assert store.delete(*key) is False
+
+
+def test_put_rejects_existing_key_without_explicit_overwrite(store: InMemoryFeatureStore) -> None:
+    key = ("momentum", "ETH-USD", "4h", "2.0.0")
+    store.put(*key, payload={"feat_momentum": [1.0]})
+
+    with pytest.raises(KeyError):
+        store.put(*key, payload={"feat_momentum": [2.0]})
+
+
+def test_put_allows_explicit_overwrite(store: InMemoryFeatureStore) -> None:
+    key = ("trend", "SOL-USD", "15m", "3.1.0")
+    store.put(*key, payload={"feat_trend": [10]})
+
+    store.put(*key, payload={"feat_trend": [20]}, overwrite=True)
+
+    assert store.get(*key) == {"feat_trend": [20]}
+
+
+def test_sequential_writes_keep_last_value_per_key(store: InMemoryFeatureStore) -> None:
+    key = ("liquidity", "ADA-USD", "1d", "1.0.1")
+
+    for value in range(10):
+        payload = {"feat_liquidity": [float(value)]}
+        if store.exists(*key):
+            store.put(*key, payload=payload, overwrite=True)
+        else:
+            store.put(*key, payload=payload)
+
+    assert store.get(*key) == {"feat_liquidity": [9.0]}


### PR DESCRIPTION
### Motivation
- Provide a lightweight in-RAM feature cache keyed by `(feature_set, symbol, timeframe, version)` for market-intelligence features.
- Ensure safe concurrent access and clear semantics for replacing stored payloads.

### Description
- Add `InMemoryFeatureStore` in `src/quant_engine/market_intelligence/feature_store_memory.py` implementing `get`, `put`, `exists`, and `delete` operations. 
- Use an `RLock` for thread-safe access and validate that all key components are `Hashable` in `_build_key`.
- Enforce explicit overwrite semantics where `put(..., overwrite=False)` raises `KeyError` if a key exists and `overwrite=True` replaces the payload.
- Add unit tests in `tests/market_intelligence/test_feature_store_memory.py` covering CRUD roundtrip, overwrite rejection, explicit overwrite acceptance, and sequential-write behavior.

### Testing
- Ran the feature store unit tests with `poetry run pytest -q tests/market_intelligence/test_feature_store_memory.py` and all tests passed. 
- Test results: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a854639e0c8323aacb9d65774057b6)