### PR TITLE
Add partitioned/versioned ParquetFeatureStore with atomic writes

### DIFF
--- a/src/quant_engine/market_intelligence/__init__.py
+++ b/src/quant_engine/market_intelligence/__init__.py
@@ -1,2 +1,6 @@
 """Market intelligence adapters and helpers."""
 
+from quant_engine.market_intelligence.feature_store_memory import InMemoryFeatureStore
+from quant_engine.market_intelligence.feature_store_parquet import ParquetFeatureStore
+
+__all__ = ["InMemoryFeatureStore", "ParquetFeatureStore"]

--- a/src/quant_engine/market_intelligence/feature_store_parquet.py
+++ b/src/quant_engine/market_intelligence/feature_store_parquet.py
@@ -1,0 +1,112 @@
+"""Parquet-backed feature store with partitioned/versioned persistence."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pandas as pd
+
+from quant_engine.market_intelligence.models import FeatureMeta
+
+
+class ParquetFeatureStore:
+    """Persist feature dataframes in a stable parquet layout.
+
+    Layout:
+        ``<root>/<feature_name>/symbol=<symbol>/timeframe=<timeframe>/version=<feature_version>/data.parquet``
+    """
+
+    def __init__(self, root_dir: str | Path, *, timestamp_column: str = "timestamp") -> None:
+        self._root_dir = Path(root_dir)
+        self._timestamp_column = timestamp_column
+
+    def _build_path(self, feature_name: str, symbol: str, timeframe: str, feature_version: str) -> Path:
+        meta = FeatureMeta(
+            feature_name=feature_name,
+            symbol=symbol,
+            timeframe=timeframe,
+            feature_version=feature_version,
+        )
+        return (
+            self._root_dir
+            / meta.feature_name
+            / f"symbol={meta.symbol}"
+            / f"timeframe={meta.timeframe}"
+            / f"version={meta.feature_version}"
+            / "data.parquet"
+        )
+
+    def put(
+        self,
+        feature_name: str,
+        symbol: str,
+        timeframe: str,
+        feature_version: str,
+        payload: pd.DataFrame,
+        *,
+        overwrite: bool = False,
+    ) -> Path:
+        data_path = self._build_path(feature_name, symbol, timeframe, feature_version)
+        if data_path.exists() and not overwrite:
+            raise KeyError(f"Feature key already exists: {data_path}")
+
+        if "feature_version" in payload.columns and not payload["feature_version"].eq(feature_version).all():
+            raise ValueError("Payload feature_version does not match requested feature_version")
+
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = data_path.with_name(f".{data_path.name}.{uuid4().hex}.tmp")
+        try:
+            payload.to_parquet(tmp_path, index=False)
+            os.replace(tmp_path, data_path)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        return data_path
+
+    def get(
+        self,
+        feature_name: str,
+        symbol: str,
+        timeframe: str,
+        feature_version: str,
+        *,
+        start: str | pd.Timestamp | None = None,
+        end: str | pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        data_path = self._build_path(feature_name, symbol, timeframe, feature_version)
+        if not data_path.exists():
+            raise KeyError(f"Feature key not found: {data_path}")
+
+        frame = pd.read_parquet(data_path)
+
+        if "feature_version" in frame.columns and not frame["feature_version"].eq(feature_version).all():
+            raise ValueError("Stored feature_version does not match requested feature_version")
+
+        if start is None and end is None:
+            return frame
+
+        if self._timestamp_column in frame.columns:
+            timestamps = pd.to_datetime(frame[self._timestamp_column], utc=False)
+            mask = pd.Series(True, index=frame.index)
+            if start is not None:
+                mask &= timestamps >= pd.Timestamp(start)
+            if end is not None:
+                mask &= timestamps <= pd.Timestamp(end)
+            return frame.loc[mask].copy()
+
+        if isinstance(frame.index, pd.DatetimeIndex):
+            mask = pd.Series(True, index=frame.index)
+            if start is not None:
+                mask &= frame.index >= pd.Timestamp(start)
+            if end is not None:
+                mask &= frame.index <= pd.Timestamp(end)
+            return frame.loc[mask].copy()
+
+        raise ValueError(
+            f"Cannot apply period filter: no '{self._timestamp_column}' column and index is not DatetimeIndex"
+        )
+
+    def exists(self, feature_name: str, symbol: str, timeframe: str, feature_version: str) -> bool:
+        return self._build_path(feature_name, symbol, timeframe, feature_version).exists()

--- a/tests/market_intelligence/test_feature_store_parquet.py
+++ b/tests/market_intelligence/test_feature_store_parquet.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from quant_engine.market_intelligence.feature_store_parquet import ParquetFeatureStore
+
+
+def test_put_get_roundtrip_with_period_filter(tmp_path) -> None:
+    store = ParquetFeatureStore(tmp_path)
+    key = ("volatility", "btc-usd", "1H", "1.0.0")
+
+    payload = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=5, freq="D"),
+            "feat_vol": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "feature_version": ["1.0.0"] * 5,
+        }
+    )
+
+    path = store.put(*key, payload=payload)
+    assert path.exists()
+    assert str(path).endswith("volatility/symbol=BTC-USD/timeframe=1h/version=1.0.0/data.parquet")
+
+    loaded = store.get(*key)
+    pd.testing.assert_frame_equal(loaded.reset_index(drop=True), payload.reset_index(drop=True))
+
+    filtered = store.get(*key, start="2024-01-02", end="2024-01-04")
+    assert filtered["timestamp"].tolist() == list(pd.date_range("2024-01-02", periods=3, freq="D"))
+    assert filtered["feat_vol"].tolist() == [0.2, 0.3, 0.4]
+
+
+def test_get_raises_on_feature_version_mismatch(tmp_path) -> None:
+    store = ParquetFeatureStore(tmp_path)
+    key = ("momentum", "ETH-USD", "4h", "2.0.0")
+
+    payload = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-03-01", periods=2, freq="h"),
+            "feat_mom": [1.0, 1.1],
+            "feature_version": ["9.9.9", "9.9.9"],
+        }
+    )
+    path = store._build_path(*key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload.to_parquet(path, index=False)
+
+    with pytest.raises(ValueError, match="Stored feature_version does not match requested feature_version"):
+        store.get(*key)


### PR DESCRIPTION
### Motivation

- Provide durable, partitioned and versioned on-disk persistence for computed market-intelligence features.
- Ensure safe atomic writes and stable path layout so consumers can rely on deterministic file locations and consistent versions.

### Description

- Add `ParquetFeatureStore` implementing a stable layout at `<root>/<feature_name>/symbol=<symbol>/timeframe=<timeframe>/version=<feature_version>/data.parquet` and using `FeatureMeta` for normalization and validation (`src/quant_engine/market_intelligence/feature_store_parquet.py`).
- Implement atomic `put` using a temporary parquet file and `os.replace` to guarantee atomic rename semantics and optional `overwrite` protection.
- Validate `feature_version` consistency on write and read, and implement `get` with optional period filtering via `start`/`end` using either a timestamp column or a `DatetimeIndex`.
- Export `ParquetFeatureStore` from the `market_intelligence` package and add tests covering round-trip, period filtering, and version mismatch behavior (`tests/market_intelligence/test_feature_store_parquet.py`).

### Testing

- Ran `poetry run pytest -q tests/market_intelligence/test_feature_store_parquet.py` and the suite completed successfully with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85a9fc414832385d6b738f3d33a98)