### PR TITLE
PY-MI-4.2: migrate feature-like stats functions to market_intelligence with compat wrappers

### DIFF
--- a/src/quant_engine/market_intelligence/conditions.py
+++ b/src/quant_engine/market_intelligence/conditions.py
@@ -1,0 +1,69 @@
+"""Condition feature functions for market intelligence."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def htf_trend(df: pd.DataFrame, *, tf_multiplier: int, ema_period: int) -> pd.Series:
+    """Return higher time frame trend as ``"up"`` or ``"down"``."""
+
+    groups = np.arange(len(df)) // tf_multiplier
+    htf_close = df["close"].groupby(groups).last()
+    ema = htf_close.ewm(span=ema_period, adjust=False).mean()
+    trend_per_group = pd.Series(
+        np.where(ema.diff() > 0, "up", "down"), index=htf_close.index
+    )
+    return pd.Series(groups).map(trend_per_group).astype("category")
+
+
+def vol_tertile(df: pd.DataFrame, *, window: int) -> pd.Series:
+    """Classify current ATR into tertiles across the sample."""
+
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    atr = tr.rolling(window).mean()
+    q1, q2 = atr.quantile([1 / 3, 2 / 3])
+    if q1 == q2:
+        tertiles = pd.Series(["mid"] * len(atr), index=atr.index)
+    else:
+        tertiles = pd.cut(atr, [-np.inf, q1, q2, np.inf], labels=["low", "mid", "high"])
+    return tertiles.astype("category")
+
+
+def session(df: pd.DataFrame, *, col: str = "session_id") -> pd.Series:
+    """Return the session label as a categorical series."""
+
+    return df[col].astype("category")
+
+
+def hour_bin(df: pd.DataFrame) -> pd.Series:
+    """Return hour-of-day bins (0-23) from timestamp column."""
+    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    return ts.dt.hour.astype("Int64")
+
+
+def day_of_week(df: pd.DataFrame) -> pd.Series:
+    """Return day-of-week bins (0=Mon..6=Sun)."""
+    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    return ts.dt.dayofweek.astype("Int64")
+
+
+def month_of_year(df: pd.DataFrame) -> pd.Series:
+    """Return month-of-year bins (1-12)."""
+    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    return ts.dt.month.astype("Int64")
+
+
+def session_from_ts(df: pd.DataFrame) -> pd.Series:
+    """Return a coarse session label from timestamp if session_id is missing."""
+    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    hours = ts.dt.hour
+    session_id = pd.Series("unknown", index=df.index)
+    session_id[(hours >= 23) | (hours < 7)] = "asia"
+    session_id[(hours >= 7) & (hours < 15)] = "london"
+    session_id[(hours >= 13) & (hours < 21)] = "newyork"
+    return session_id.astype("category")

--- a/src/quant_engine/market_intelligence/events.py
+++ b/src/quant_engine/market_intelligence/events.py
@@ -1,0 +1,94 @@
+"""Event feature functions for market intelligence."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def k_consecutive(df: pd.DataFrame, *, k: int, direction: str) -> pd.Series:
+    """Return ``True`` when ``k`` consecutive bars close in ``direction``."""
+
+    up = df["close"] > df["open"]
+    down = df["open"] > df["close"]
+    series = up if direction == "up" else down
+    return series.rolling(k).sum().eq(k).fillna(False)
+
+
+def shock_atr(df: pd.DataFrame, *, mult: float, window: int) -> pd.Series:
+    """True if the current true range exceeds ``mult`` times the ATR."""
+
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    atr = tr.rolling(window).mean()
+    return (tr > mult * atr).fillna(False)
+
+
+def breakout_hhll(df: pd.DataFrame, *, lookback: int, type: str) -> pd.Series:
+    """Detect breakout of higher highs or lower lows."""
+
+    if type == "hh":
+        ref = df["high"].shift(1).rolling(lookback, min_periods=1).max()
+        return (df["high"] > ref).fillna(False)
+    if type == "ll":
+        ref = df["low"].shift(1).rolling(lookback, min_periods=1).min()
+        return (df["low"] < ref).fillna(False)
+    raise ValueError("type must be 'hh' or 'll'")
+
+
+def bullish_candle(df: pd.DataFrame) -> pd.Series:
+    """True when close > open."""
+    return (df["close"] > df["open"]).fillna(False)
+
+
+def bearish_candle(df: pd.DataFrame) -> pd.Series:
+    """True when close < open."""
+    return (df["close"] < df["open"]).fillna(False)
+
+
+def bullish_engulfing(df: pd.DataFrame) -> pd.Series:
+    """True on bullish engulfing pattern."""
+    prev_open = df["open"].shift(1)
+    prev_close = df["close"].shift(1)
+    prev_bear = prev_close < prev_open
+    curr_bull = df["close"] > df["open"]
+    engulf = (df["close"] >= prev_open) & (df["open"] <= prev_close)
+    return (prev_bear & curr_bull & engulf).fillna(False)
+
+
+def bearish_engulfing(df: pd.DataFrame) -> pd.Series:
+    """True on bearish engulfing pattern."""
+    prev_open = df["open"].shift(1)
+    prev_close = df["close"].shift(1)
+    prev_bull = prev_close > prev_open
+    curr_bear = df["close"] < df["open"]
+    engulf = (df["open"] >= prev_close) & (df["close"] <= prev_open)
+    return (prev_bull & curr_bear & engulf).fillna(False)
+
+
+def bullish_streak(df: pd.DataFrame, *, k: int = 3) -> pd.Series:
+    """True when k consecutive bullish candles occur."""
+    return k_consecutive(df, k=k, direction="up")
+
+
+def bearish_streak(df: pd.DataFrame, *, k: int = 3) -> pd.Series:
+    """True when k consecutive bearish candles occur."""
+    return k_consecutive(df, k=k, direction="down")
+
+
+def gap_up(df: pd.DataFrame) -> pd.Series:
+    """True when current low is above previous high."""
+    prev_high = df["high"].shift(1)
+    return (df["low"] > prev_high).fillna(False)
+
+
+def gap_down(df: pd.DataFrame) -> pd.Series:
+    """True when current high is below previous low."""
+    prev_low = df["low"].shift(1)
+    return (df["high"] < prev_low).fillna(False)
+
+
+def always_true(df: pd.DataFrame) -> pd.Series:
+    """Always-true event for frequency calculations."""
+    return pd.Series(True, index=df.index)

--- a/src/quant_engine/stats/conditions.py
+++ b/src/quant_engine/stats/conditions.py
@@ -1,18 +1,30 @@
 """Regime condition helpers for statistics runs."""
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import Dict, Iterable, Optional, Tuple
 
-import numpy as np
 import pandas as pd
 
 from quant_engine.levels import helpers as lvl_helpers
 from quant_engine.levels import repo as lvl_repo
+from quant_engine.market_intelligence import conditions as mi_conditions
 
 
 LEVELS_TABLE = "marketdata.levels"
 _LEVELS_CACHE: Dict[Tuple[str, Optional[pd.Timestamp], Optional[pd.Timestamp], Tuple[str, ...]], pd.DataFrame] = {}
+
+
+def _warn_deprecated(func_name: str) -> None:
+    warnings.warn(
+        (
+            f"quant_engine.stats.conditions.{func_name} is deprecated and will be removed "
+            "in a future release; use quant_engine.market_intelligence.conditions instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 def _normalise_timestamp(series: pd.Series) -> pd.Series:
@@ -92,72 +104,52 @@ def _load_levels_for(df_symbol: pd.DataFrame, level_types: list[str]) -> pd.Data
 
 
 def htf_trend(df: pd.DataFrame, *, tf_multiplier: int, ema_period: int) -> pd.Series:
-    """Return higher time frame trend as ``"up"`` or ``"down"``.
+    """Return higher time frame trend as ``"up"`` or ``"down"``."""
 
-    The dataset is downsampled by ``tf_multiplier`` and an EMA of ``ema_period``
-    is computed on the resulting series.  Trend labels are then forward filled
-    to the original frequency.
-    """
-
-    groups = np.arange(len(df)) // tf_multiplier
-    htf_close = df["close"].groupby(groups).last()
-    ema = htf_close.ewm(span=ema_period, adjust=False).mean()
-    trend_per_group = pd.Series(
-        np.where(ema.diff() > 0, "up", "down"), index=htf_close.index
-    )
-    return pd.Series(groups).map(trend_per_group).astype("category")
+    _warn_deprecated("htf_trend")
+    return mi_conditions.htf_trend(df, tf_multiplier=tf_multiplier, ema_period=ema_period)
 
 
 def vol_tertile(df: pd.DataFrame, *, window: int) -> pd.Series:
     """Classify current ATR into tertiles across the sample."""
 
-    high, low, close = df["high"], df["low"], df["close"]
-    prev_close = close.shift(1)
-    tr = pd.concat(
-        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
-    ).max(axis=1)
-    atr = tr.rolling(window).mean()
-    q1, q2 = atr.quantile([1 / 3, 2 / 3])
-    if q1 == q2:
-        tertiles = pd.Series(["mid"] * len(atr), index=atr.index)
-    else:
-        tertiles = pd.cut(atr, [-np.inf, q1, q2, np.inf], labels=["low", "mid", "high"])
-    return tertiles.astype("category")
+    _warn_deprecated("vol_tertile")
+    return mi_conditions.vol_tertile(df, window=window)
 
 
 def session(df: pd.DataFrame, *, col: str = "session_id") -> pd.Series:
     """Return the session label as a categorical series."""
 
-    return df[col].astype("category")
+    _warn_deprecated("session")
+    return mi_conditions.session(df, col=col)
 
 
 def hour_bin(df: pd.DataFrame) -> pd.Series:
     """Return hour-of-day bins (0-23) from timestamp column."""
-    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
-    return ts.dt.hour.astype("Int64")
+
+    _warn_deprecated("hour_bin")
+    return mi_conditions.hour_bin(df)
 
 
 def day_of_week(df: pd.DataFrame) -> pd.Series:
     """Return day-of-week bins (0=Mon..6=Sun)."""
-    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
-    return ts.dt.dayofweek.astype("Int64")
+
+    _warn_deprecated("day_of_week")
+    return mi_conditions.day_of_week(df)
 
 
 def month_of_year(df: pd.DataFrame) -> pd.Series:
     """Return month-of-year bins (1-12)."""
-    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
-    return ts.dt.month.astype("Int64")
+
+    _warn_deprecated("month_of_year")
+    return mi_conditions.month_of_year(df)
 
 
 def session_from_ts(df: pd.DataFrame) -> pd.Series:
     """Return a coarse session label from timestamp if session_id is missing."""
-    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
-    hours = ts.dt.hour
-    session_id = pd.Series("unknown", index=df.index)
-    session_id[(hours >= 23) | (hours < 7)] = "asia"
-    session_id[(hours >= 7) & (hours < 15)] = "london"
-    session_id[(hours >= 13) & (hours < 21)] = "newyork"
-    return session_id.astype("category")
+
+    _warn_deprecated("session_from_ts")
+    return mi_conditions.session_from_ts(df)
 
 
 def in_zone_level(level_type: str, tolerance: float = 0.0) -> Callable[[pd.DataFrame, Optional[pd.DataFrame]], pd.Series]:
@@ -225,4 +217,3 @@ def list_condition_types() -> list[str]:
         if callable(obj):
             supported.append(name)
     return sorted(set(supported))
-

--- a/src/quant_engine/stats/events.py
+++ b/src/quant_engine/stats/events.py
@@ -1,115 +1,82 @@
-"""Event definitions for statistics runs."""
+"""Legacy event definitions for statistics runs.
+
+Deprecated wrappers around market-intelligence event feature functions.
+"""
 from __future__ import annotations
+
+import warnings
 
 import pandas as pd
 
+from quant_engine.market_intelligence import events as mi_events
+
+
+def _warn_deprecated(func_name: str) -> None:
+    warnings.warn(
+        (
+            f"quant_engine.stats.events.{func_name} is deprecated and will be removed "
+            "in a future release; use quant_engine.market_intelligence.events instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
 
 def k_consecutive(df: pd.DataFrame, *, k: int, direction: str) -> pd.Series:
-    """Return ``True`` when ``k`` consecutive bars close in ``direction``.
-
-    Parameters
-    ----------
-    df:
-        DataFrame containing at least ``open`` and ``close`` columns.
-    k:
-        Number of consecutive bars to check.
-    direction:
-        ``"up"`` for positive closes, ``"down"`` for negative closes.
-    """
-
-    up = df["close"] > df["open"]
-    down = df["open"] > df["close"]
-    series = up if direction == "up" else down
-    return series.rolling(k).sum().eq(k).fillna(False)
+    _warn_deprecated("k_consecutive")
+    return mi_events.k_consecutive(df, k=k, direction=direction)
 
 
 def shock_atr(df: pd.DataFrame, *, mult: float, window: int) -> pd.Series:
-    """True if the current true range exceeds ``mult`` times the ATR."""
-
-    high, low, close = df["high"], df["low"], df["close"]
-    prev_close = close.shift(1)
-    tr = pd.concat(
-        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
-    ).max(axis=1)
-    atr = tr.rolling(window).mean()
-    return (tr > mult * atr).fillna(False)
+    _warn_deprecated("shock_atr")
+    return mi_events.shock_atr(df, mult=mult, window=window)
 
 
 def breakout_hhll(df: pd.DataFrame, *, lookback: int, type: str) -> pd.Series:
-    """Detect breakout of higher highs or lower lows.
-
-    Parameters
-    ----------
-    df:
-        OHLC DataFrame.
-    lookback:
-        Number of bars to look back when computing the reference high/low.
-    type:
-        ``"hh"`` to detect new highs, ``"ll"`` for new lows.
-    """
-
-    if type == "hh":
-        ref = df["high"].shift(1).rolling(lookback, min_periods=1).max()
-        return (df["high"] > ref).fillna(False)
-    if type == "ll":
-        ref = df["low"].shift(1).rolling(lookback, min_periods=1).min()
-        return (df["low"] < ref).fillna(False)
-    raise ValueError("type must be 'hh' or 'll'")
+    _warn_deprecated("breakout_hhll")
+    return mi_events.breakout_hhll(df, lookback=lookback, type=type)
 
 
 def bullish_candle(df: pd.DataFrame) -> pd.Series:
-    """True when close > open."""
-    return (df["close"] > df["open"]).fillna(False)
+    _warn_deprecated("bullish_candle")
+    return mi_events.bullish_candle(df)
 
 
 def bearish_candle(df: pd.DataFrame) -> pd.Series:
-    """True when close < open."""
-    return (df["close"] < df["open"]).fillna(False)
+    _warn_deprecated("bearish_candle")
+    return mi_events.bearish_candle(df)
 
 
 def bullish_engulfing(df: pd.DataFrame) -> pd.Series:
-    """True on bullish engulfing pattern."""
-    prev_open = df["open"].shift(1)
-    prev_close = df["close"].shift(1)
-    prev_bear = prev_close < prev_open
-    curr_bull = df["close"] > df["open"]
-    engulf = (df["close"] >= prev_open) & (df["open"] <= prev_close)
-    return (prev_bear & curr_bull & engulf).fillna(False)
+    _warn_deprecated("bullish_engulfing")
+    return mi_events.bullish_engulfing(df)
 
 
 def bearish_engulfing(df: pd.DataFrame) -> pd.Series:
-    """True on bearish engulfing pattern."""
-    prev_open = df["open"].shift(1)
-    prev_close = df["close"].shift(1)
-    prev_bull = prev_close > prev_open
-    curr_bear = df["close"] < df["open"]
-    engulf = (df["open"] >= prev_close) & (df["close"] <= prev_open)
-    return (prev_bull & curr_bear & engulf).fillna(False)
+    _warn_deprecated("bearish_engulfing")
+    return mi_events.bearish_engulfing(df)
 
 
 def bullish_streak(df: pd.DataFrame, *, k: int = 3) -> pd.Series:
-    """True when k consecutive bullish candles occur."""
-    return k_consecutive(df, k=k, direction="up")
+    _warn_deprecated("bullish_streak")
+    return mi_events.bullish_streak(df, k=k)
 
 
 def bearish_streak(df: pd.DataFrame, *, k: int = 3) -> pd.Series:
-    """True when k consecutive bearish candles occur."""
-    return k_consecutive(df, k=k, direction="down")
+    _warn_deprecated("bearish_streak")
+    return mi_events.bearish_streak(df, k=k)
 
 
 def gap_up(df: pd.DataFrame) -> pd.Series:
-    """True when current low is above previous high."""
-    prev_high = df["high"].shift(1)
-    return (df["low"] > prev_high).fillna(False)
+    _warn_deprecated("gap_up")
+    return mi_events.gap_up(df)
 
 
 def gap_down(df: pd.DataFrame) -> pd.Series:
-    """True when current high is below previous low."""
-    prev_low = df["low"].shift(1)
-    return (df["high"] < prev_low).fillna(False)
+    _warn_deprecated("gap_down")
+    return mi_events.gap_down(df)
 
 
 def always_true(df: pd.DataFrame) -> pd.Series:
-    """Always-true event for frequency calculations."""
-    return pd.Series(True, index=df.index)
-
+    _warn_deprecated("always_true")
+    return mi_events.always_true(df)

--- a/tests/stats/test_stats_compat_wrappers.py
+++ b/tests/stats/test_stats_compat_wrappers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from quant_engine.market_intelligence import conditions as mi_conditions
+from quant_engine.market_intelligence import events as mi_events
+from quant_engine.stats import conditions as stats_conditions
+from quant_engine.stats import events as stats_events
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.date_range("2024-01-01", periods=6, freq="h", tz="UTC"),
+            "open": [100, 101, 102, 101, 103, 104],
+            "high": [101, 102, 103, 104, 105, 106],
+            "low": [99, 100, 101, 100, 102, 103],
+            "close": [101, 102, 101, 103, 104, 103],
+            "session_id": ["asia", "asia", "london", "london", "newyork", "newyork"],
+        }
+    )
+
+
+def test_stats_event_wrapper_matches_mi_and_warns() -> None:
+    df = _sample_df()
+
+    expected = mi_events.gap_up(df)
+    with pytest.warns(DeprecationWarning):
+        observed = stats_events.gap_up(df)
+
+    pd.testing.assert_series_equal(observed, expected)
+
+
+def test_stats_condition_wrapper_matches_mi_and_warns() -> None:
+    df = _sample_df()
+
+    expected = mi_conditions.day_of_week(df)
+    with pytest.warns(DeprecationWarning):
+        observed = stats_conditions.day_of_week(df)
+
+    pd.testing.assert_series_equal(observed, expected)


### PR DESCRIPTION
### Motivation
- Separate purely feature-like calculations from `stats` into a dedicated `market_intelligence` module to clarify responsibilities and enable reuse. 
- Preserve backward compatibility for existing `stats` consumers by keeping the original function signatures. 

### Description
- Added MI feature modules `src/quant_engine/market_intelligence/events.py` and `src/quant_engine/market_intelligence/conditions.py` containing the moved event- and condition-style feature functions. 
- Replaced implementations in `src/quant_engine/stats/events.py` with thin compatibility wrappers that delegate to the new MI implementations and emit a soft `DeprecationWarning` via `warnings.warn(...)`. 
- Converted purely-calculated functions in `src/quant_engine/stats/conditions.py` (`htf_trend`, `vol_tertile`, `session`, `hour_bin`, `day_of_week`, `month_of_year`, `session_from_ts`) into deprecated wrappers delegating to `quant_engine.market_intelligence.conditions`, while leaving levels-backed factories (`in_zone_level`, `distance_to_level`, `touched_level_since`) intact. 
- Added `tests/stats/test_stats_compat_wrappers.py` to assert wrappers produce identical output to MI functions and that they emit `DeprecationWarning`.

### Testing
- Ran `poetry run pytest -q tests/stats/test_stats_compat_wrappers.py` and observed `2 passed`, verifying wrapper outputs and deprecation warnings. 
- No other automated test changes were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c89ffbf08323811911f885abe62b)