### PR TITLE
PY-MI-3.3: add market_intelligence enabled toggle with OFF fallback mode

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -17,6 +17,7 @@ from ..core import dataset
 from ..core.contracts import MarketIntelligenceService
 from ..core.features import atr
 from ..core.spec import DataSpec, parse_data_spec, uses_strategy_sources
+from ..config import get_settings
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
 from ..performance.backtest_builder import build_backtest_payload
@@ -154,7 +155,11 @@ def _resolve_market_features(
     symbol: str,
     mi_service: MarketIntelligenceService | None,
 ) -> Mapping[str, Any]:
-    service = mi_service or _NullMarketIntelligenceService()
+    settings = get_settings()
+    if not settings.market_intelligence_enabled:
+        service = _NullMarketIntelligenceService()
+    else:
+        service = mi_service or _NullMarketIntelligenceService()
     frame = _rows_to_frame(rows)
     return service.build_snapshot(symbol, frame)
 

--- a/src/quant_engine/config.py
+++ b/src/quant_engine/config.py
@@ -20,6 +20,18 @@ class Settings:
     db_sqlite_path: str = ".db/quant.db"
     db_echo: bool = False
     mlflow_tracking_uri: str | None = None
+    market_intelligence_enabled: bool = False
+
+
+def _parse_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
 
 
 @lru_cache()
@@ -30,11 +42,16 @@ def get_settings() -> Settings:
     db_sqlite_path = os.getenv("DB_SQLITE_PATH", ".db/quant.db")
     db_echo = os.getenv("DB_ECHO", "false").lower() == "true"
     mlflow_tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
+    market_intelligence_enabled = _parse_bool(
+        os.getenv("MARKET_INTELLIGENCE_ENABLED"),
+        default=False,
+    )
     return Settings(
         db_dsn=db_dsn,
         db_sqlite_path=db_sqlite_path,
         db_echo=db_echo,
         mlflow_tracking_uri=mlflow_tracking_uri,
+        market_intelligence_enabled=market_intelligence_enabled,
     )
 
 

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -17,6 +17,7 @@ from sqlalchemy import create_engine, inspect, text
 
 from . import create_strategy
 from .base import StrategySignal
+from ..config import get_settings
 from ..integrations import java_client
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
@@ -138,6 +139,15 @@ def _extract_features_rows_by_ts(df: pd.DataFrame) -> Dict[pd.Timestamp, Dict[st
     return {pd.Timestamp(ts): row.to_dict() for ts, row in features.iterrows()}
 
 
+def _market_intelligence_enabled(spec: Mapping[str, Any]) -> bool:
+    mi_cfg = spec.get("market_intelligence") or {}
+    if isinstance(mi_cfg, Mapping) and "enabled" in mi_cfg:
+        value = mi_cfg.get("enabled")
+        if isinstance(value, bool):
+            return value
+    return get_settings().market_intelligence_enabled
+
+
 def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[str, pd.DataFrame]]:
     """Run the strategy backtest and return raw results plus OHLC cache."""
 
@@ -155,6 +165,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
     screening_cfg = optimization_cfg.get("screening") or spec.get("screening") or {}
     cache_cfg = optimization_cfg.get("cache_features") or {}
     cache_enabled = bool(cache_cfg) and cache_cfg.get("enabled", True) is not False
+    mi_enabled = _market_intelligence_enabled(spec)
     universe: Iterable[Mapping[str, Any]] = _expand_universe(spec)
     signals_by_symbol: Dict[str, List[Dict[str, Any]]] = {}
     counts: Dict[str, int] = {}
@@ -258,7 +269,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
         t_signals = time.monotonic()
         context = {"symbol": symbol, "asset_class": asset_class, "screening": screening_cfg}
         context = universe_adapter.adapt_context(context, universe_rules)
-        feature_rows_by_ts = _extract_features_rows_by_ts(df)
+        feature_rows_by_ts = _extract_features_rows_by_ts(df) if mi_enabled else {}
         if feature_rows_by_ts:
             context["features_by_ts"] = feature_rows_by_ts
         on_bar = getattr(strategy, "on_bar", None)

--- a/tests/integration/test_mi_toggle_on_off.py
+++ b/tests/integration/test_mi_toggle_on_off.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+import sys
+import types
+
+import pandas as pd
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+from quant_engine.backtest import runner as backtest_runner
+from quant_engine.config import reset_settings_cache
+from quant_engine.strategies.base import StrategySignal
+from quant_engine.strategies import runner as strategies_runner
+
+
+class _DummyMIService:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, int]] = []
+
+    def build_snapshot(self, symbol: str, ohlcv: pd.DataFrame) -> Dict[str, Any]:
+        self.calls.append((symbol, len(ohlcv)))
+        return {"symbol": symbol, "features": {"mi_mode": "on"}}
+
+
+class _FeatureAwareDummyStrategy:
+    def __init__(self, strategy_id: str, params: Dict[str, Any]) -> None:
+        self.strategy_id = strategy_id
+        self.params = params
+        self.rows: list[tuple[pd.Timestamp, Optional[Mapping[str, Any]]]] = []
+
+    def on_bar(
+        self,
+        bar: pd.Series,
+        context: Dict[str, Any],
+        features_row: Optional[Mapping[str, Any]] = None,
+    ) -> List[StrategySignal]:
+        self.rows.append((pd.Timestamp(bar.name), features_row))
+        return []
+
+
+def _build_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "EURUSD",
+            "open": 1.1,
+            "high": 1.2,
+            "low": 1.0,
+            "close": 1.15,
+            "volume": 100,
+        },
+        {
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "EURUSD",
+            "open": 1.2,
+            "high": 1.3,
+            "low": 1.1,
+            "close": 1.25,
+            "volume": 110,
+        },
+    ]
+
+
+BACKTEST_SPEC = {
+    "data": {"source": "csv", "path": "unused.csv", "symbol": "EURUSD", "start": "2024-01-01", "end": "2024-01-02"},
+    "strategy": {"asset_class": "FX"},
+    "signal": {"type": "ema_cross", "params": {"fast": 1, "slow": 2}},
+}
+
+
+def test_backtest_mi_toggle_on_off(monkeypatch) -> None:
+    monkeypatch.setattr(backtest_runner, "_load_rows", lambda *_args, **_kwargs: (_build_rows(), None))
+    observed: dict[str, Any] = {}
+    original_build_signal = backtest_runner._build_signal
+
+    def wrapped_build_signal(spec_input, rows, features=None):
+        observed["features"] = features
+        return original_build_signal(spec_input, rows, features)
+
+    monkeypatch.setattr(backtest_runner, "_build_signal", wrapped_build_signal)
+    mi_service = _DummyMIService()
+
+    monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", "false")
+    reset_settings_cache()
+    backtest_runner.run_backtest_from_spec(BACKTEST_SPEC, mi_service=mi_service)
+
+    assert mi_service.calls == []
+    assert observed["features"]["features"] == {}
+
+    monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", "true")
+    reset_settings_cache()
+    backtest_runner.run_backtest_from_spec(BACKTEST_SPEC, mi_service=mi_service)
+
+    assert mi_service.calls
+    assert observed["features"]["features"]["mi_mode"] == "on"
+
+
+def test_strategies_mi_toggle_on_off(monkeypatch) -> None:
+    observed: Dict[str, Any] = {}
+
+    def _factory(strategy_type: str, strategy_id: str, params: Dict[str, Any]):
+        strategy = _FeatureAwareDummyStrategy(strategy_id=strategy_id, params=params)
+        observed["strategy"] = strategy
+        return strategy
+
+    df = pd.DataFrame(
+        {
+            "ts": pd.to_datetime(["2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"], utc=True),
+            "open": [100.0, 101.0],
+            "high": [101.0, 102.0],
+            "low": [99.0, 100.0],
+            "close": [100.5, 101.5],
+            "volume": [1000.0, 1100.0],
+            "feat_regime": ["trend", "range"],
+        }
+    )
+
+    monkeypatch.setattr(strategies_runner, "create_strategy", _factory)
+    monkeypatch.setattr(
+        strategies_runner,
+        "_fetch_ohlc_for_symbol",
+        lambda symbol, asset_class, data_spec, instrument_spec: df.copy(),
+    )
+
+    spec = {
+        "strategy": {"type": "dummy", "strategy_id": "s1", "params": {}},
+        "universe": [{"symbol": "SPY", "asset_class": "ETF"}],
+        "data": {"source": "csv", "path": "unused.csv"},
+    }
+
+    monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", "false")
+    reset_settings_cache()
+    strategies_runner.run_backtest_from_spec(spec)
+    assert all(features is None for _, features in observed["strategy"].rows)
+
+    monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", "true")
+    reset_settings_cache()
+    strategies_runner.run_backtest_from_spec(spec)
+    assert observed["strategy"].rows[-1][1] == {"feat_regime": "range"}


### PR DESCRIPTION
### Motivation
- Provide a safe, configurable way to enable/disable Market Intelligence (MI) globally so existing runs keep legacy behavior when MI is not desired.
- Allow per-spec override for strategy runs while keeping the default behavior OFF to avoid breaking runs that don't expect MI data.

### Description
- Add `market_intelligence_enabled` to `Settings` and parse it from the `MARKET_INTELLIGENCE_ENABLED` environment variable with tolerant boolean parsing via `_parse_bool` in `src/quant_engine/config.py`.
- Gate backtest MI resolution in `src/quant_engine/backtest/runner.py` so `_resolve_market_features` uses the null adapter when `get_settings().market_intelligence_enabled` is false and uses the injected `mi_service` when enabled.
- Add `_market_intelligence_enabled` helper in `src/quant_engine/strategies/runner.py` to allow an optional per-spec `market_intelligence.enabled` override and only populate `features_by_ts` when MI is enabled.
- Add integration tests `tests/integration/test_mi_toggle_on_off.py` covering both backtest and strategy runner behavior for MI OFF (legacy null behaviour) and MI ON (service/features propagated).

### Testing
- Ran `poetry run pytest -q tests/integration/test_mi_toggle_on_off.py`; initial run showed one failing test due to missing date range in the test spec, the test was corrected and re-run.
- Final test run `poetry run pytest -q tests/integration/test_mi_toggle_on_off.py` succeeded with `2 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8700a86a08323b23a2a305d27dc99)