### PR TITLE
Align MI contract handling across optimize_backtest and optimize_dca

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -719,6 +719,32 @@ def _canonical_optimization_trials(result: Mapping[str, Any]) -> List[Dict[str, 
     return normalized
 
 
+
+
+def _normalize_mi_metadata(raw_metadata: Any) -> Dict[str, Any]:
+    metadata = raw_metadata if isinstance(raw_metadata, Mapping) else {}
+    raw_mi = metadata.get("mi") if isinstance(metadata, Mapping) else None
+    if isinstance(raw_mi, Mapping):
+        mi_meta = dict(raw_mi)
+    else:
+        mi_meta = {}
+    contract = mi_meta.get("contract")
+    if not isinstance(contract, Mapping):
+        contract = {}
+    else:
+        contract = dict(contract)
+    enabled = mi_meta.get("enabled")
+    if not isinstance(enabled, bool):
+        enabled = contract.get("enabled") if isinstance(contract.get("enabled"), bool) else None
+    return {"mi": {"enabled": enabled, "contract": contract}}
+
+
+def _copy_mi_contract(request: Dict[str, Any], target: Dict[str, Any]) -> None:
+    for field in ("market_intelligence", "mi"):
+        raw = request.get(field)
+        if isinstance(raw, dict):
+            target[field] = dict(raw)
+
 def _canonical_optimization_from_request(request: Dict[str, Any]) -> Dict[str, Any]:
     spec_type = str(request.get("spec_type") or "").strip().lower()
     if spec_type not in {"optimize_backtest", "optimize_dca"}:
@@ -787,6 +813,7 @@ def _canonical_optimization_from_request(request: Dict[str, Any]) -> Dict[str, A
     }
 
     raw_result = runner_fn(runner_spec)
+    metadata = _normalize_mi_metadata(raw_result.get("metadata") if isinstance(raw_result, dict) else None)
     trials = _canonical_optimization_trials(raw_result if isinstance(raw_result, dict) else {})
     succeeded = sum(1 for trial in trials if trial.get("status") == "SUCCEEDED")
     failed = len(trials) - succeeded
@@ -821,6 +848,7 @@ def _canonical_optimization_from_request(request: Dict[str, Any]) -> Dict[str, A
                 "trials_path": raw_result.get("trials_path") if isinstance(raw_result, dict) else None,
                 "summary_path": raw_result.get("summary") if isinstance(raw_result, dict) else None,
             },
+            "metadata": metadata,
         },
     }
 
@@ -907,6 +935,7 @@ def _canonical_backtest_to_spec(request: Dict[str, Any]) -> Dict[str, Any]:
         mapped["output"] = request.get("output")
     if isinstance(request.get("persistence"), dict):
         mapped["persistence"] = request.get("persistence")
+    _copy_mi_contract(request, mapped)
 
     return mapped
 
@@ -1216,6 +1245,7 @@ def _canonical_dca_to_strategy_spec(request: Dict[str, Any]) -> Dict[str, Any]:
         performance_spec = _canonical_performance_to_internal(performance_block)
         if performance_spec:
             spec["performance"] = performance_spec
+    _copy_mi_contract(request, spec)
 
     return spec
 

--- a/src/quant_engine/optimize/variants.py
+++ b/src/quant_engine/optimize/variants.py
@@ -454,6 +454,16 @@ def _trial_metadata(spec: Mapping[str, Any], cfg: Mapping[str, Any]) -> Dict[str
     strategy = spec.get("strategy") or {}
     data_hash = _data_hash(spec)
     config_hash = _json_hash(spec)
+    mi_contract = spec.get("market_intelligence")
+    if mi_contract is None:
+        mi_contract = spec.get("mi")
+    if isinstance(mi_contract, Mapping):
+        mi_contract_payload: Dict[str, Any] = dict(mi_contract)
+    else:
+        mi_contract_payload = {}
+    mi_enabled_raw = mi_contract_payload.get("enabled")
+    mi_enabled = bool(mi_enabled_raw) if isinstance(mi_enabled_raw, bool) else None
+
     meta = {
         "seed": cfg.get("seed"),
         "dataset_id": _dataset_id(spec),
@@ -464,6 +474,10 @@ def _trial_metadata(spec: Mapping[str, Any], cfg: Mapping[str, Any]) -> Dict[str
         "data_hash": data_hash,
         "config_hash": config_hash,
         "lib_versions": _collect_lib_versions(),
+        "mi": {
+            "enabled": mi_enabled,
+            "contract": mi_contract_payload,
+        },
     }
     root = Path.cwd()
     code_version = _git_head_sha(root)

--- a/tests/integration/test_optimize_backtest_dca_mi_alignment.py
+++ b/tests/integration/test_optimize_backtest_dca_mi_alignment.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import sys
+import types
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+from quant_engine.api import app as api_app
+
+
+MI_CONTRACT = {
+    "enabled": True,
+    "provider": "dummy",
+    "labels": ["regime", "liquidity"],
+}
+
+
+def _optimize_backtest_request() -> Dict[str, Any]:
+    return {
+        "spec_type": "optimize_backtest",
+        "catalog_version": "v1",
+        "market_intelligence": dict(MI_CONTRACT),
+        "optimization": {
+            "base_spec": {
+                "spec_type": "backtest",
+                "catalog_version": "v1",
+                "market_intelligence": dict(MI_CONTRACT),
+                "data": {
+                    "symbol": "EURUSD",
+                    "timeframe": "M1",
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-02",
+                },
+                "signal": {"type": "ema_cross", "fast": 9, "slow": 21},
+            },
+            "search_space": {"signal.fast": {"type": "int", "min": 5, "max": 6}},
+            "objective": {"metric": "sharpe", "direction": "max"},
+            "budget": {"max_trials": 1, "seed": 7},
+        },
+    }
+
+
+def _optimize_dca_request() -> Dict[str, Any]:
+    return {
+        "spec_type": "optimize_dca",
+        "catalog_version": "v1",
+        "mi": dict(MI_CONTRACT),
+        "optimization": {
+            "base_spec": {
+                "spec_type": "dca",
+                "catalog_version": "v1",
+                "mi": dict(MI_CONTRACT),
+                "data": {
+                    "symbol": "BTCUSD",
+                    "timeframe": "H1",
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-01-02",
+                },
+                "strategy": {
+                    "type": "dca_equity",
+                    "grid": [],
+                    "params": {
+                        "grid": [{"dd": -5.0, "weight": 1.0}],
+                        "execution_mode": "bar_close",
+                        "drawdown_reference": "ATH",
+                    },
+                },
+            },
+            "search_space": {"strategy.params.grid[0].dd": {"type": "int", "min": -6, "max": -5}},
+            "objective": {"metric": "sharpe", "direction": "max"},
+            "budget": {"max_trials": 1, "seed": 9},
+        },
+    }
+
+
+def test_optimize_backtest_and_dca_align_mi_contract_and_metadata(monkeypatch) -> None:
+    observed: Dict[str, Dict[str, Any]] = {}
+
+    def _fake_backtest(spec: Dict[str, Any]) -> Dict[str, Any]:
+        observed["backtest"] = spec
+        return {
+            "trials_path": "",
+            "summary": "",
+            "best": {"params": {"signal.fast": 5}, "objective": 1.0},
+            "metadata": {"mi": {"enabled": True, "contract": dict(spec.get("market_intelligence") or {})}},
+        }
+
+    def _fake_dca(spec: Dict[str, Any]) -> Dict[str, Any]:
+        observed["dca"] = spec
+        return {
+            "trials_path": "",
+            "summary": "",
+            "best": {"params": {"strategy.params.grid[0].dd": -5}, "objective": 0.5},
+            "metadata": {"mi": {"enabled": True, "contract": dict(spec.get("mi") or {})}},
+        }
+
+    monkeypatch.setattr(api_app.optimize_variants, "run_backtest_optimization", _fake_backtest)
+    monkeypatch.setattr(api_app.optimize_variants, "run_strategy_optimization", _fake_dca)
+
+    backtest_result = api_app._canonical_optimization_from_request(_optimize_backtest_request())
+    dca_result = api_app._canonical_optimization_from_request(_optimize_dca_request())
+
+    assert observed["backtest"]["market_intelligence"] == MI_CONTRACT
+    assert observed["dca"]["mi"] == MI_CONTRACT
+
+    assert backtest_result["result"]["metadata"] == {"mi": {"enabled": True, "contract": MI_CONTRACT}}
+    assert dca_result["result"]["metadata"] == {"mi": {"enabled": True, "contract": MI_CONTRACT}}


### PR DESCRIPTION
### Motivation
- Ensure market-intelligence (MI) contract fields are consumed consistently by both optimization branches (`optimize_backtest` and `optimize_dca`).
- Provide a stable, canonical `metadata.mi` shape in optimization results so callers can rely on `enabled` + `contract` fields.

### Description
- Normalize trial metadata in `src/quant_engine/optimize/variants.py` by adding a `mi` entry with `enabled` and `contract` extracted from either `market_intelligence` or `mi` in the spec via the `_trial_metadata` helper. 
- Add `_normalize_mi_metadata` and `_copy_mi_contract` helpers in `src/quant_engine/api/app.py` and include normalized `metadata` in `_canonical_optimization_from_request` results. 
- Propagate MI contract from canonical base specs into runner specs by calling `_copy_mi_contract` in both `_canonical_backtest_to_spec` and `_canonical_dca_to_strategy_spec` so both runner branches receive the same MI contract fields. 
- Add an integration test `tests/integration/test_optimize_backtest_dca_mi_alignment.py` that verifies MI contract injection into both runner specs and the aligned `result.metadata.mi` shape in the canonical optimization response.

### Testing
- Ran the new integration test with `poetry run pytest -q tests/integration/test_optimize_backtest_dca_mi_alignment.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8cd20ec748323b21ae8e045d10d33)