### PR TITLE
Introduce Market Intelligence architecture doc and MI epic roadmap/tickets

### DIFF
--- a/docs/architecture_market_intelligence_refactor.md
+++ b/docs/architecture_market_intelligence_refactor.md
@@ -1,0 +1,387 @@
+# Refactor architecture — Market Intelligence Layer
+
+## 1) Audit de la structure actuelle
+
+### Packages top-level observés
+
+Le package principal `quant_engine` contient actuellement les sous-modules suivants :
+
+- `api`, `backtest`, `cli`, `core`, `datafeeds`, `execution`, `filters`, `integrations`, `io`, `levels`, `live`, `notify`, `optimize`, `performance`, `persistence`, `seasonality`, `signals`, `stats`, `strategies`, `tpsl`, `validate`.
+
+### Points de couplage élevés / "god modules"
+
+- **`api/app.py` (~4000 lignes)** : concentre orchestration, endpoints, jobs async/sync, persistence et dispatch métier.
+- **`optimize/variants.py` (~2500 lignes)** : logique très volumineuse orientée variantes.
+- **`performance/stress_tests.py` (~1900 lignes)** : contrat + implémentation de stress tests (MC/scénarios) dans un seul fichier.
+- **`strategies/runner.py` (~1500 lignes)** : orchestration multi-stratégies + exécution.
+
+Ces fichiers sont des candidats prioritaires pour une extraction par responsabilités.
+
+### Frontières actuellement fragiles
+
+- `api/app.py` importe directement backtest, stats, seasonality, strategies, optimize, stress tests : couche application très couplée aux détails d’implémentation.
+- `stats/runner.py` dépend de `api.schemas.StatsSpec`, ce qui inverse la dépendance (le domaine stats devrait dépendre de modèles domaine, pas de l’API HTTP).
+- Plusieurs calculs de "régime/liquidité" existent déjà dans `filters/*` alors que ces signaux devraient être centralisés dans une future couche **market_intelligence**.
+
+### Cycles d’import
+
+- Aucune boucle d’import détectée au niveau module lors d’un scan AST interne (bonne base).
+
+### Duplications de responsabilité (fonctionnelles)
+
+- **Stats vs Filters vs Seasonality** : chaque module calcule des transformations de marché (événements, conditions, patterns) avec des conventions différentes.
+- **Signal enrichments** dispersés entre `filters`, `stats.events`, `stats.conditions`, `signals`.
+
+Conséquence : difficulté à réutiliser des features de manière cohérente entre backtest, DCA, stress-tests et analytics.
+
+---
+
+## 2) Architecture cible proposée
+
+Objectif : introduire une couche **Market Intelligence Layer** faiblement couplée et consommée via interfaces.
+
+```text
+quant_engine/
+  core/
+    domain/
+      models.py            # Candle, Trade, Position, Portfolio, RunResult
+      enums.py
+    contracts/
+      market_intelligence.py
+      strategy.py
+      feature_store.py
+      data_provider.py
+    time/
+    utils/
+
+  data/
+    providers/             # mysql, parquet, api
+    loaders/
+    alignment/             # multi-asset sync, calendars, joins
+
+  indicators/
+    trend/
+    vol/
+    volume/
+    structure/
+
+  market_intelligence/
+    pipeline.py
+    service.py
+    models.py              # FeatureFrame, RegimeLabel, LiquidityFlags...
+    correlation/
+      rolling.py
+      lead_lag.py
+    regime/
+      detectors.py
+      labels.py
+    liquidity/
+      signals.py
+      magnet_failure.py
+    structure/
+      market_structure.py
+
+  strategy_engine/
+    base.py                # StrategyProtocol
+    adapters/
+    implementations/
+
+  backtest_engine/
+    engine.py
+    execution.py
+    portfolio.py
+    event_loop.py
+
+  dca_engine/
+    engine.py
+    schedulers.py
+
+  stress_test_engine/
+    engine.py
+    scenarios.py
+    monte_carlo.py
+    regime_shift.py
+
+  performance_analytics/
+    metrics.py
+    attribution.py
+    segmentation.py        # per-regime, per-flag analytics
+
+  seasonality/
+    profiles.py
+    compute.py
+
+  api_or_cli/
+    api/
+    cli/
+```
+
+### Pourquoi cette structuration
+
+- `core`: noyau stable (objets métier + contrats abstraits).
+- `data`: accès et normalisation des datasets (pas de logique stratégique).
+- `indicators`: primitives de calcul réutilisables (EMA/ATR/etc.).
+- `market_intelligence`: composition de primitives en features/scores business (corrélation, régime, liquidité, structure).
+- `strategy_engine`: décision d’allocation/entry/exit ; **consomme** les features, ne les calcule pas.
+- `backtest_engine` + `dca_engine`: moteurs d’exécution indépendants, branchés sur les mêmes contrats.
+- `stress_test_engine`: simulation post-run ou in-run, branchée sur outputs standards (returns/equity/trades).
+- `performance_analytics`: métriques + segmentation par labels MI.
+- `api_or_cli`: uniquement couche d’exposition/orchestration.
+
+---
+
+## 3) Interfaces / contrats
+
+### Modèles communs (core.domain)
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Optional
+
+@dataclass(frozen=True)
+class Candle:
+    ts: datetime
+    symbol: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+@dataclass(frozen=True)
+class Trade:
+    ts_open: datetime
+    ts_close: Optional[datetime]
+    symbol: str
+    side: str
+    qty: float
+    entry: float
+    exit: Optional[float]
+    pnl: Optional[float]
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    qty: float
+    avg_price: float
+
+@dataclass(frozen=True)
+class Portfolio:
+    cash: float
+    equity: float
+    positions: Mapping[str, Position]
+```
+
+### FeatureStore / FeaturePipeline
+
+```python
+from typing import Protocol
+import pandas as pd
+
+class FeatureStore(Protocol):
+    def get(self, feature_set: str, symbol: str, timeframe: str) -> pd.DataFrame | None: ...
+    def put(self, feature_set: str, symbol: str, timeframe: str, frame: pd.DataFrame) -> None: ...
+
+class FeaturePipeline(Protocol):
+    name: str
+    version: str
+    def compute(self, candles: pd.DataFrame) -> pd.DataFrame: ...
+```
+
+### MarketIntelligenceService API
+
+```python
+class MarketIntelligenceService(Protocol):
+    def compute_features(self, symbol: str, timeframe: str, candles: pd.DataFrame) -> pd.DataFrame: ...
+    def get_feature_slice(self, symbol: str, timeframe: str, start_ts, end_ts) -> pd.DataFrame: ...
+    def label_regimes(self, symbol: str, timeframe: str, candles: pd.DataFrame) -> pd.Series: ...
+    def liquidity_flags(self, symbol: str, timeframe: str, candles: pd.DataFrame) -> pd.DataFrame: ...
+```
+
+### Strategy API (consommation sans calcul)
+
+```python
+class Strategy(Protocol):
+    name: str
+    def on_bar(self, candle: Candle, features_row: dict, portfolio: Portfolio) -> list[dict]: ...
+```
+
+Le moteur fournit `features_row` ; la stratégie ne connaît ni pipeline ni stockage.
+
+---
+
+## 4) Règles de dépendances explicites
+
+Règles cibles à faire respecter par convention + tests d’architecture :
+
+1. `market_intelligence` -> dépend de `data`, `indicators`, `core`.
+2. `strategy_engine` -> dépend de `core` + contrats `market_intelligence` (pas implémentation concrète).
+3. `backtest_engine` -> dépend de `strategy_engine`, `core`, contrats MI.
+4. `dca_engine` -> dépend de `strategy_engine` (ou `portfolio policies`) + `core` + contrats MI.
+5. `performance_analytics` -> dépend de sorties normalisées backtest/DCA + labels MI.
+6. `stress_test_engine` -> dépend de sorties normalisées + utilitaires randomization partagés.
+7. **Interdits**:
+   - `market_intelligence` n’importe jamais `backtest_engine`, `api_or_cli`, `performance_analytics`.
+   - `strategy_engine` n’importe jamais `api_or_cli`.
+   - `core` n’importe aucun module métier haut niveau.
+
+Exemple de garde-fou (test simple) :
+
+```python
+# tests/architecture/test_import_rules.py
+FORBIDDEN = {
+    "quant_engine.market_intelligence": ["quant_engine.backtest_engine", "quant_engine.api_or_cli"],
+}
+```
+
+---
+
+## 5) Plan de refactor incrémental (risque minimal)
+
+### PR1 — Poser les contrats sans déplacer le code
+
+- Créer `core/contracts/*` + modèles de base.
+- Ajouter des adapters qui enveloppent les modules existants (`stats`, `filters`) sans changer leur API publique.
+- Ajouter tests unitaires des contrats (shape des retours, colonnes obligatoires).
+
+### PR2 — Introduire `market_intelligence` en façade
+
+- Créer `market_intelligence/service.py` avec implémentation initiale qui délègue à l’existant (`filters.market_regime`, `filters.liquidity`, etc.).
+- Ajouter `FeatureStore` (in-memory + parquet) avec clé `(feature_set, symbol, timeframe, version)`.
+- Ajouter CLI: `qe features recompute ...` (non-breaking).
+
+### PR3 — Brancher backtest & DCA sur MI
+
+- Injecter `MarketIntelligenceService` dans les moteurs (dependency injection).
+- Les stratégies lisent `features_row` fourni par le moteur.
+- Garder fallback legacy via adapter pour éviter régression.
+
+### PR4 — Segmentation performance par régimes/flags
+
+- Ajouter dans `performance_analytics` des vues segmentées :
+  - métriques globales
+  - métriques conditionnées (`regime=bull`, `magnet_failure=True`)
+- Snapshot tests JSON pour stabiliser le format des rapports.
+
+### PR5 — Migrer progressivement `stats` vers MI
+
+- Déplacer d’abord les fonctions purement "feature computation" (events/conditions non causales de target).
+- Laisser les agrégateurs statistiques dans `stats`.
+- Déprécier API ancienne avec warnings + fenêtre de compatibilité.
+
+### PR6 — Nettoyage et verrouillage d’architecture
+
+- Réduire `api/app.py` en route handlers fins + application services.
+- Ajouter tests d’architecture (imports interdits).
+- Documenter le graphe de dépendances officiel dans `docs/`.
+
+### Stratégie de tests
+
+- **Unitaires**: détecteurs MI, normalisation features, feature store.
+- **Intégration**: run backtest minimal + MI ON/OFF, run DCA minimal + MI labels.
+- **Snapshot**: payload performance et stress-tests segmentés.
+- **Non-régression**: comparer KPIs principaux avant/après sur 2-3 specs de référence.
+
+---
+
+## 6) Recommandations complémentaires
+
+### Pattern recommandé
+
+- **Ports & Adapters (hexagonal light)** :
+  - Ports: `MarketIntelligenceService`, `FeatureStore`, `Strategy`.
+  - Adapters: wrappers legacy (`filters`, `stats`, `persistence`).
+- DDD “light” sur le noyau : entités/VO dans `core.domain`, services applicatifs dans les engines.
+
+### Configuration
+
+- Centraliser config via fichiers versionnés (YAML/JSON) :
+  - pipeline features (`windows`, `thresholds`, `assets`, `timeframes`)
+  - params stratégies
+- Inclure `config_hash` dans artefacts pour reproductibilité.
+
+### Caching
+
+- L1: cache mémoire par run (dict/LRU).
+- L2: cache disque parquet partitionné (`feature_set/symbol/timeframe/date`).
+- Invalidation par `(pipeline_version, data_hash)`.
+
+### Multi-actifs et synchronisation temporelle
+
+- Créer `data/alignment` avec :
+  - calendrier de référence
+  - forward-fill contrôlé (max gap)
+  - stratégie explicite des trous de données
+- Imposer index temporel UTC unique dans toutes les features.
+
+### CLI utile
+
+- `qe features recompute --feature-set mi_v1 --symbol BTCUSDT --tf 1h --from ... --to ...`
+- `qe features inspect --feature-set mi_v1 --symbol BTCUSDT --tf 1h`
+- `qe backtest run --with-features mi_v1`
+
+---
+
+## 7) Clarification importante — capacités métier vs modules Python
+
+Tu as raison : dans le projet actuel, tout n’est **pas** un module isolé. Certaines briques sont des
+capacités métier réparties sur plusieurs fichiers.
+
+### Cartographie recommandée (état cible simple)
+
+| Capacité métier | Aujourd’hui (principalement) | Cible recommandée |
+|---|---|---|
+| Backtest | `backtest/*` + morceaux dans `strategies/*`, `performance/*`, `api/app.py` | `backtest_engine/*` |
+| DCA | `strategies/dca_*`, `performance/dca_builder.py`, `io/dca_artifacts.py` | `dca_engine/*` + `performance_analytics/*` |
+| Stress tests | `performance/stress_tests.py` | `stress_test_engine/*` |
+| Performance analytics | `performance/backtest_builder.py`, `performance/dca_builder.py` | `performance_analytics/*` |
+| Market stats (proba/conditions/événements) | `stats/*` + partie `filters/*` | `market_intelligence/*` (features/labels) + `stats/*` (agrégation/stat inference) |
+| Seasonality | `seasonality/*` | `seasonality/*` (reste module dédié, alimenté par MI au besoin) |
+| Optimisation | `optimize/*` | `optimize/*` (orchestrateur de variantes branché sur moteurs + contrats MI) |
+
+### Optimisation : moteur d’exécution ou orchestrateur ?
+
+Réponse courte : **dans cette architecture, `optimize` est un orchestrateur d’expériences (méta-couche), pas le moteur d’exécution principal**.
+
+- Un **moteur d’exécution** consomme une série temporelle + des signaux et simule positions/fills/équité (ex: backtest, DCA).
+- L’**optimisation** boucle sur des jeux de paramètres (`trials`), appelle les moteurs, compare des objectifs (Sharpe, drawdown, contraintes), puis promeut les meilleurs candidats.
+- Donc `optimize` “exécute des runs”, mais **n’implémente pas lui-même** la mécanique d’exécution des ordres/trades ; il la délègue à `backtest`/`strategy runner`.
+- **Oui, cela inclut aussi DCA** : si la stratégie testée est de type DCA, l’optimisation reste la même méta-couche, mais elle pilote alors des runs DCA via le runner stratégie/API canonique.
+
+Dans le code actuel, on voit bien cette délégation : `optimize/variants.py` importe `backtest.runner` et `strategies.runner` puis appelle `run_backtest_from_spec(...)` / `run_backtest_with_payload(...)`. Côté API, le flux canonique supporte aussi `optimize_dca` (converti ensuite vers le runner adapté).
+
+### Décision structurante
+
+- **`stats` ne disparaît pas** : il se spécialise sur l’inférence statistique et les agrégations.
+- **`market_intelligence` devient la source unique** des features contextuelles (corrélation, régimes,
+  liquidité, structure, magnet failure).
+- **`seasonality` reste un module dédié**, mais lit les mêmes données alignées et peut consommer
+  des labels MI pour la segmentation.
+- **`optimize` reste transverse** (ce n’est pas un moteur d’exécution), il pilote des runs via les
+  interfaces stables (`strategy`, `backtest_engine`, `dca_engine`, `market_intelligence`).
+
+En pratique : on garde les modules existants au début, puis on déplace progressivement le code vers
+les packages cibles avec des adapters pour éviter la casse.
+
+---
+
+## North-star architecture diagram (texte)
+
+```text
+[data providers] -> [data/alignment] -> [indicators] -> [market_intelligence pipelines] -> [feature_store]
+                                                                    |                     |
+                                                                    v                     v
+                                                             [strategy_engine] -----> [backtest_engine / dca_engine]
+                                                                    |                     |
+                                                                    v                     v
+                                                            [orders/trades/positions] -> [performance_analytics]
+                                                                                          |
+                                                                                          v
+                                                                                 [stress_test_engine]
+                                                                                          |
+                                                                                          v
+                                                                                    [api_or_cli]
+```
+
+Principe : tout calcul de contexte marché (corrélation/régime/liquidité/structure) vit dans `market_intelligence`; les stratégies et moteurs **consomment** ce contexte via contrats stables.

--- a/tickets/active/PY-MI-EPIC-0-roadmap-index.md
+++ b/tickets/active/PY-MI-EPIC-0-roadmap-index.md
@@ -1,0 +1,42 @@
+## Title
+- PY-MI-EPIC-0 — Roadmap d’implémentation Market Intelligence (index)
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Architect
+
+## Cross-Repo Coordination
+- Cross-Repo Initiative: N/A
+- Repo Owner: quant-python-engine
+- Upstream Dependencies: docs/architecture_market_intelligence_refactor.md
+- Contract Version: mi-arch-v1
+
+## Goal
+- Fournir un plan exécutable par agents Codex pour introduire la couche `market_intelligence` sans casser les flux backtest/DCA/stress/perf/stats/seasonality/optimize.
+
+## Epic order (obligatoire)
+1. PY-MI-EPIC-1 — Core contracts + import guards
+2. PY-MI-EPIC-2 — Feature store + service Market Intelligence
+3. PY-MI-EPIC-3 — Intégration moteurs (backtest + DCA + stress)
+4. PY-MI-EPIC-4 — Analytics (performance/stats/seasonality) + alignement optimize
+5. PY-MI-EPIC-5 — Migration legacy + dépréciations + hardening
+
+## Delivery policy (Codex)
+- PRs petites (200-500 LOC si possible), un seul sujet par PR.
+- Chaque PR doit inclure:
+  - code,
+  - tests unitaires et/ou intégration,
+  - note de compatibilité rétro,
+  - update doc minimale.
+- Interdiction de déplacer massivement les fichiers en une seule PR.
+
+## Definition of Done
+- [ ] Les 5 epics sont livrées dans l’ordre.
+- [ ] Les règles d’import interdites sont testées automatiquement.
+- [ ] Les runs de référence backtest + DCA restent compatibles (non-régression KPI).
+
+## Non-goals / Out of scope
+- Refonte UI ou dashboards.
+- Changement des specs JSON externes non versionné.

--- a/tickets/active/PY-MI-EPIC-1-core-contracts-and-import-guards.md
+++ b/tickets/active/PY-MI-EPIC-1-core-contracts-and-import-guards.md
@@ -1,0 +1,35 @@
+## Title
+- PY-MI-EPIC-1 — Contrats core et garde-fous d’architecture
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Dev
+
+## Goal
+- Poser les interfaces stables (`core/domain`, `core/contracts`) et verrouiller les dépendances interdites dès le début.
+
+## Context / Entry points
+- Modules/files:
+  - `src/quant_engine/core/`
+  - `tests/architecture/`
+  - `docs/architecture_market_intelligence_refactor.md`
+
+## Tickets enfants
+- PY-MI-1.1: Créer `core/domain/models.py` (`Candle`, `Trade`, `Position`, `Portfolio`).
+- PY-MI-1.2: Créer `core/contracts/market_intelligence.py`, `feature_store.py`, `strategy.py`.
+- PY-MI-1.3: Ajouter `tests/architecture/test_import_rules.py` (imports interdits).
+- PY-MI-1.4: Ajouter adaptateurs de compatibilité minimale pour l’existant (sans breaking change).
+
+## Definition of Done
+- [ ] Contrats versionnés et importables.
+- [ ] Test d’architecture en place et vert.
+- [ ] Aucun changement de comportement métier observé sur les tests existants.
+
+## Validation commands
+- `poetry run pytest -q tests/architecture/test_import_rules.py`
+- `poetry run pytest -q tests/backtest tests/strategies`
+
+## Notes / pitfalls
+- Ne pas coupler `core` vers `api`, `backtest`, `performance`, `optimize`.

--- a/tickets/active/PY-MI-EPIC-2-feature-store-and-mi-service.md
+++ b/tickets/active/PY-MI-EPIC-2-feature-store-and-mi-service.md
@@ -1,0 +1,39 @@
+## Title
+- PY-MI-EPIC-2 — Feature Store + MarketIntelligenceService
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Dev
+
+## Goal
+- Introduire la couche `market_intelligence` opérationnelle (v1) avec cache mémoire + disque et premiers labels (régime/liquidité/corrélation).
+
+## Context / Entry points
+- Modules/files:
+  - `src/quant_engine/market_intelligence/` (nouveau)
+  - `src/quant_engine/filters/` (adapters temporaires)
+  - `src/quant_engine/stats/` (réutilisation partielle)
+
+## Tickets enfants
+- PY-MI-2.1: Créer `market_intelligence/models.py` (FeatureFrame, FeatureMeta, labels).
+- PY-MI-2.2: Implémenter `FeatureStore` in-memory (`InMemoryFeatureStore`).
+- PY-MI-2.3: Implémenter `FeatureStore` parquet (`ParquetFeatureStore`) avec clé `(feature_set, symbol, timeframe, version)`.
+- PY-MI-2.4: Implémenter `MarketIntelligenceService` v1 avec pipelines:
+  - corrélation glissante,
+  - régime (trend/range/compression),
+  - flags liquidité / magnet-failure.
+- PY-MI-2.5: Tests unitaires sur shape/colonnes/index UTC/NaN policy.
+
+## Definition of Done
+- [ ] Service MI calcule et lit des features persistées.
+- [ ] Colonnes de features documentées et stables.
+- [ ] Tests unitaires dédiés verts.
+
+## Validation commands
+- `poetry run pytest -q tests/market_intelligence`
+
+## Notes / pitfalls
+- Standardiser timezone en UTC.
+- Politique explicite de forward-fill et trous de données.

--- a/tickets/active/PY-MI-EPIC-3-engine-integration-backtest-dca-stress.md
+++ b/tickets/active/PY-MI-EPIC-3-engine-integration-backtest-dca-stress.md
@@ -1,0 +1,36 @@
+## Title
+- PY-MI-EPIC-3 — Intégration MI dans backtest, DCA et stress tests
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Dev
+
+## Goal
+- Faire consommer des features MI pré-calculées aux moteurs sans embarquer la logique de calcul dans les stratégies.
+
+## Context / Entry points
+- Modules/files:
+  - `src/quant_engine/backtest/`
+  - `src/quant_engine/strategies/`
+  - `src/quant_engine/performance/stress_tests.py`
+
+## Tickets enfants
+- PY-MI-3.1: Injection de dépendance `MarketIntelligenceService` dans run backtest.
+- PY-MI-3.2: Injection MI dans run stratégie/DCA (feature row fournie à la stratégie).
+- PY-MI-3.3: Ajouter mode fallback legacy (MI OFF) via adapter.
+- PY-MI-3.4: Étendre stress tests pour scénarios de shifts de régime + vol spikes en utilisant labels MI.
+- PY-MI-3.5: Tests d’intégration backtest/DCA avec MI ON vs OFF.
+
+## Definition of Done
+- [ ] Backtest et DCA exécutent avec features MI sans régression majeure.
+- [ ] Stress tests consomment labels régime de manière contractuelle.
+- [ ] Tests d’intégration verts.
+
+## Validation commands
+- `poetry run pytest -q tests/backtest tests/strategies tests/integration`
+
+## Notes / pitfalls
+- Garder compatibilité specs existantes.
+- Éviter d’ajouter des imports `market_intelligence` profonds dans les stratégies.

--- a/tickets/active/PY-MI-EPIC-4-analytics-seasonality-stats-optimize-alignment.md
+++ b/tickets/active/PY-MI-EPIC-4-analytics-seasonality-stats-optimize-alignment.md
@@ -1,0 +1,36 @@
+## Title
+- PY-MI-EPIC-4 — Segmentation analytics + alignement stats/seasonality/optimize
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Dev
+
+## Goal
+- Aligner les capacités analytiques autour des labels MI, sans casser les modules existants.
+
+## Context / Entry points
+- Modules/files:
+  - `src/quant_engine/performance/`
+  - `src/quant_engine/stats/`
+  - `src/quant_engine/seasonality/`
+  - `src/quant_engine/optimize/`
+
+## Tickets enfants
+- PY-MI-4.1: Ajouter segmentation performance par `regime` et `magnet_failure`.
+- PY-MI-4.2: Déplacer la partie "feature computation" de `stats` vers MI (avec wrappers compat).
+- PY-MI-4.3: Permettre à `seasonality` de segmenter par labels MI (optionnel via flag).
+- PY-MI-4.4: Clarifier `optimize` comme orchestrateur backtest + DCA consommant les mêmes contrats MI.
+- PY-MI-4.5: Snapshot tests payload analytics/stats/seasonality.
+
+## Definition of Done
+- [ ] Les rapports performance exposent des vues par régime/flag.
+- [ ] `stats` conserve l’inférence, MI centralise les features de contexte.
+- [ ] `seasonality` et `optimize` restent compatibles.
+
+## Validation commands
+- `poetry run pytest -q tests/stats tests/integration tests/io`
+
+## Notes / pitfalls
+- Respecter les contrats existants côté API/persistence.

--- a/tickets/active/PY-MI-EPIC-5-migration-hardening-and-deprecations.md
+++ b/tickets/active/PY-MI-EPIC-5-migration-hardening-and-deprecations.md
@@ -1,0 +1,36 @@
+## Title
+- PY-MI-EPIC-5 — Migration progressive, dépréciations et hardening final
+
+## Ticket type
+- Type B: Implementation
+
+## BMAD Stage
+- Reviewer
+
+## Goal
+- Finaliser la migration sans dette cachée: déprécier proprement le legacy, sécuriser la non-régression et documenter les garde-fous de dérive architecture.
+
+## Context / Entry points
+- Modules/files:
+  - `src/quant_engine/api/app.py`
+  - `src/quant_engine/cli/main.py`
+  - `docs/`
+  - `tests/`
+
+## Tickets enfants
+- PY-MI-5.1: Dépréciations progressives (`warnings`, changelog, fenêtre de migration).
+- PY-MI-5.2: Réduction progressive de `api/app.py` (handlers fins + services).
+- PY-MI-5.3: Non-régression KPI (baseline specs backtest + DCA + stress).
+- PY-MI-5.4: Durcir tests architecture (forbidden imports + smoke DI).
+- PY-MI-5.5: Doc finale d’exploitation (`qe features recompute/inspect`, runbooks cache).
+
+## Definition of Done
+- [ ] Chemins legacy encore supportés mais balisés.
+- [ ] Diff KPI dans tolérance documentée.
+- [ ] Documentation d’exploitation à jour.
+
+## Validation commands
+- `poetry run pytest -q`
+
+## Notes / pitfalls
+- Toute rupture de contrat doit être versionnée et explicitée.

--- a/tickets/active/PY-MI-SUBTASKS-EXECUTION-PLAN.md
+++ b/tickets/active/PY-MI-SUBTASKS-EXECUTION-PLAN.md
@@ -1,0 +1,528 @@
+## PY-MI — Plan d’exécution détaillé (autonome pour agents Codex)
+
+Objectif: rendre chaque sous-tâche exécutable sans ambiguïté par un agent.
+
+---
+
+## Mode opératoire standard (à appliquer à **chaque** sous-tâche)
+
+### Pré-checks obligatoires
+1. Lire l’epic cible (`PY-MI-EPIC-x`).
+2. Vérifier l’état git propre.
+3. Identifier exactement les fichiers autorisés à modifier.
+4. Lister les tests minimaux à exécuter avant PR.
+
+### Convention branch / commit / PR
+- Branch: `codex/py-mi-<subtask-id>-<slug>`
+- Commit: `PY-MI-<id>: <résumé court>`
+- PR title: `PY-MI-<id> <résumé>`
+- PR body doit inclure:
+  - Scope exact
+  - Risques
+  - Tests exécutés + résultat
+  - Rollback plan
+
+### Done minimal (pour chaque sous-tâche)
+- [ ] Code + tests + doc locale mis à jour.
+- [ ] Pas de rupture API involontaire.
+- [ ] `pytest` ciblé vert.
+- [ ] Diff borné au scope.
+
+---
+
+## EPIC-1 — Core contracts + import guards
+
+### PY-MI-1.1 — `core/domain/models.py`
+**Mission**
+- Introduire modèles de domaine immuables: `Candle`, `Trade`, `Position`, `Portfolio`.
+
+**Fichiers cibles**
+- `src/quant_engine/core/domain/models.py` (nouveau)
+- `src/quant_engine/core/domain/__init__.py` (nouveau)
+- `tests/core/test_domain_models.py` (nouveau)
+
+**Étapes d’implémentation**
+1. Créer dataclasses `frozen=True` + types explicites.
+2. Ajouter méthodes utilitaires minimales (`to_dict` optionnel, sans dépendance externe).
+3. Exposer imports via `__init__.py`.
+4. Écrire tests:
+   - création objet,
+   - immutabilité,
+   - champs obligatoires,
+   - comparaison/égalité.
+
+**Tests à exécuter**
+- `poetry run pytest -q tests/core/test_domain_models.py`
+
+**Critères d’acceptation**
+- Les 4 modèles sont importables depuis `quant_engine.core.domain`.
+- Les tests d’immuabilité passent.
+
+---
+
+### PY-MI-1.2 — `core/contracts/*` (Protocols)
+**Mission**
+- Formaliser contrats `MarketIntelligenceService`, `FeatureStore`, `StrategyContract`.
+
+**Fichiers cibles**
+- `src/quant_engine/core/contracts/market_intelligence.py`
+- `src/quant_engine/core/contracts/feature_store.py`
+- `src/quant_engine/core/contracts/strategy.py`
+- `src/quant_engine/core/contracts/__init__.py`
+- `tests/core/test_contracts_imports.py`
+
+**Étapes d’implémentation**
+1. Définir `Protocol` + signatures minimales.
+2. Utiliser types pandas seulement si nécessaire (`typing.TYPE_CHECKING`).
+3. Ajouter docstrings de contrat (inputs/outputs attendus).
+4. Tester import + conformité d’une implémentation fake.
+
+**Tests à exécuter**
+- `poetry run pytest -q tests/core/test_contracts_imports.py`
+
+**Critères d’acceptation**
+- Contrats importables et utilisables par classes fake.
+
+---
+
+### PY-MI-1.3 — Architecture import guards
+**Mission**
+- Empêcher les dépendances interdites via tests d’architecture.
+
+**Fichiers cibles**
+- `tests/architecture/test_import_rules.py`
+
+**Étapes d’implémentation**
+1. Scanner les imports AST des modules `src/quant_engine`.
+2. Définir matrice `FORBIDDEN_IMPORTS` (ex: `core` -> pas `api/backtest/optimize`).
+3. Faire échouer avec message clair indiquant source/target interdits.
+
+**Tests à exécuter**
+- `poetry run pytest -q tests/architecture/test_import_rules.py`
+
+**Critères d’acceptation**
+- Test échoue en cas de violation reproduite localement.
+
+---
+
+### PY-MI-1.4 — Adapters legacy minimaux
+**Mission**
+- Introduire adaptation de l’existant vers les nouveaux contrats sans break.
+
+**Fichiers cibles**
+- `src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py` (nouveau)
+- `src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py` (nouveau)
+- `tests/market_intelligence/test_legacy_adapters.py`
+
+**Étapes d’implémentation**
+1. Créer wrappers pour appeler `filters` / `stats` existants.
+2. Uniformiser retour (`DataFrame` indexé UTC + colonnes normalisées).
+3. Ajouter tests sur shape et colonnes.
+
+**Tests à exécuter**
+- `poetry run pytest -q tests/market_intelligence/test_legacy_adapters.py`
+
+**Critères d’acceptation**
+- Aucune régression visible sur flows existants.
+
+---
+
+## EPIC-2 — Feature Store + MI Service
+
+### PY-MI-2.1 — Modèles MI
+**Mission**
+- Définir structures `FeatureMeta`, conventions de colonnes et labels.
+
+**Fichiers cibles**
+- `src/quant_engine/market_intelligence/models.py`
+- `tests/market_intelligence/test_models.py`
+
+**Étapes**
+1. Définir schéma minimal des métadonnées.
+2. Ajouter validateurs simples (version, timeframe, symbol).
+3. Tester validation positive/négative.
+
+**Tests**
+- `poetry run pytest -q tests/market_intelligence/test_models.py`
+
+---
+
+### PY-MI-2.2 — InMemoryFeatureStore
+**Mission**
+- Stockage en RAM par clé `(feature_set, symbol, timeframe, version)`.
+
+**Fichiers cibles**
+- `src/quant_engine/market_intelligence/feature_store_memory.py`
+- `tests/market_intelligence/test_feature_store_memory.py`
+
+**Étapes**
+1. Implémenter `get/put/exists/delete`.
+2. Gérer overwrite explicite.
+3. Tests concurrence simple (écritures séquentielles).
+
+**Tests**
+- `poetry run pytest -q tests/market_intelligence/test_feature_store_memory.py`
+
+---
+
+### PY-MI-2.3 — ParquetFeatureStore
+**Mission**
+- Persistance disque partitionnée et versionnée.
+
+**Fichiers cibles**
+- `src/quant_engine/market_intelligence/feature_store_parquet.py`
+- `tests/market_intelligence/test_feature_store_parquet.py`
+
+**Étapes**
+1. Définir layout de path stable.
+2. Implémenter write atomique (tmp + rename).
+3. Implémenter lecture filtrée période.
+4. Tests round-trip + version mismatch.
+
+**Tests**
+- `poetry run pytest -q tests/market_intelligence/test_feature_store_parquet.py`
+
+---
+
+### PY-MI-2.4 — MarketIntelligenceService v1
+**Mission**
+- Service unique pour calcul features corrélation/régime/liquidité.
+
+**Fichiers cibles**
+- `src/quant_engine/market_intelligence/service.py`
+- `src/quant_engine/market_intelligence/pipeline.py`
+- `tests/market_intelligence/test_service_v1.py`
+
+**Étapes**
+1. `compute_features(...)` + `label_regimes(...)` + `liquidity_flags(...)`.
+2. Brancher adapters legacy en interne (phase transitoire).
+3. Ajouter cache store read-through/write-through.
+4. Tester déterminisme sur dataset fixe.
+
+**Tests**
+- `poetry run pytest -q tests/market_intelligence/test_service_v1.py`
+
+---
+
+### PY-MI-2.5 — Qualité de données features
+**Mission**
+- Encadrer index UTC, NaN policy, colonnes obligatoires.
+
+**Fichiers cibles**
+- `tests/market_intelligence/test_feature_quality_contract.py`
+
+**Étapes**
+1. Créer assertions réutilisables (`assert_feature_frame_contract`).
+2. Tester monotonicité index, timezone UTC, colonnes minimales.
+3. Tester policy NaN par feature.
+
+**Tests**
+- `poetry run pytest -q tests/market_intelligence/test_feature_quality_contract.py`
+
+---
+
+## EPIC-3 — Intégration moteurs
+
+### PY-MI-3.1 — Injection MI dans backtest
+**Mission**
+- Permettre au runner backtest de consommer `MarketIntelligenceService`.
+
+**Fichiers cibles**
+- `src/quant_engine/backtest/runner.py`
+- `tests/backtest/test_backtest_with_mi_injection.py`
+
+**Étapes**
+1. Ajouter param optionnel `mi_service` + fallback null adapter.
+2. Résoudre features avant boucle d’exécution.
+3. Passer features au composant de décision.
+
+**Tests**
+- `poetry run pytest -q tests/backtest/test_backtest_with_mi_injection.py`
+
+---
+
+### PY-MI-3.2 — Injection MI dans stratégie/DCA
+**Mission**
+- Faire consommer `features_row` par stratégies, y compris DCA.
+
+**Fichiers cibles**
+- `src/quant_engine/strategies/base.py`
+- `src/quant_engine/strategies/runner.py`
+- `tests/strategies/test_strategy_consumes_features.py`
+
+**Étapes**
+1. Étendre contrat stratégie (`on_bar(..., features_row, ...)`).
+2. Adapter runner pour extraire row features par timestamp.
+3. Maintenir compat backward (`features_row=None`).
+
+**Tests**
+- `poetry run pytest -q tests/strategies/test_strategy_consumes_features.py`
+
+---
+
+### PY-MI-3.3 — Mode fallback MI OFF
+**Mission**
+- Activer/désactiver MI par config sans casser les runs.
+
+**Fichiers cibles**
+- `src/quant_engine/config.py`
+- `src/quant_engine/backtest/runner.py`
+- `src/quant_engine/strategies/runner.py`
+- `tests/integration/test_mi_toggle_on_off.py`
+
+**Étapes**
+1. Ajouter flag config `market_intelligence.enabled`.
+2. En OFF: comportement identique legacy.
+3. En ON: service MI utilisé.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_mi_toggle_on_off.py`
+
+---
+
+### PY-MI-3.4 — Stress tests sensibles au régime
+**Mission**
+- Ajouter chocs dépendants des labels MI (regime shift / vol spike).
+
+**Fichiers cibles**
+- `src/quant_engine/performance/stress_tests.py`
+- `tests/integration/test_stress_regime_shift.py`
+
+**Étapes**
+1. Ajouter paramètre `regime_labels` au pipeline stress.
+2. Moduler scénarios selon régime.
+3. Tracer paramètres appliqués dans payload.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_stress_regime_shift.py`
+
+---
+
+### PY-MI-3.5 — Intégration ON/OFF + snapshots
+**Mission**
+- Garantir forme stable des payloads en mode MI ON/OFF.
+
+**Fichiers cibles**
+- `tests/integration/test_payload_snapshot_mi.py`
+- `tests/data/golden/*` (si nécessaire)
+
+**Étapes**
+1. Générer snapshots de référence.
+2. Comparer champs invariants + champs MI additionnels.
+3. Documenter exceptions tolérées.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_payload_snapshot_mi.py`
+
+---
+
+## EPIC-4 — Analytics + stats/seasonality/optimize
+
+### PY-MI-4.1 — Segmentation performance
+**Mission**
+- Exposer métriques segmentées par `regime` et `magnet_failure`.
+
+**Fichiers cibles**
+- `src/quant_engine/performance/backtest_builder.py`
+- `src/quant_engine/performance/dca_builder.py`
+- `tests/performance/test_segmentation_by_regime.py`
+
+**Étapes**
+1. Ajouter agrégations conditionnelles.
+2. Intégrer au payload sans casser format existant.
+3. Tester sur échantillons multi-régimes.
+
+**Tests**
+- `poetry run pytest -q tests/performance/test_segmentation_by_regime.py`
+
+---
+
+### PY-MI-4.2 — Migration partielle stats -> MI
+**Mission**
+- Déplacer calculs feature-like depuis `stats` vers MI avec wrappers compat.
+
+**Fichiers cibles**
+- `src/quant_engine/stats/events.py`
+- `src/quant_engine/stats/conditions.py`
+- `src/quant_engine/market_intelligence/` (nouveaux composants)
+- `tests/stats/test_stats_compat_wrappers.py`
+
+**Étapes**
+1. Identifier fonctions purement feature.
+2. Déplacer vers MI.
+3. Laisser wrappers dans `stats` (même signature).
+4. Marquer wrappers dépréciés (warning soft).
+
+**Tests**
+- `poetry run pytest -q tests/stats/test_stats_compat_wrappers.py`
+
+---
+
+### PY-MI-4.3 — Seasonality segmentée par labels MI
+**Mission**
+- Rendre la segmentation seasonality optionnelle via labels MI.
+
+**Fichiers cibles**
+- `src/quant_engine/seasonality/compute.py`
+- `src/quant_engine/seasonality/runner.py`
+- `tests/integration/test_seasonality_with_mi_labels.py`
+
+**Étapes**
+1. Ajouter option `segment_by_mi_labels`.
+2. Joindre labels MI sur index temps.
+3. Sortir stats globales + segmentées.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_seasonality_with_mi_labels.py`
+
+---
+
+### PY-MI-4.4 — Alignement optimize backtest + DCA
+**Mission**
+- Standardiser consommation des contrats MI dans flux optimize backtest/DCA.
+
+**Fichiers cibles**
+- `src/quant_engine/optimize/variants.py`
+- `src/quant_engine/api/app.py`
+- `tests/integration/test_optimize_backtest_dca_mi_alignment.py`
+
+**Étapes**
+1. Vérifier injection cohérente MI dans deux branches optimize.
+2. Uniformiser shape des metadata MI dans résultats.
+3. Tester `optimize_backtest` et `optimize_dca`.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_optimize_backtest_dca_mi_alignment.py`
+
+---
+
+### PY-MI-4.5 — Snapshot analytics globaux
+**Mission**
+- Stabiliser payload analytics/stats/seasonality en snapshots.
+
+**Fichiers cibles**
+- `tests/integration/test_analytics_snapshots.py`
+- `tests/data/golden/*`
+
+**Étapes**
+1. Produire snapshots versionnés.
+2. Ajouter stratégie d’update contrôlée.
+3. Documenter champs volatils ignorés.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_analytics_snapshots.py`
+
+---
+
+## EPIC-5 — Migration/hardening final
+
+### PY-MI-5.1 — Dépréciations progressives
+**Mission**
+- Introduire warnings de migration sans rupture.
+
+**Fichiers cibles**
+- `src/quant_engine/*` modules wrappers legacy
+- `docs/` notes migration
+- `tests/integration/test_deprecation_paths.py`
+
+**Étapes**
+1. Ajouter warnings explicites avec date/version cible.
+2. Ajouter doc de migration old->new.
+3. Tester présence warnings.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_deprecation_paths.py`
+
+---
+
+### PY-MI-5.2 — Découpage progressif `api/app.py`
+**Mission**
+- Extraire services applicatifs pour réduire couplage.
+
+**Fichiers cibles**
+- `src/quant_engine/api/app.py`
+- `src/quant_engine/api/services/*.py` (nouveau)
+- `tests/api/*`
+
+**Étapes**
+1. Extraire logique métier hors endpoints.
+2. Garder routes minces (validation + appel service).
+3. Assurer compat payload/status codes.
+
+**Tests**
+- `poetry run pytest -q tests/api`
+
+---
+
+### PY-MI-5.3 — Baseline KPI non-régression
+**Mission**
+- Comparer runs de référence avant/après.
+
+**Fichiers cibles**
+- `tests/integration/test_kpi_non_regression_mi.py`
+- `tests/data/golden/*`
+
+**Étapes**
+1. Définir 2-3 specs de référence (backtest, dca, stress).
+2. Comparer KPI clés avec tolérance.
+3. Reporter diff en cas d’écart.
+
+**Tests**
+- `poetry run pytest -q tests/integration/test_kpi_non_regression_mi.py`
+
+---
+
+### PY-MI-5.4 — Renforcer architecture tests
+**Mission**
+- Élargir les règles d’import interdites à tous modules critiques.
+
+**Fichiers cibles**
+- `tests/architecture/test_import_rules.py`
+
+**Étapes**
+1. Ajouter toutes règles officielles de dépendance.
+2. Tester cas négatifs synthétiques.
+3. Ajouter message de remédiation.
+
+**Tests**
+- `poetry run pytest -q tests/architecture/test_import_rules.py`
+
+---
+
+### PY-MI-5.5 — Runbook opératoire final
+**Mission**
+- Documenter opérationnellement recalcul/inspection features et maintenance cache.
+
+**Fichiers cibles**
+- `docs/market_intelligence_runbook.md` (nouveau)
+- `docs/architecture_market_intelligence_refactor.md` (liens)
+
+**Étapes**
+1. Documenter commandes CLI (`features recompute/inspect`).
+2. Documenter invalidation cache et troubleshooting.
+3. Ajouter checklist incident.
+
+**Tests / checks**
+- Vérification manuelle cohérence doc + commandes existantes.
+
+---
+
+## Checklists PR (copier-coller pour agents)
+
+### Template "PR Summary"
+- Scope:
+- Fichiers modifiés:
+- Compatibilité:
+- Risques:
+- Rollback:
+
+### Template "Validation"
+- ✅ `poetry run pytest -q <tests ciblés>`
+- ✅ `poetry run pytest -q` (si coût acceptable)
+- ✅ `poetry run ruff check src tests` (si configuré)
+
+### Template "Reviewer notes"
+- Contrats respectés ?
+- Imports interdits respectés ?
+- Données temporelles UTC garanties ?
+- Diff borné au ticket ?


### PR DESCRIPTION
### Motivation

- Consolidate and decouple market-context computations by introducing a dedicated `market_intelligence` layer and stable core contracts to avoid god-modules and tangled imports.
- Provide an explicit target package layout, dependency rules and incremental migration strategy to minimize risk during refactor.
- Capture execution plan and per-epic tickets so work can be executed incrementally and by automated agents. 

### Description

- Add comprehensive architecture specification `docs/architecture_market_intelligence_refactor.md` describing target packages (`core`, `data`, `indicators`, `market_intelligence`, engines, analytics, `api_or_cli`), contracts, pipelines and dependency guard rules. 
- Add roadmap index `tickets/active/PY-MI-EPIC-0-roadmap-index.md` and per-epic ticket files `PY-MI-EPIC-1` through `PY-MI-EPIC-5` plus a detailed subtask execution plan `PY-MI-SUBTASKS-EXECUTION-PLAN.md` defining tasks, file targets and validation commands. 
- Define required contracts, migration PR sequence, feature-store/service goals, integration steps for backtest/DCA/stress engines, and recommended tests/validation commands in each ticket. 

### Testing

- No automated tests were executed as part of this documentation/ticket-only PR. 
- The tickets and docs include concrete validation commands to run after implementation, for example `poetry run pytest -q tests/architecture/test_import_rules.py` and `poetry run pytest -q tests/market_intelligence` (to be executed in follow-up implementation PRs). 
- CI should run the included architecture tests and targeted unit/integration suites described in each ticket once code changes implementing the contracts are submitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8289ae9708323a9150f7136cef151)