### PR TITLE
EPIC-5: add progressive deprecation warnings for legacy stats wrappers

### DIFF
--- a/docs/cleanup_legacy.md
+++ b/docs/cleanup_legacy.md
@@ -14,3 +14,6 @@
 ## TODO
 - Confirmer dependances Java/FE sur endpoints legacy.
 - Ajouter warnings deprecation dans docs et logs.
+
+## Migration guide
+- Voir `docs/migration_legacy_wrappers.md` pour la correspondance old->new des wrappers `quant_engine.stats.*`.

--- a/docs/migration_legacy_wrappers.md
+++ b/docs/migration_legacy_wrappers.md
@@ -1,0 +1,47 @@
+# Migration des wrappers legacy `quant_engine.stats.*`
+
+Ce document décrit la migration progressive des wrappers legacy vers les modules Market Intelligence canoniques, sans rupture immédiate.
+
+## Statut
+
+- Les wrappers `quant_engine.stats.conditions.*` et `quant_engine.stats.events.*` restent utilisables pour la compatibilité.
+- Chaque appel déclenche désormais un `DeprecationWarning` explicite.
+- Cible de suppression : **v0.15.0** (date cible : **2026-04-30**).
+
+## Migration old -> new
+
+### Conditions
+
+- `quant_engine.stats.conditions.htf_trend` -> `quant_engine.market_intelligence.conditions.htf_trend`
+- `quant_engine.stats.conditions.vol_tertile` -> `quant_engine.market_intelligence.conditions.vol_tertile`
+- `quant_engine.stats.conditions.session` -> `quant_engine.market_intelligence.conditions.session`
+- `quant_engine.stats.conditions.hour_bin` -> `quant_engine.market_intelligence.conditions.hour_bin`
+- `quant_engine.stats.conditions.day_of_week` -> `quant_engine.market_intelligence.conditions.day_of_week`
+- `quant_engine.stats.conditions.month_of_year` -> `quant_engine.market_intelligence.conditions.month_of_year`
+- `quant_engine.stats.conditions.session_from_ts` -> `quant_engine.market_intelligence.conditions.session_from_ts`
+
+### Events
+
+- `quant_engine.stats.events.k_consecutive` -> `quant_engine.market_intelligence.events.k_consecutive`
+- `quant_engine.stats.events.shock_atr` -> `quant_engine.market_intelligence.events.shock_atr`
+- `quant_engine.stats.events.breakout_hhll` -> `quant_engine.market_intelligence.events.breakout_hhll`
+- `quant_engine.stats.events.bullish_candle` -> `quant_engine.market_intelligence.events.bullish_candle`
+- `quant_engine.stats.events.bearish_candle` -> `quant_engine.market_intelligence.events.bearish_candle`
+- `quant_engine.stats.events.bullish_engulfing` -> `quant_engine.market_intelligence.events.bullish_engulfing`
+- `quant_engine.stats.events.bearish_engulfing` -> `quant_engine.market_intelligence.events.bearish_engulfing`
+- `quant_engine.stats.events.bullish_streak` -> `quant_engine.market_intelligence.events.bullish_streak`
+- `quant_engine.stats.events.bearish_streak` -> `quant_engine.market_intelligence.events.bearish_streak`
+- `quant_engine.stats.events.gap_up` -> `quant_engine.market_intelligence.events.gap_up`
+- `quant_engine.stats.events.gap_down` -> `quant_engine.market_intelligence.events.gap_down`
+- `quant_engine.stats.events.always_true` -> `quant_engine.market_intelligence.events.always_true`
+
+## Exemple de warning
+
+Message attendu :
+
+`quant_engine.stats.events.gap_up is deprecated and will be removed in v0.15.0 (target date: 2026-04-30); use quant_engine.market_intelligence.events instead.`
+
+## Recommandation projet
+
+- Remplacer les imports legacy dans les nouvelles features.
+- Conserver temporairement les wrappers uniquement pour compatibilité ascendante.

--- a/src/quant_engine/stats/conditions.py
+++ b/src/quant_engine/stats/conditions.py
@@ -14,13 +14,16 @@ from quant_engine.market_intelligence import conditions as mi_conditions
 
 LEVELS_TABLE = "marketdata.levels"
 _LEVELS_CACHE: Dict[Tuple[str, Optional[pd.Timestamp], Optional[pd.Timestamp], Tuple[str, ...]], pd.DataFrame] = {}
+_DEPRECATION_TARGET_VERSION = "v0.15.0"
+_DEPRECATION_TARGET_DATE = "2026-04-30"
 
 
 def _warn_deprecated(func_name: str) -> None:
     warnings.warn(
         (
             f"quant_engine.stats.conditions.{func_name} is deprecated and will be removed "
-            "in a future release; use quant_engine.market_intelligence.conditions instead."
+            f"in {_DEPRECATION_TARGET_VERSION} (target date: {_DEPRECATION_TARGET_DATE}); "
+            "use quant_engine.market_intelligence.conditions instead."
         ),
         DeprecationWarning,
         stacklevel=2,

--- a/src/quant_engine/stats/events.py
+++ b/src/quant_engine/stats/events.py
@@ -10,12 +10,16 @@ import pandas as pd
 
 from quant_engine.market_intelligence import events as mi_events
 
+_DEPRECATION_TARGET_VERSION = "v0.15.0"
+_DEPRECATION_TARGET_DATE = "2026-04-30"
+
 
 def _warn_deprecated(func_name: str) -> None:
     warnings.warn(
         (
             f"quant_engine.stats.events.{func_name} is deprecated and will be removed "
-            "in a future release; use quant_engine.market_intelligence.events instead."
+            f"in {_DEPRECATION_TARGET_VERSION} (target date: {_DEPRECATION_TARGET_DATE}); "
+            "use quant_engine.market_intelligence.events instead."
         ),
         DeprecationWarning,
         stacklevel=2,

--- a/tests/integration/test_deprecation_paths.py
+++ b/tests/integration/test_deprecation_paths.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from quant_engine.stats import conditions as stats_conditions
+from quant_engine.stats import events as stats_events
+
+
+def _sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.date_range("2024-01-01", periods=6, freq="h", tz="UTC"),
+            "open": [100, 101, 102, 101, 103, 104],
+            "high": [101, 102, 103, 104, 105, 106],
+            "low": [99, 100, 101, 100, 102, 103],
+            "close": [101, 102, 101, 103, 104, 103],
+            "session_id": ["asia", "asia", "london", "london", "newyork", "newyork"],
+        }
+    )
+
+
+def test_stats_event_deprecation_warning_contains_target_version_and_date() -> None:
+    df = _sample_df()
+
+    with pytest.warns(DeprecationWarning, match=r"v0\.15\.0.*2026-04-30"):
+        _ = stats_events.gap_up(df)
+
+
+def test_stats_condition_deprecation_warning_contains_target_version_and_date() -> None:
+    df = _sample_df()
+
+    with pytest.warns(DeprecationWarning, match=r"v0\.15\.0.*2026-04-30"):
+        _ = stats_conditions.day_of_week(df)


### PR DESCRIPTION
### Motivation
- Introduce explicit, non-breaking deprecation warnings for legacy `quant_engine.stats.*` wrappers with a concrete removal target to help users migrate incrementally.
- Provide documentation and test coverage to make the migration path discoverable and verifiable.

### Description
- Added `_DEPRECATION_TARGET_VERSION = "v0.15.0"` and `_DEPRECATION_TARGET_DATE = "2026-04-30"` and included them in emitted `DeprecationWarning` messages in `src/quant_engine/stats/conditions.py` and `src/quant_engine/stats/events.py` so warnings now state the target version and date.
- Kept existing wrapper behavior intact so calls to `quant_engine.stats.conditions.*` and `quant_engine.stats.events.*` continue forwarding to `quant_engine.market_intelligence.*` while emitting the enhanced warning.
- Added a migration guide file `docs/migration_legacy_wrappers.md` documenting the old->new function mapping and an expected example warning message.
- Linked the new migration guide from `docs/cleanup_legacy.md` and added an integration test `tests/integration/test_deprecation_paths.py` that asserts the `DeprecationWarning` contains both the version and date.

### Testing
- Ran the integration tests with `poetry run pytest -q tests/integration/test_deprecation_paths.py` and the two new tests passed (`2 passed`).
- No breaking changes to behavior were introduced and the wrappers remain backward-compatible while emitting deprecation warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8d1dcb2dc83239fbf7e6e732e9108)