### PR TITLE
PY-MI-2.4: add MarketIntelligenceService v1 pipeline, legacy adapters, and cache

### DIFF
--- a/src/quant_engine/market_intelligence/__init__.py
+++ b/src/quant_engine/market_intelligence/__init__.py
@@ -2,5 +2,6 @@
 
 from quant_engine.market_intelligence.feature_store_memory import InMemoryFeatureStore
 from quant_engine.market_intelligence.feature_store_parquet import ParquetFeatureStore
+from quant_engine.market_intelligence.service import MarketIntelligenceServiceV1
 
-__all__ = ["InMemoryFeatureStore", "ParquetFeatureStore"]
+__all__ = ["InMemoryFeatureStore", "ParquetFeatureStore", "MarketIntelligenceServiceV1"]

--- a/src/quant_engine/market_intelligence/pipeline.py
+++ b/src/quant_engine/market_intelligence/pipeline.py
@@ -1,0 +1,67 @@
+"""Pure pipeline primitives for MarketIntelligenceService v1."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _utc_indexed(frame: pd.DataFrame) -> pd.DatetimeIndex:
+    if isinstance(frame.index, pd.DatetimeIndex):
+        return frame.index.tz_localize("UTC") if frame.index.tz is None else frame.index.tz_convert("UTC")
+    if "ts" not in frame.columns:
+        raise ValueError("ohlcv must expose a DatetimeIndex or a 'ts' column")
+    return pd.to_datetime(frame["ts"], utc=True)
+
+
+def compute_features(ohlcv: pd.DataFrame) -> pd.DataFrame:
+    """Compute deterministic correlation/regime/liquidity base features from OHLCV."""
+    idx = _utc_indexed(ohlcv)
+    base = ohlcv.copy()
+
+    close = pd.to_numeric(base["close"], errors="coerce")
+    volume = pd.to_numeric(base["volume"], errors="coerce")
+
+    features = pd.DataFrame(index=idx)
+    features.index.name = "ts"
+    features["feat_return_1"] = close.pct_change().fillna(0.0)
+    features["feat_volatility_5"] = features["feat_return_1"].rolling(5, min_periods=2).std().fillna(0.0)
+    features["feat_corr_close_volume_5"] = close.rolling(5, min_periods=3).corr(volume).fillna(0.0)
+
+    return features
+
+
+def label_regimes(features: pd.DataFrame) -> pd.DataFrame:
+    """Label market regime from momentum and realized volatility proxies."""
+    frame = features.copy()
+    trend = frame["feat_return_1"].rolling(3, min_periods=1).mean()
+    high_vol = frame["feat_volatility_5"] > frame["feat_volatility_5"].rolling(8, min_periods=1).median()
+
+    labels = pd.DataFrame(index=frame.index)
+    labels.index.name = "ts"
+    labels["label_regime"] = "sideways"
+    labels.loc[trend > 0.002, "label_regime"] = "bull"
+    labels.loc[trend < -0.002, "label_regime"] = "bear"
+    labels.loc[high_vol, "label_regime"] = labels.loc[high_vol, "label_regime"] + "_high_vol"
+    return labels
+
+
+def liquidity_flags(ohlcv: pd.DataFrame) -> pd.DataFrame:
+    """Generate deterministic liquidity flags from volume and intrabar spread."""
+    idx = _utc_indexed(ohlcv)
+    volume = pd.to_numeric(ohlcv["volume"], errors="coerce")
+    high = pd.to_numeric(ohlcv["high"], errors="coerce")
+    low = pd.to_numeric(ohlcv["low"], errors="coerce")
+    close = pd.to_numeric(ohlcv["close"], errors="coerce")
+
+    spread = ((high - low) / close.replace(0, pd.NA)).fillna(0.0)
+    rolling_median_vol = volume.rolling(10, min_periods=1).median()
+
+    flags = pd.DataFrame(index=idx)
+    flags.index.name = "ts"
+    flags["liq_low_volume"] = volume < (rolling_median_vol * 0.5)
+    flags["liq_wide_spread"] = spread > 0.02
+    flags["liq_illiquid"] = flags["liq_low_volume"] | flags["liq_wide_spread"]
+    return flags
+
+
+__all__ = ["compute_features", "label_regimes", "liquidity_flags"]

--- a/src/quant_engine/market_intelligence/service.py
+++ b/src/quant_engine/market_intelligence/service.py
@@ -1,0 +1,92 @@
+"""Market Intelligence service v1 with transitional legacy adapters and caching."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from quant_engine.market_intelligence.adapters.legacy_filters_adapter import LegacyFiltersAdapter
+from quant_engine.market_intelligence.adapters.legacy_stats_adapter import LegacyStatsAdapter
+from quant_engine.market_intelligence.feature_store_memory import InMemoryFeatureStore
+from quant_engine.market_intelligence.pipeline import compute_features, label_regimes, liquidity_flags
+
+
+class MarketIntelligenceServiceV1:
+    """Compute market intelligence snapshots with read/write-through cache semantics."""
+
+    def __init__(
+        self,
+        *,
+        feature_store: InMemoryFeatureStore | Any | None = None,
+        stats_adapter: LegacyStatsAdapter | None = None,
+        filters_adapter: LegacyFiltersAdapter | None = None,
+        feature_set: str = "market_intelligence",
+        feature_version: str = "1.0.0",
+        timeframe: str = "1h",
+    ) -> None:
+        self._feature_store = feature_store
+        self._stats_adapter = stats_adapter or LegacyStatsAdapter()
+        self._filters_adapter = filters_adapter or LegacyFiltersAdapter()
+        self._feature_set = feature_set
+        self._feature_version = feature_version
+        self._timeframe = timeframe
+
+    def compute_features(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        return compute_features(ohlcv)
+
+    def label_regimes(self, features: pd.DataFrame) -> pd.DataFrame:
+        return label_regimes(features)
+
+    def liquidity_flags(self, ohlcv: pd.DataFrame) -> pd.DataFrame:
+        return liquidity_flags(ohlcv)
+
+    def _cache_get(self, symbol: str) -> dict[str, Any] | None:
+        if self._feature_store is None:
+            return None
+        try:
+            return self._feature_store.get(self._feature_set, symbol, self._timeframe, self._feature_version)
+        except KeyError:
+            return None
+
+    def _cache_put(self, symbol: str, snapshot: dict[str, Any]) -> None:
+        if self._feature_store is None:
+            return
+        overwrite = self._feature_store.exists(self._feature_set, symbol, self._timeframe, self._feature_version)
+        self._feature_store.put(
+            self._feature_set,
+            symbol,
+            self._timeframe,
+            self._feature_version,
+            snapshot,
+            overwrite=overwrite,
+        )
+
+    def build_snapshot(self, symbol: str, ohlcv: pd.DataFrame) -> dict[str, Any]:
+        """Read-through cache, then compute and write-through on miss."""
+        cached = self._cache_get(symbol)
+        if cached is not None:
+            return cached
+
+        features = self.compute_features(ohlcv)
+        regimes = self.label_regimes(features)
+        liquidity = self.liquidity_flags(ohlcv)
+
+        legacy_stats = self._stats_adapter.run(spec={"symbol": symbol, "ohlcv": ohlcv})
+        legacy_filters = self._filters_adapter.run(ohlcv, rules=[], symbol=symbol)
+
+        snapshot: dict[str, Any] = {
+            "symbol": symbol,
+            "timeframe": self._timeframe,
+            "feature_version": self._feature_version,
+            "features": features,
+            "regimes": regimes,
+            "liquidity": liquidity,
+            "legacy_stats": legacy_stats,
+            "legacy_filters": legacy_filters,
+        }
+        self._cache_put(symbol, snapshot)
+        return snapshot
+
+
+__all__ = ["MarketIntelligenceServiceV1"]

--- a/tests/market_intelligence/test_service_v1.py
+++ b/tests/market_intelligence/test_service_v1.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from quant_engine.market_intelligence.feature_store_memory import InMemoryFeatureStore
+from quant_engine.market_intelligence.service import MarketIntelligenceServiceV1
+
+
+class _DummyStatsAdapter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, spec):
+        self.calls += 1
+        return pd.DataFrame(
+            {
+                "symbol": [spec["symbol"]],
+                "event": ["dummy"],
+                "p_hat": [0.5],
+            },
+            index=pd.to_datetime(["2026-01-01T00:00:00Z"], utc=True),
+        )
+
+
+class _DummyFiltersAdapter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, ohlcv, rules, **_kwargs):
+        self.calls += 1
+        return pd.DataFrame(
+            {
+                "hard_mask": [True] * len(ohlcv),
+                "score": [1.0] * len(ohlcv),
+                "score_pct": [1.0] * len(ohlcv),
+                "final_mask": [True] * len(ohlcv),
+            },
+            index=ohlcv.index.tz_localize("UTC") if ohlcv.index.tz is None else ohlcv.index,
+        )
+
+
+def _fixed_ohlcv() -> pd.DataFrame:
+    idx = pd.date_range("2026-01-01", periods=12, freq="h", tz="UTC")
+    return pd.DataFrame(
+        {
+            "open": [100, 101, 102, 103, 102, 101, 100, 99, 99.5, 100, 101, 102],
+            "high": [101, 102, 103, 104, 103, 102, 101, 100, 100, 101, 102, 103],
+            "low": [99, 100, 101, 102, 101, 100, 99, 98, 99, 99.5, 100, 101],
+            "close": [100.5, 101.5, 102.5, 102.8, 101.7, 100.3, 99.4, 99.2, 99.7, 100.4, 101.3, 102.2],
+            "volume": [1000, 1100, 1200, 1300, 900, 800, 700, 650, 680, 720, 760, 800],
+        },
+        index=idx,
+    )
+
+
+def test_service_v1_build_snapshot_is_deterministic_with_fixed_dataset() -> None:
+    ohlcv = _fixed_ohlcv()
+    service = MarketIntelligenceServiceV1(
+        stats_adapter=_DummyStatsAdapter(),
+        filters_adapter=_DummyFiltersAdapter(),
+    )
+
+    first = service.build_snapshot("BTC-USD", ohlcv)
+    second = service.build_snapshot("BTC-USD", ohlcv)
+
+    pd.testing.assert_frame_equal(first["features"], second["features"])
+    pd.testing.assert_frame_equal(first["regimes"], second["regimes"])
+    pd.testing.assert_frame_equal(first["liquidity"], second["liquidity"])
+
+
+def test_service_v1_uses_read_through_write_through_cache() -> None:
+    ohlcv = _fixed_ohlcv()
+    stats = _DummyStatsAdapter()
+    filters = _DummyFiltersAdapter()
+    store = InMemoryFeatureStore()
+
+    service = MarketIntelligenceServiceV1(
+        feature_store=store,
+        stats_adapter=stats,
+        filters_adapter=filters,
+    )
+
+    cold = service.build_snapshot("ETH-USD", ohlcv)
+    warm = service.build_snapshot("ETH-USD", ohlcv)
+
+    assert stats.calls == 1
+    assert filters.calls == 1
+    assert store.exists("market_intelligence", "ETH-USD", "1h", "1.0.0")
+
+    pd.testing.assert_frame_equal(cold["features"], warm["features"])
+    pd.testing.assert_frame_equal(cold["legacy_stats"], warm["legacy_stats"])
+
+
+def test_service_v1_methods_delegate_pipeline_shapes() -> None:
+    service = MarketIntelligenceServiceV1(
+        stats_adapter=_DummyStatsAdapter(),
+        filters_adapter=_DummyFiltersAdapter(),
+    )
+    ohlcv = _fixed_ohlcv()
+
+    features = service.compute_features(ohlcv)
+    regimes = service.label_regimes(features)
+    flags = service.liquidity_flags(ohlcv)
+
+    assert list(features.columns) == ["feat_return_1", "feat_volatility_5", "feat_corr_close_volume_5"]
+    assert list(regimes.columns) == ["label_regime"]
+    assert list(flags.columns) == ["liq_low_volume", "liq_wide_spread", "liq_illiquid"]
+    assert len(features) == len(ohlcv)
+    assert len(regimes) == len(ohlcv)
+    assert len(flags) == len(ohlcv)


### PR DESCRIPTION
### Motivation
- Provide a v1 Market Intelligence implementation that computes deterministic features, regime labels, and liquidity flags from OHLCV and supports a transitional path for legacy adapters. 
- Add read-through / write-through cache semantics so computed snapshots can be stored and reused via a feature store interface. 
- Supply unit tests that validate determinism, cache behavior, and pipeline shapes for a fixed dataset.

### Description
- Add `src/quant_engine/market_intelligence/pipeline.py` with pipeline primitives `compute_features`, `label_regimes`, and `liquidity_flags` that operate deterministically on OHLCV. 
- Add `src/quant_engine/market_intelligence/service.py` implementing `MarketIntelligenceServiceV1` which wires pipeline functions, integrates `LegacyStatsAdapter` and `LegacyFiltersAdapter` for transitional compatibility, and implements `_cache_get` / `_cache_put` read-through/write-through behavior against the feature store API. 
- Export `MarketIntelligenceServiceV1` from `src/quant_engine/market_intelligence/__init__.py` and add `tests/market_intelligence/test_service_v1.py` covering determinism, cache cold/warm behavior, and delegated pipeline shapes. 

### Testing
- Ran the unit tests in the new file with `poetry run pytest -q tests/market_intelligence/test_service_v1.py` and observed `3 passed` (completed successfully in 3.10s). 
- No failures were encountered when running the above automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85c99a2d8832381301baa47546eb8)