### PR TITLE
Add optional MI-label segmentation to seasonality profiles

### DIFF
--- a/src/quant_engine/api/schemas.py
+++ b/src/quant_engine/api/schemas.py
@@ -354,6 +354,7 @@ class SeasonalityProfileSpec(BaseModel):
     by_month_last_days: bool = False
     by_quarter: bool = False
     by_month_flags: bool = False
+    segment_by_mi_labels: bool = False
     # mesure : 'direction' (P(close_{t+1} > close_t)) ou 'return'
     measure: Literal["direction", "return"] = "direction"
     ret_horizon: int = 1  # nb de barres Ã  regarder

--- a/src/quant_engine/seasonality/compute.py
+++ b/src/quant_engine/seasonality/compute.py
@@ -676,6 +676,8 @@ def _empty_profiles_table(
     symbol_type = df.schema.get("symbol", pl.Utf8)
     base_schema: list[tuple[str, pl.PolarsDataType]] = [
         ("symbol", symbol_type),
+        ("mi_label_name", pl.Utf8),
+        ("mi_label_value", pl.Utf8),
         ("dim", pl.Utf8),
         ("bin", pl.Int64),
         ("n", pl.Int64),
@@ -753,6 +755,7 @@ def compute_profiles(
     period_start: datetime | None = None,
     period_end: datetime | None = None,
     artifacts_out_dir: str | None = None,
+    segment_by_mi_labels: bool = False,
 ) -> pl.DataFrame:
     """Compute seasonality profiles and optionally persist them to parquet."""
 
@@ -766,23 +769,47 @@ def compute_profiles(
 
     dims = _collect_profile_dimensions(profile)
 
+    mi_label_columns = [col for col in dataset.columns if str(col).startswith("label_")]
+
     tables: list[pl.DataFrame] = []
     for dim in dims:
         if dim not in dataset.columns:
             continue
-        group_cols: list[str] = ["symbol", dim]
-        if profile.measure == "direction":
-            table = profile_direction(dataset, group_cols, horizon, profile.min_samples_bin)
-        else:
-            table = profile_return(dataset, group_cols, horizon, profile.min_samples_bin)
-        if table.is_empty():
-            continue
-        table = table.rename({dim: "bin"})
-        table = table.with_columns(
-            pl.col("bin").cast(pl.Utf8),
-            pl.lit(dim).alias("dim"),
-        )
-        tables.append(table)
+        aggregation_specs: list[tuple[list[str], str | None]] = [(["symbol", dim], None)]
+        if segment_by_mi_labels:
+            aggregation_specs.extend(
+                (["symbol", label_col, dim], label_col) for label_col in mi_label_columns
+            )
+
+        for group_cols, mi_label_col in aggregation_specs:
+            if mi_label_col is not None:
+                filtered_dataset = dataset.filter(pl.col(mi_label_col).is_not_null())
+            else:
+                filtered_dataset = dataset
+            if filtered_dataset.is_empty():
+                continue
+
+            if profile.measure == "direction":
+                table = profile_direction(filtered_dataset, group_cols, horizon, profile.min_samples_bin)
+            else:
+                table = profile_return(filtered_dataset, group_cols, horizon, profile.min_samples_bin)
+            if table.is_empty():
+                continue
+
+            rename_map = {dim: "bin"}
+            if mi_label_col is not None:
+                rename_map[mi_label_col] = "mi_label_value"
+            table = table.rename(rename_map)
+            table = table.with_columns(
+                pl.col("bin").cast(pl.Utf8),
+                pl.lit(dim).alias("dim"),
+                pl.lit(mi_label_col, dtype=pl.Utf8).alias("mi_label_name"),
+            )
+            if mi_label_col is None:
+                table = table.with_columns(pl.lit(None, dtype=pl.Utf8).alias("mi_label_value"))
+            else:
+                table = table.with_columns(pl.col("mi_label_value").cast(pl.Utf8))
+            tables.append(table)
 
     if tables:
         combined = pl.concat(tables, how="vertical", rechunk=True)
@@ -802,6 +829,8 @@ def compute_profiles(
         ordered_cols = [
             "symbol",
             "timeframe",
+            "mi_label_name",
+            "mi_label_value",
             "dim",
             "bin",
             "n",
@@ -821,6 +850,8 @@ def compute_profiles(
         ordered_cols = [
             "symbol",
             "timeframe",
+            "mi_label_name",
+            "mi_label_value",
             "dim",
             "bin",
             "n",

--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -19,6 +19,7 @@ from ..core.dataset import load_ohlcv
 from ..core.features import atr
 from ..io import artifacts, ids
 from ..signals.seasonality_signal import DIMENSION_TO_COLUMN, make_seasonality_signals
+from ..market_intelligence.pipeline import compute_features as mi_compute_features, label_regimes as mi_label_regimes
 from ..validate import splitter
 from ..persistence import db
 from ..persistence.repo import (
@@ -295,12 +296,45 @@ def _default_rules_metadata(rules: profiles.SeasonalityRules) -> Dict[str, Any]:
     return meta
 
 
+def _attach_mi_labels(dataset: pl.DataFrame, enabled: bool) -> pl.DataFrame:
+    """Attach market-intelligence label columns keyed by symbol/timestamp."""
+
+    if not enabled or dataset.is_empty() or "timestamp" not in dataset.columns or "symbol" not in dataset.columns:
+        return dataset
+
+    labels_frames: list[pl.DataFrame] = []
+    for symbol in dataset.get_column("symbol").drop_nulls().unique().to_list():
+        symbol_df = dataset.filter(pl.col("symbol") == symbol).sort("timestamp")
+        if symbol_df.is_empty():
+            continue
+        symbol_pd = symbol_df.select(["timestamp", "open", "high", "low", "close", "volume"]).to_pandas()
+        symbol_pd = symbol_pd.rename(columns={"timestamp": "ts"})
+        features = mi_compute_features(symbol_pd)
+        labels = mi_label_regimes(features).reset_index().rename(columns={"ts": "timestamp"})
+        labels["symbol"] = symbol
+        labels_pl = pl.from_pandas(labels)
+        if "timestamp" in labels_pl.columns and labels_pl.schema.get("timestamp") != pl.Datetime:
+            labels_pl = labels_pl.with_columns(pl.col("timestamp").cast(pl.Datetime))
+        labels_frames.append(labels_pl)
+
+    if not labels_frames:
+        return dataset
+
+    all_labels = pl.concat(labels_frames, how="vertical", rechunk=True)
+    join_cols = ["symbol", "timestamp"]
+    label_cols = [col for col in all_labels.columns if col.startswith("label_")]
+    if not label_cols:
+        return dataset
+    return dataset.join(all_labels.select(join_cols + label_cols), on=join_cols, how="left", coalesce=True)
+
+
 def _compute_profiles(
     dataset: pl.DataFrame,
     cfg: spec.NormalisedSeasonalitySpec,
     fold_dir: Path | None,
 ) -> pl.DataFrame:
     horizon_features = compute.prepare_features(dataset, cfg.profile)
+    horizon_features = _attach_mi_labels(horizon_features, bool(getattr(cfg.profile, "segment_by_mi_labels", False)))
     profiles_path = str(fold_dir) if fold_dir is not None else None
     return compute.compute_profiles(
         horizon_features,
@@ -309,6 +343,7 @@ def _compute_profiles(
         period_start=None,
         period_end=None,
         artifacts_out_dir=profiles_path,
+        segment_by_mi_labels=bool(getattr(cfg.profile, "segment_by_mi_labels", False)),
     )
 
 

--- a/tests/integration/test_seasonality_with_mi_labels.py
+++ b/tests/integration/test_seasonality_with_mi_labels.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import sys
+import types
+
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_cursors_stub = types.ModuleType("pymysql.cursors")
+    pymysql_cursors_stub.DictCursor = object
+    pymysql_stub.cursors = pymysql_cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = pymysql_cursors_stub
+
+from quant_engine.api import schemas
+from quant_engine.seasonality import runner, spec as seasonality_spec
+
+pl = pytest.importorskip("polars")
+
+
+def _build_train_df() -> "pl.DataFrame":
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    rows = []
+    price = 100.0
+    for idx in range(96):
+        ts = start + timedelta(hours=idx)
+        drift = 0.6 if idx < 48 else -0.4
+        close = price + drift
+        rows.append(
+            {
+                "timestamp": ts,
+                "symbol": "BTC-USD",
+                "open": price,
+                "high": max(price, close) + 0.5,
+                "low": min(price, close) - 0.5,
+                "close": close,
+                "volume": 1_000 + idx,
+            }
+        )
+        price = close
+    return pl.DataFrame(rows)
+
+
+def test_seasonality_profiles_include_global_and_mi_segmented_stats() -> None:
+    train_df = _build_train_df()
+    model = schemas.SeasonalitySpec(
+        data=schemas.SeasonalityDataSpec(
+            symbols=["BTC-USD"],
+            timeframe="H1",
+            start="2025-01-01",
+            end="2025-01-10",
+        ),
+        profile=schemas.SeasonalityProfileSpec(
+            by_hour=True,
+            by_dow=False,
+            measure="direction",
+            ret_horizon=1,
+            min_samples_bin=1,
+            segment_by_mi_labels=True,
+        ),
+    )
+    cfg = seasonality_spec.normalise(model)
+
+    profiles_df = runner._compute_profiles(train_df, cfg, fold_dir=None)
+
+    assert not profiles_df.is_empty()
+    assert {"mi_label_name", "mi_label_value"}.issubset(set(profiles_df.columns))
+
+    global_rows = profiles_df.filter(pl.col("mi_label_name").is_null())
+    segmented_rows = profiles_df.filter(pl.col("mi_label_name").is_not_null())
+
+    assert global_rows.height > 0
+    assert segmented_rows.height > 0
+    assert set(segmented_rows.get_column("mi_label_name").unique().to_list()) == {"label_regime"}
+    assert all(v is not None for v in segmented_rows.get_column("mi_label_value").to_list())


### PR DESCRIPTION
### Motivation

- Make seasonality segmentation by Market Intelligence (MI) labels optional and attach MI labels to the time-index so we can compute both global and MI-segmented profiles.
- Emit both global stats and segmented stats per MI `label_*` column to support downstream rule selection and analysis.

### Description

- Added a new boolean flag `segment_by_mi_labels` to `SeasonalityProfileSpec` to toggle MI segmentation. (`src/quant_engine/api/schemas.py`)
- Extended `compute.compute_profiles` to include `mi_label_name` and `mi_label_value` in the profiles schema and to produce global rows plus optional segmented rows per `label_*` column when `segment_by_mi_labels=True`. (`src/quant_engine/seasonality/compute.py`)
- Implemented `_attach_mi_labels` in the runner which computes MI features and regime labels per symbol/timestamp and left-joins MI `label_*` columns onto the prepared features; the runner passes `segment_by_mi_labels` through to `compute_profiles`. (`src/quant_engine/seasonality/runner.py`)
- Added an integration test `tests/integration/test_seasonality_with_mi_labels.py` validating that profiles contain both global and MI-segmented rows with `mi_label_name`/`mi_label_value` populated.

### Testing

- Ran `poetry run pytest -q tests/integration/test_seasonality_with_mi_labels.py`; initial collection failed due to a missing `pymysql` import which was addressed by adding a lightweight import stub in the test, then re-ran tests.
- Final test execution in this environment resulted in the test being skipped because `polars` is not installed (test uses `pytest.importorskip("polars")`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8cc05168883238919c93182cfe848)