### PR TITLE
EPIC-3 PY-MI-3.1: Inject MarketIntelligenceService into backtest runner

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -14,6 +14,7 @@ import logging
 
 from . import engine
 from ..core import dataset
+from ..core.contracts import MarketIntelligenceService
 from ..core.features import atr
 from ..core.spec import DataSpec, parse_data_spec, uses_strategy_sources
 from ..filters.utils import apply_filter_stack, FilterValidationError
@@ -25,6 +26,13 @@ from ..strategies.runner import persist_payload_to_db
 
 LOGGER = logging.getLogger(__name__)
 _ROWS_CACHE: Dict[str, Tuple[List[Dict[str, Any]], Optional[str]]] = {}
+
+
+class _NullMarketIntelligenceService:
+    """Fallback adapter returning an empty snapshot when MI is not configured."""
+
+    def build_snapshot(self, symbol: str, ohlcv: pd.DataFrame) -> Mapping[str, Any]:
+        return {"symbol": symbol, "features": {}, "ohlcv_rows": len(ohlcv)}
 
 
 def load_backtest_spec(path: Path | str) -> Dict[str, Any]:
@@ -120,7 +128,11 @@ def _load_rows(
     return rows, None
 
 
-def _build_signal(spec: Mapping[str, Any], rows: List[Dict[str, Any]]) -> List[int]:
+def _build_signal(
+    spec: Mapping[str, Any],
+    rows: List[Dict[str, Any]],
+    features: Mapping[str, Any] | None = None,
+) -> List[int]:
     signal_spec = spec.get("signal", {}) or {}
     signal_type = str(signal_spec.get("type") or "").strip().lower()
     params = signal_spec.get("params", {}) or {}
@@ -129,8 +141,22 @@ def _build_signal(spec: Mapping[str, Any], rows: List[Dict[str, Any]]) -> List[i
         slow = params.get("slow", params.get("ema_slow"))
         if fast is None or slow is None:
             raise ValueError("ema_cross requires fast/slow parameters")
-        return EmaCross(int(fast), int(slow)).generate(rows)
+        signal_impl = EmaCross(int(fast), int(slow))
+        try:
+            return signal_impl.generate(rows, features=features)
+        except TypeError:
+            return signal_impl.generate(rows)
     raise ValueError(f"Unsupported signal type '{signal_type}'")
+
+
+def _resolve_market_features(
+    rows: List[Dict[str, Any]],
+    symbol: str,
+    mi_service: MarketIntelligenceService | None,
+) -> Mapping[str, Any]:
+    service = mi_service or _NullMarketIntelligenceService()
+    frame = _rows_to_frame(rows)
+    return service.build_snapshot(symbol, frame)
 
 
 def _validate_ohlc_rows(rows: List[Dict[str, Any]]) -> None:
@@ -203,7 +229,10 @@ def _apply_filter_mask(
     return gated
 
 
-def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
+def run_backtest_from_spec(
+    spec: Mapping[str, Any],
+    mi_service: MarketIntelligenceService | None = None,
+) -> Dict[str, Any]:
     """Execute a classic backtest based on a JSON specification."""
 
     data_raw = spec.get("data", {}) or {}
@@ -252,8 +281,9 @@ def run_backtest_from_spec(spec: Mapping[str, Any]) -> Dict[str, Any]:
             pruning_cfg = candidate_pruning
 
     symbol = _detect_symbol(rows)
+    features = _resolve_market_features(rows, symbol, mi_service)
     t_signal = time.monotonic()
-    signal = _build_signal(spec, rows)
+    signal = _build_signal(spec, rows, features)
     _perf_log("backtest.build_signal", t_signal)
 
     filters_spec = spec.get("filters") or (spec.get("strategy", {}) or {}).get("filters") or []

--- a/tests/backtest/test_backtest_with_mi_injection.py
+++ b/tests/backtest/test_backtest_with_mi_injection.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import pandas as pd
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+from quant_engine.backtest import runner as backtest_runner
+
+
+SPEC_DIR = Path("specs/tests")
+
+
+class DummyMarketIntelligenceService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    def build_snapshot(self, symbol: str, ohlcv: pd.DataFrame) -> dict:
+        self.calls.append((symbol, len(ohlcv)))
+        return {
+            "symbol": symbol,
+            "features": {"regime": "trend"},
+            "bars": len(ohlcv),
+        }
+
+
+def test_backtest_injects_market_intelligence_service(monkeypatch) -> None:
+    spec = backtest_runner.load_backtest_spec(SPEC_DIR / "backtest_csv_basic.json")
+    observed: dict = {}
+    original_build_signal = backtest_runner._build_signal
+
+    def wrapped_build_signal(spec_input, rows, features=None):
+        observed["features"] = features
+        return original_build_signal(spec_input, rows, features)
+
+    monkeypatch.setattr(backtest_runner, "_build_signal", wrapped_build_signal)
+    mi_service = DummyMarketIntelligenceService()
+
+    result = backtest_runner.run_backtest_from_spec(spec, mi_service=mi_service)
+
+    assert result["symbol"] == "EURUSD"
+    assert mi_service.calls
+    assert observed["features"]["features"]["regime"] == "trend"
+
+
+def test_backtest_uses_null_mi_adapter_by_default(monkeypatch) -> None:
+    spec = backtest_runner.load_backtest_spec(SPEC_DIR / "backtest_csv_basic.json")
+    observed: dict = {}
+    original_build_signal = backtest_runner._build_signal
+
+    def wrapped_build_signal(spec_input, rows, features=None):
+        observed["features"] = features
+        return original_build_signal(spec_input, rows, features)
+
+    monkeypatch.setattr(backtest_runner, "_build_signal", wrapped_build_signal)
+
+    result = backtest_runner.run_backtest_from_spec(spec)
+
+    assert result["symbol"] == "EURUSD"
+    assert observed["features"]["symbol"] == "EURUSD"
+    assert observed["features"]["features"] == {}


### PR DESCRIPTION
### Motivation
- Enable the backtest runner to consume market-intelligence snapshots so decision logic can use MI features while preserving existing behaviour when no MI service is provided.
- Provide a safe, backward-compatible path so existing signal implementations continue to work without modification.

### Description
- Added an optional `mi_service` parameter to `run_backtest_from_spec` and resolve MI features before signal generation via a new `_resolve_market_features` helper that calls the injected service.
- Introduced a null adapter `
_NullMarketIntelligenceService` that returns an empty snapshot so the runner behaves the same when no `mi_service` is supplied.
- Extended `_build_signal` to accept an optional `features` argument and attempt to pass it to signal generators (with a `TypeError` fallback to call legacy signature), keeping compatibility with current signals.
- Added tests `tests/backtest/test_backtest_with_mi_injection.py` that verify explicit injection and default null-adapter behaviour; the test file includes a local shim for `pymysql` to avoid import-time DB dependency during test collection.

### Testing
- Ran `poetry run pytest -q tests/backtest/test_backtest_with_mi_injection.py` and the suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a865870cdc83238f3945516649c909)