### PR TITLE
PY-MI-3.2: Inject timestamp-aligned features_row into strategy execution

### DIFF
--- a/src/quant_engine/strategies/base.py
+++ b/src/quant_engine/strategies/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Protocol
+from typing import Any, Dict, List, Mapping, Optional, Protocol
 
 import pandas as pd
 
@@ -22,6 +22,19 @@ class StrategySignal:
 
 class Strategy(Protocol):
     """Abstract interface implemented by every high level strategy."""
+
+    def on_bar(
+        self,
+        bar: pd.Series,
+        context: Dict[str, Any],
+        features_row: Optional[Mapping[str, Any]] = None,
+    ) -> List[StrategySignal]:
+        """Handle a single bar and return zero or more signals.
+
+        ``features_row`` provides market-intelligence features aligned with
+        ``bar`` timestamp. Implementations should accept ``None`` for backward
+        compatibility when no features are available.
+        """
 
     def backtest(self, ohlc: pd.DataFrame, context: Dict[str, Any]) -> List[StrategySignal]:
         """Return the list of signals (entries/exits/rotations) for the whole period."""

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -103,6 +103,41 @@ def _expand_universe(spec: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
     return list(collected.values())
 
 
+def _extract_features_rows_by_ts(df: pd.DataFrame) -> Dict[pd.Timestamp, Dict[str, Any]]:
+    """Build timestamp-aligned market-intelligence feature rows from an OHLC frame."""
+
+    if df.empty:
+        return {}
+    working = df.copy()
+    if "ts" in working.columns:
+        index = pd.to_datetime(working["ts"], utc=True)
+        working.index = index
+    elif isinstance(working.index, pd.DatetimeIndex):
+        if working.index.tz is None:
+            working.index = working.index.tz_localize("UTC")
+        else:
+            working.index = working.index.tz_convert("UTC")
+    else:
+        return {}
+    excluded = {
+        "ts",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "symbol",
+        "asset_class",
+        "_filter_ok",
+        "_filter_score",
+    }
+    feature_cols = [col for col in working.columns if col not in excluded]
+    if not feature_cols:
+        return {}
+    features = working[feature_cols].where(pd.notna(working[feature_cols]), None)
+    return {pd.Timestamp(ts): row.to_dict() for ts, row in features.iterrows()}
+
+
 def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[str, pd.DataFrame]]:
     """Run the strategy backtest and return raw results plus OHLC cache."""
 
@@ -223,7 +258,26 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
         t_signals = time.monotonic()
         context = {"symbol": symbol, "asset_class": asset_class, "screening": screening_cfg}
         context = universe_adapter.adapt_context(context, universe_rules)
-        signals = strategy.backtest(df, context)
+        feature_rows_by_ts = _extract_features_rows_by_ts(df)
+        if feature_rows_by_ts:
+            context["features_by_ts"] = feature_rows_by_ts
+        on_bar = getattr(strategy, "on_bar", None)
+        if callable(on_bar):
+            normalized = df.copy()
+            if "ts" in normalized.columns:
+                normalized["ts"] = pd.to_datetime(normalized["ts"], utc=True)
+                normalized = normalized.set_index("ts")
+            elif isinstance(normalized.index, pd.DatetimeIndex):
+                if normalized.index.tz is None:
+                    normalized.index = normalized.index.tz_localize("UTC")
+                else:
+                    normalized.index = normalized.index.tz_convert("UTC")
+            signals = []
+            for ts, row in normalized.iterrows():
+                features_row = feature_rows_by_ts.get(pd.Timestamp(ts)) if feature_rows_by_ts else None
+                signals.extend(on_bar(row, context, features_row=features_row))
+        else:
+            signals = strategy.backtest(df, context)
         serialized = [_serialize_signal(sig) for sig in signals]
         signals_by_symbol[symbol] = serialized
         counts[symbol] = len(serialized)

--- a/tests/strategies/test_strategy_consumes_features.py
+++ b/tests/strategies/test_strategy_consumes_features.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+import sys
+import types
+
+import pandas as pd
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+from quant_engine.strategies.base import StrategySignal
+from quant_engine.strategies import runner as strategies_runner
+
+
+class _FeatureAwareDummyStrategy:
+    def __init__(self, strategy_id: str, params: Dict[str, Any]) -> None:
+        self.strategy_id = strategy_id
+        self.params = params
+        self.rows: list[tuple[pd.Timestamp, Optional[Mapping[str, Any]]]] = []
+
+    def on_bar(
+        self,
+        bar: pd.Series,
+        context: Dict[str, Any],
+        features_row: Optional[Mapping[str, Any]] = None,
+    ) -> List[StrategySignal]:
+        ts = pd.Timestamp(bar.name)
+        self.rows.append((ts, features_row))
+        return []
+
+
+class _LegacyDummyStrategy:
+    def __init__(self, strategy_id: str, params: Dict[str, Any]) -> None:
+        self.strategy_id = strategy_id
+        self.params = params
+
+    def backtest(self, ohlc: pd.DataFrame, context: Dict[str, Any]) -> List[StrategySignal]:
+        return []
+
+
+def _build_spec(strategy_type: str) -> Dict[str, Any]:
+    return {
+        "strategy": {"type": strategy_type, "strategy_id": "s1", "params": {}},
+        "universe": [{"symbol": "SPY", "asset_class": "ETF"}],
+        "data": {"source": "csv", "path": "unused.csv"},
+    }
+
+
+def _build_ohlc_with_features() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.to_datetime([
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            ], utc=True),
+            "open": [100.0, 101.0],
+            "high": [101.0, 102.0],
+            "low": [99.0, 100.0],
+            "close": [100.5, 101.5],
+            "volume": [1000.0, 1100.0],
+            "feat_regime": ["trend", "range"],
+            "feat_score": [0.75, 0.35],
+        }
+    )
+
+
+def test_runner_passes_timestamp_aligned_features_row(monkeypatch) -> None:
+    observed: Dict[str, Any] = {}
+
+    def _factory(strategy_type: str, strategy_id: str, params: Dict[str, Any]):
+        strat = _FeatureAwareDummyStrategy(strategy_id=strategy_id, params=params)
+        observed["strategy"] = strat
+        return strat
+
+    monkeypatch.setattr(strategies_runner, "create_strategy", _factory)
+    monkeypatch.setattr(
+        strategies_runner,
+        "_fetch_ohlc_for_symbol",
+        lambda symbol, asset_class, data_spec, instrument_spec: _build_ohlc_with_features(),
+    )
+
+    strategies_runner.run_backtest_from_spec(_build_spec("dummy_feature_aware"))
+
+    strategy = observed["strategy"]
+    assert len(strategy.rows) == 2
+    first_ts, first_features = strategy.rows[0]
+    second_ts, second_features = strategy.rows[1]
+    assert first_ts == pd.Timestamp("2024-01-01T00:00:00Z")
+    assert second_ts == pd.Timestamp("2024-01-02T00:00:00Z")
+    assert first_features == {"feat_regime": "trend", "feat_score": 0.75}
+    assert second_features == {"feat_regime": "range", "feat_score": 0.35}
+
+
+def test_runner_keeps_backward_compat_without_on_bar(monkeypatch) -> None:
+    monkeypatch.setattr(
+        strategies_runner,
+        "create_strategy",
+        lambda strategy_type, strategy_id, params: _LegacyDummyStrategy(strategy_id=strategy_id, params=params),
+    )
+    monkeypatch.setattr(
+        strategies_runner,
+        "_fetch_ohlc_for_symbol",
+        lambda symbol, asset_class, data_spec, instrument_spec: _build_ohlc_with_features(),
+    )
+
+    result = strategies_runner.run_backtest_from_spec(_build_spec("dummy_legacy"))
+
+    assert result["counts"]["SPY"] == 0


### PR DESCRIPTION
### Motivation
- Allow strategies (including DCA family) to consume per-bar market-intelligence features aligned to each bar timestamp.
- Ensure the feature injection is non-breaking for existing strategies by providing an opt-in per-bar handler and a `features_row=None` default.

### Description
- Extend the `Strategy` protocol in `src/quant_engine/strategies/base.py` with an `on_bar(bar, context, features_row=None)` method to receive a single bar and its optional features.
- Add `_extract_features_rows_by_ts` to `src/quant_engine/strategies/runner.py` to normalize timestamps, pick feature columns (excluding OHLC/meta), and build a timestamp->feature-row map.
- Update the runner to attach `features_by_ts` into `context` when features exist and to call `strategy.on_bar(...)` per bar with `features_row=` when implemented, otherwise fall back to `strategy.backtest(df, context)` for backward compatibility.
- Add tests in `tests/strategies/test_strategy_consumes_features.py` that validate timestamp-aligned `features_row` delivery and legacy fallback behavior.

### Testing
- Executed `poetry run pytest -q tests/strategies/test_strategy_consumes_features.py` and the test suite passed with `2 passed` (plus warnings) in ~1.8s.
- Tests cover feature extraction alignment and backward compatibility for strategies without `on_bar`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86ee60ae08323b8bf91c428075250)