### PR TITLE
Add segmented performance metrics by regime and magnet_failure

### DIFF
--- a/src/quant_engine/performance/backtest_builder.py
+++ b/src/quant_engine/performance/backtest_builder.py
@@ -23,6 +23,46 @@ from .stress_tests import (
 )
 
 
+def _segment_value(meta: Mapping[str, Any], key: str) -> str:
+    value = meta.get(key)
+    if value is None:
+        return "unknown"
+    text = str(value).strip()
+    return text if text else "unknown"
+
+
+def _build_segmented_metrics(trades: List[CompletedTrade]) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    segmented: Dict[str, Dict[str, Dict[str, Any]]] = {"regime": {}, "magnet_failure": {}}
+    for trade in trades:
+        trade_meta = trade.meta if isinstance(trade.meta, Mapping) else {}
+        for segment_key in segmented.keys():
+            bucket = _segment_value(trade_meta, segment_key)
+            groups = segmented[segment_key]
+            if bucket not in groups:
+                groups[bucket] = {
+                    "trades": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "total_return_pct": 0.0,
+                    "average_trade_pct": 0.0,
+                    "winrate_pct": None,
+                }
+            row = groups[bucket]
+            row["trades"] += 1
+            if trade.gross_pnl_pct > 0:
+                row["wins"] += 1
+            else:
+                row["losses"] += 1
+            row["total_return_pct"] += float(trade.gross_pnl_pct)
+
+    for groups in segmented.values():
+        for row in groups.values():
+            trades_count = int(row["trades"])
+            row["average_trade_pct"] = (row["total_return_pct"] / trades_count) if trades_count else 0.0
+            row["winrate_pct"] = (row["wins"] / trades_count * 100.0) if trades_count else None
+    return segmented
+
+
 def _maybe_dt(value: Any) -> Optional[datetime]:
     if isinstance(value, datetime):
         return value
@@ -174,9 +214,13 @@ def build_backtest_performance(
         pnl = float(tr.get("pnl") or 0.0)
         pnl_pct = (pnl / entry_price * 100.0) if entry_price else 0.0
         returns_pct.append(pnl_pct)
-        meta = {
-            "r_multiple": tr.get("r_multiple"),
-        }
+        raw_meta = tr.get("meta") if isinstance(tr.get("meta"), Mapping) else {}
+        meta = dict(raw_meta)
+        meta.setdefault("r_multiple", tr.get("r_multiple"))
+        if "regime" not in meta:
+            meta["regime"] = tr.get("regime")
+        if "magnet_failure" not in meta:
+            meta["magnet_failure"] = tr.get("magnet_failure")
         completed.append(
             CompletedTrade(
                 strategy_id=strategy_id,
@@ -318,6 +362,7 @@ def build_backtest_performance(
             "periods_per_year": periods_per_year,
             "risk_free_rate": risk_free_rate,
             "cagr_pct": cagr_pct,
+            "segmentation": _build_segmented_metrics(completed),
         },
     )
     _perf_log("payload.build_backtest_performance", t0)

--- a/src/quant_engine/performance/dca_builder.py
+++ b/src/quant_engine/performance/dca_builder.py
@@ -67,6 +67,46 @@ def _extract_buy_cashflows(trade: CompletedTrade) -> List[Tuple[datetime, float]
 
 
 
+
+
+def _segment_value(meta: Mapping[str, Any], key: str) -> str:
+    value = meta.get(key)
+    if value is None:
+        return "unknown"
+    text = str(value).strip()
+    return text if text else "unknown"
+
+
+def _build_segmented_metrics(trades: List[CompletedTrade]) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    segmented: Dict[str, Dict[str, Dict[str, Any]]] = {"regime": {}, "magnet_failure": {}}
+    for trade in trades:
+        trade_meta = trade.meta if isinstance(trade.meta, Mapping) else {}
+        for segment_key in segmented.keys():
+            bucket = _segment_value(trade_meta, segment_key)
+            groups = segmented[segment_key]
+            if bucket not in groups:
+                groups[bucket] = {
+                    "trades": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "total_return_pct": 0.0,
+                    "average_trade_pct": 0.0,
+                    "winrate_pct": None,
+                }
+            row = groups[bucket]
+            row["trades"] += 1
+            if trade.gross_pnl_pct > 0:
+                row["wins"] += 1
+            else:
+                row["losses"] += 1
+            row["total_return_pct"] += float(trade.gross_pnl_pct)
+
+    for groups in segmented.values():
+        for row in groups.values():
+            trades_count = int(row["trades"])
+            row["average_trade_pct"] = (row["total_return_pct"] / trades_count) if trades_count else 0.0
+            row["winrate_pct"] = (row["wins"] / trades_count * 100.0) if trades_count else None
+    return segmented
 def _label_market_regime(return_pct: float) -> str:
     """Label market regime from window return.
 
@@ -336,6 +376,10 @@ def build_dca_performance_from_signals(
             tp_meta["position_qty"] = quantity
             tp_meta["pnl_pct_at_exit"] = gross_pnl_pct
             tp_meta["capital_used"] = capital_used
+            if "regime" not in tp_meta:
+                tp_meta["regime"] = "unknown"
+            if "magnet_failure" not in tp_meta:
+                tp_meta["magnet_failure"] = "unknown"
             if be_pct is not None:
                 try:
                     tp_meta["break_even_reached"] = gross_pnl_pct >= float(be_pct)
@@ -544,6 +588,7 @@ def build_dca_performance_from_signals(
             "dca_composite_score": dca_score,
             "dca_edge": dca_score.get("edge"),
             "dca_score": dca_score.get("score"),
+            "segmentation": _build_segmented_metrics(trades),
         },
     )
 

--- a/tests/performance/test_segmentation_by_regime.py
+++ b/tests/performance/test_segmentation_by_regime.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from quant_engine.performance.backtest_builder import build_backtest_payload
+from quant_engine.performance.dca_builder import build_backend_payload_for_java
+
+
+@dataclass
+class FakeSignal:
+    strategy_id: str
+    symbol: str
+    asset_class: str
+    side: str
+    ts_open_utc: datetime
+    qty: float
+    meta: Mapping[str, Any]
+
+
+def _make_signal(
+    *,
+    cycle_id: int,
+    side: str,
+    ts: datetime,
+    qty: float = 1.0,
+    action: str | None = None,
+    symbol: str = "ABC",
+    extra_meta: Mapping[str, Any] | None = None,
+) -> FakeSignal:
+    meta: dict[str, Any] = {"cycle_id": cycle_id}
+    if action is not None:
+        meta["action"] = action
+    if extra_meta:
+        meta.update(extra_meta)
+    return FakeSignal(
+        strategy_id="dca",
+        symbol=symbol,
+        asset_class="EQUITY",
+        side=side,
+        ts_open_utc=ts,
+        qty=qty,
+        meta=meta,
+    )
+
+
+def _make_ohlc(closes: list[float], start: str = "2024-01-01") -> pd.DataFrame:
+    dates = pd.date_range(start=start, periods=len(closes), freq="D", tz="UTC")
+    return pd.DataFrame({"ts": dates, "close": closes})
+
+
+def test_backtest_payload_exposes_segmentation_by_regime_and_magnet_failure() -> None:
+    payload = build_backtest_payload(
+        strategy_id="seg",
+        run_id="run-seg",
+        asset_class="EQUITY",
+        symbol="ABC",
+        timeframe="1D",
+        trades=[
+            {
+                "ts_entry": "2024-01-01T00:00:00Z",
+                "ts_exit": "2024-01-02T00:00:00Z",
+                "price_entry": 100.0,
+                "price_exit": 105.0,
+                "quantity": 1.0,
+                "pnl": 5.0,
+                "side": "LONG",
+                "meta": {"regime": "bull", "magnet_failure": False},
+            },
+            {
+                "ts_entry": "2024-01-03T00:00:00Z",
+                "ts_exit": "2024-01-04T00:00:00Z",
+                "price_entry": 100.0,
+                "price_exit": 95.0,
+                "quantity": 1.0,
+                "pnl": -5.0,
+                "side": "LONG",
+                "regime": "bear",
+                "magnet_failure": True,
+            },
+            {
+                "ts_entry": "2024-01-05T00:00:00Z",
+                "ts_exit": "2024-01-06T00:00:00Z",
+                "price_entry": 100.0,
+                "price_exit": 103.0,
+                "quantity": 1.0,
+                "pnl": 3.0,
+                "side": "LONG",
+                "meta": {"regime": "bull", "magnet_failure": True},
+            },
+        ],
+        equity=[0.0, 5.0, 0.0, 3.0],
+        start_ts="2024-01-01T00:00:00Z",
+        end_ts="2024-01-06T00:00:00Z",
+    )
+
+    segmentation = payload["run"]["extra"]["segmentation"]
+    bull = segmentation["regime"]["bull"]
+    bear = segmentation["regime"]["bear"]
+    failed = segmentation["magnet_failure"]["True"]
+    stable = segmentation["magnet_failure"]["False"]
+
+    assert bull["trades"] == 2
+    assert bull["wins"] == 2
+    assert bull["losses"] == 0
+    assert bull["winrate_pct"] == pytest.approx(100.0)
+    assert bear["trades"] == 1
+    assert bear["losses"] == 1
+    assert failed["trades"] == 2
+    assert stable["trades"] == 1
+
+
+def test_dca_payload_exposes_segmentation_by_regime_and_magnet_failure() -> None:
+    base = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    signals = [
+        _make_signal(cycle_id=1, side="BUY", ts=base, qty=1.0),
+        _make_signal(
+            cycle_id=1,
+            side="SELL",
+            ts=base.replace(day=2),
+            action="take_profit",
+            extra_meta={"regime": "bull", "magnet_failure": False},
+        ),
+        _make_signal(cycle_id=2, side="BUY", ts=base.replace(day=3), qty=1.0),
+        _make_signal(
+            cycle_id=2,
+            side="SELL",
+            ts=base.replace(day=4),
+            action="take_profit",
+            extra_meta={"regime": "bear", "magnet_failure": True},
+        ),
+    ]
+
+    payload = build_backend_payload_for_java(
+        strategy_id="dca",
+        run_id="run-seg-dca",
+        asset_class="EQUITY",
+        universe="ABC",
+        timeframe="1D",
+        signals_by_symbol={"ABC": signals},
+        ohlc_by_symbol={"ABC": _make_ohlc([100.0, 110.0, 120.0, 100.0], start="2024-06-01")},
+        config={"capital_per_unit": 100.0},
+    )
+
+    segmentation = payload["run"]["extra"]["segmentation"]
+    bull = segmentation["regime"]["bull"]
+    bear = segmentation["regime"]["bear"]
+    failed = segmentation["magnet_failure"]["True"]
+    stable = segmentation["magnet_failure"]["False"]
+
+    assert bull["trades"] == 1
+    assert bull["wins"] == 1
+    assert bear["trades"] == 1
+    assert bear["losses"] == 1
+    assert failed["trades"] == 1
+    assert stable["trades"] == 1


### PR DESCRIPTION
### Motivation
- Expose segmented performance metrics conditioned on `regime` and `magnet_failure` so analytics can report per-bucket trade statistics for backtests and DCA runs.
- Integrate segment aggregations into existing payloads without breaking current payload shape or downstream consumers.

### Description
- Add `_segment_value` and `_build_segmented_metrics` helpers and attach segmentation results under `run.extra["segmentation"]` for backtest payloads in `src/quant_engine/performance/backtest_builder.py`.
- Normalize trade `meta` when ingesting backtest trades to preserve compatibility and allow segmentation sources from either `meta` or top-level trade fields (`regime`/`magnet_failure`).
- Add the same segmentation helpers to `src/quant_engine/performance/dca_builder.py`, ensure `tp_meta` contains fallback `regime`/`magnet_failure` values when building `CompletedTrade`, and include segmentation in DCA `run.extra`.
- Add tests `tests/performance/test_segmentation_by_regime.py` covering both backtest and DCA payloads to validate per-bucket counts (`trades`, `wins`, `losses`, `winrate_pct`, etc.).

### Testing
- Ran `poetry run pytest -q tests/performance/test_segmentation_by_regime.py` and observed `2 passed`.
- Ran `poetry run pytest -q tests/test_performance_dca_builder.py::test_build_backend_payload_for_java_structure_and_meta tests/test_backtest_stress_sources.py::test_backtest_monte_carlo_source_trades_changes_output` and observed `2 passed, 1 warning` (tests succeeded; one DeprecationWarning from a datetime utility).
- No automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c714a07c8323a995faf7efee6770)