### PR TITLE
refactor(api): extract runs endpoint business logic into service module

### DIFF
--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 import time
 import threading
 import re
@@ -43,6 +42,7 @@ from ..strategies import runner as strategies_runner
 from ..performance import stress_tests as stress_tests_runner
 from ..filters import list_filter_types
 from . import schemas
+from .services import runs as runs_service
 from .run_request_input import validate_run_request_input
 from .validation_errors import (
     ApiValidationException,
@@ -3694,15 +3694,17 @@ def runs_cancel_endpoint(run_id: str, request: Request) -> schemas.StatusRespons
         }
     )
 
-    job = _get_job(run_id)
-    if not job:
-        return _json_error(404, "not_found", "Run not found")
-    status = _external_job_status(job.get("status", ""))
-    if status in {JOB_STATUS_SUCCEEDED, JOB_STATUS_FAILED_CANONICAL}:
-        return _json_error(409, "already_finished", "Run already finished")
-    request_job_cancel(run_id)
-    job = _get_job(run_id) or job
-    status = _external_job_status(job.get("status", ""))
+    response = runs_service.cancel_run(
+        run_id,
+        get_job=_get_job,
+        external_job_status=_external_job_status,
+        request_job_cancel=request_job_cancel,
+        json_error=_json_error,
+    )
+    if isinstance(response, JSONResponse):
+        return response
+
+    status = response.status
     request.state.request_id = run_id
     _log_event(
         {
@@ -3714,7 +3716,7 @@ def runs_cancel_endpoint(run_id: str, request: Request) -> schemas.StatusRespons
             "client_host": client_host,
         }
     )
-    return schemas.StatusResponse(status=status, id=run_id)
+    return response
 
 
 @fastapi_app.get('/status/{job_id}', response_model=schemas.StatusResponse)
@@ -4035,13 +4037,12 @@ def runs_capabilities_endpoint(spec_type: str = Query(..., description="Canonica
 def run_detail_endpoint(run_id: str) -> Dict[str, Any]:
     """Return a single run and aggregated metrics."""
 
-    job = _get_job(run_id)
-    if job and job.get("job_type") == JOB_TYPE_CANONICAL_RUN:
-        return _canonical_run_payload(job)
-    payload = get_run(run_id)
-    if payload is None:
-        raise HTTPException(status_code=404, detail='Run not found')
-    return payload
+    return runs_service.run_detail(
+        run_id,
+        get_job=_get_job,
+        get_legacy_run=get_run,
+        canonical_run_payload=_canonical_run_payload,
+    )
 
 
 
@@ -4049,66 +4050,23 @@ def run_detail_endpoint(run_id: str) -> Dict[str, Any]:
 def get_run_artifacts(run_id: str) -> Dict[str, Any]:
     """Return artifact listing for a canonical run output directory."""
 
-    job = _get_job(run_id)
-    if not job or job.get("job_type") != JOB_TYPE_CANONICAL_RUN:
-        raise HTTPException(status_code=404, detail='Run not found')
-
-    payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
-    request = payload.get("request") if isinstance(payload.get("request"), dict) else {}
-    output = request.get("output") if isinstance(request.get("output"), dict) else {}
-    out_dir_raw = output.get("out_dir")
-    out_dir = Path(str(out_dir_raw)).expanduser() if isinstance(out_dir_raw, str) and out_dir_raw.strip() else None
-
-    files: List[Dict[str, Any]] = []
-    if out_dir and out_dir.exists() and out_dir.is_dir():
-        for item in sorted(out_dir.iterdir()):
-            if item.is_file():
-                files.append({"name": item.name, "path": str(item), "size_bytes": item.stat().st_size})
-
-    file_names = {entry["name"] for entry in files}
-    contract_artifacts = {
-        "best_plausible_passive_ex_ante": {
-            "json": "best_plausible_passive_ex_ante.json" if "best_plausible_passive_ex_ante.json" in file_names else None,
-            "parquet": "best_plausible_passive_ex_ante.parquet" if "best_plausible_passive_ex_ante.parquet" in file_names else None,
-        }
-    }
-    return {
-        "run_id": run_id,
-        "schema_version": SCHEMA_VERSION,
-        "out_dir": str(out_dir) if out_dir is not None else None,
-        "files": files,
-        "contract_artifacts": contract_artifacts,
-        "audit_trail": {
-            "run_manifest": "run_manifest.json" if "run_manifest.json" in file_names else None,
-            "checksums": "checksums.txt" if "checksums.txt" in file_names else None,
-        },
-    }
+    return runs_service.run_artifacts(
+        run_id,
+        get_job=_get_job,
+        schema_version=SCHEMA_VERSION,
+    )
 
 @fastapi_app.get('/runs/{run_id}/result', response_model=Dict[str, Any])
 def run_result_endpoint(run_id: str) -> Dict[str, Any]:
     """Return the result for a canonical run."""
 
-    job = _get_job(run_id)
-    if not job or job.get("job_type") != JOB_TYPE_CANONICAL_RUN:
-        return _json_error(404, "not_found", "Run not found")
-    status = _external_job_status(job.get("status", ""))
-    payload: Dict[str, Any] = {
-        "run_id": job.get("job_id"),
-        "request_id": job.get("job_id"),
-        "requestId": job.get("job_id"),
-        "status": status,
-    }
-    if not _is_terminal_status(status):
-        payload["message"] = "Result not available yet"
-        return payload
-    result = job.get("result")
-    if result is not None:
-        payload["result"] = result
-    if job.get("error_message"):
-        payload["error"] = {"code": "execution_error", "message": job.get("error_message")}
-    if isinstance(result, dict) and "error" in result:
-        payload["error"] = result.get("error")
-    return payload
+    return runs_service.run_result(
+        run_id,
+        get_job=_get_job,
+        external_job_status=_external_job_status,
+        is_terminal_status=_is_terminal_status,
+        json_error=_json_error,
+    )
 
 
 @fastapi_app.get('/runs/{run_id}/artifacts', response_model=Dict[str, Any])

--- a/src/quant_engine/api/services/__init__.py
+++ b/src/quant_engine/api/services/__init__.py
@@ -1,0 +1,5 @@
+"""Application service layer for API endpoints."""
+
+from . import runs
+
+__all__ = ["runs"]

--- a/src/quant_engine/api/services/runs.py
+++ b/src/quant_engine/api/services/runs.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping
+
+from fastapi import HTTPException
+
+from .. import schemas
+
+
+RunLookup = Callable[[str], Dict[str, Any] | None]
+StatusMapper = Callable[[str], str]
+JsonError = Callable[[int, str, str], Any]
+TerminalStatusPredicate = Callable[[str], bool]
+
+
+def cancel_run(
+    run_id: str,
+    *,
+    get_job: RunLookup,
+    external_job_status: StatusMapper,
+    request_job_cancel: Callable[[str], bool],
+    json_error: JsonError,
+) -> schemas.StatusResponse | Any:
+    """Request cancellation for a canonical run while preserving API response semantics."""
+
+    job = get_job(run_id)
+    if not job:
+        return json_error(404, "not_found", "Run not found")
+
+    status = external_job_status(job.get("status", ""))
+    if status in {"SUCCEEDED", "FAILED"}:
+        return json_error(409, "already_finished", "Run already finished")
+
+    request_job_cancel(run_id)
+    job = get_job(run_id) or job
+    status = external_job_status(job.get("status", ""))
+    return schemas.StatusResponse(status=status, id=run_id)
+
+
+def run_detail(
+    run_id: str,
+    *,
+    get_job: RunLookup,
+    get_legacy_run: RunLookup,
+    canonical_run_payload: Callable[[Dict[str, Any]], Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return canonical payload for canonical runs, fallback to legacy run payload otherwise."""
+
+    job = get_job(run_id)
+    if job and job.get("job_type") == "canonical_run":
+        return canonical_run_payload(job)
+
+    payload = get_legacy_run(run_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return payload
+
+
+def run_result(
+    run_id: str,
+    *,
+    get_job: RunLookup,
+    external_job_status: StatusMapper,
+    is_terminal_status: TerminalStatusPredicate,
+    json_error: JsonError,
+) -> Dict[str, Any] | Any:
+    """Return canonical run result payload while keeping compatibility for pending states."""
+
+    job = get_job(run_id)
+    if not job or job.get("job_type") != "canonical_run":
+        return json_error(404, "not_found", "Run not found")
+
+    status = external_job_status(job.get("status", ""))
+    payload: Dict[str, Any] = {
+        "run_id": job.get("job_id"),
+        "request_id": job.get("job_id"),
+        "requestId": job.get("job_id"),
+        "status": status,
+    }
+    if not is_terminal_status(status):
+        payload["message"] = "Result not available yet"
+        return payload
+
+    result = job.get("result")
+    if result is not None:
+        payload["result"] = result
+    if job.get("error_message"):
+        payload["error"] = {"code": "execution_error", "message": job.get("error_message")}
+    if isinstance(result, dict) and "error" in result:
+        payload["error"] = result.get("error")
+    return payload
+
+
+def run_artifacts(
+    run_id: str,
+    *,
+    get_job: RunLookup,
+    schema_version: str,
+) -> Dict[str, Any]:
+    """Return artifact listing for a canonical run output directory."""
+
+    job = get_job(run_id)
+    if not job or job.get("job_type") != "canonical_run":
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    payload = job.get("payload") if isinstance(job.get("payload"), Mapping) else {}
+    request = payload.get("request") if isinstance(payload.get("request"), Mapping) else {}
+    output = request.get("output") if isinstance(request.get("output"), Mapping) else {}
+    out_dir_raw = output.get("out_dir")
+    out_dir = Path(str(out_dir_raw)).expanduser() if isinstance(out_dir_raw, str) and out_dir_raw.strip() else None
+
+    files: list[dict[str, Any]] = []
+    if out_dir and out_dir.exists() and out_dir.is_dir():
+        for item in sorted(out_dir.iterdir()):
+            if item.is_file():
+                files.append({"name": item.name, "path": str(item), "size_bytes": item.stat().st_size})
+
+    file_names = {entry["name"] for entry in files}
+    contract_artifacts = {
+        "best_plausible_passive_ex_ante": {
+            "json": "best_plausible_passive_ex_ante.json" if "best_plausible_passive_ex_ante.json" in file_names else None,
+            "parquet": "best_plausible_passive_ex_ante.parquet" if "best_plausible_passive_ex_ante.parquet" in file_names else None,
+        }
+    }
+    return {
+        "run_id": run_id,
+        "schema_version": schema_version,
+        "out_dir": str(out_dir) if out_dir is not None else None,
+        "files": files,
+        "contract_artifacts": contract_artifacts,
+        "audit_trail": {
+            "run_manifest": "run_manifest.json" if "run_manifest.json" in file_names else None,
+            "checksums": "checksums.txt" if "checksums.txt" in file_names else None,
+        },
+    }

--- a/tests/api/test_runs_service_endpoints.py
+++ b/tests/api/test_runs_service_endpoints.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import types
+
+import pytest
+from fastapi.responses import JSONResponse
+
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_stub.connect = lambda *args, **kwargs: None
+    cursors_stub = types.ModuleType("pymysql.cursors")
+    cursors_stub.DictCursor = object
+    pymysql_stub.cursors = cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = cursors_stub
+
+from quant_engine.api import app as api_app
+from quant_engine.config import reset_settings_cache
+
+
+@pytest.fixture
+def api_db(tmp_path):
+    os.environ["DB_SQLITE_PATH"] = str(tmp_path / "quant.db")
+    reset_settings_cache()
+    yield
+    os.environ.pop("DB_SQLITE_PATH", None)
+    reset_settings_cache()
+
+
+def test_run_result_endpoint_not_found_still_returns_json_error(api_db):
+    response = api_app.run_result_endpoint("missing-run")
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 404
+    assert response.body == b'{"code":"not_found","message":"Run not found"}'
+
+
+def test_runs_cancel_endpoint_still_returns_conflict_when_already_finished(api_db):
+    run_id = "finished-run"
+    api_app._init_job(
+        run_id,
+        api_app.JOB_TYPE_CANONICAL_RUN,
+        payload={"request": {"spec_type": "market_stats"}},
+        status=api_app.JOB_STATUS_SUCCEEDED,
+    )
+
+    response = api_app.runs_service.cancel_run(
+        run_id,
+        get_job=api_app._get_job,
+        external_job_status=api_app._external_job_status,
+        request_job_cancel=api_app.request_job_cancel,
+        json_error=api_app._json_error,
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 409
+    assert response.body == b'{"code":"already_finished","message":"Run already finished"}'
+
+
+def test_run_detail_endpoint_still_returns_canonical_payload(api_db):
+    run_id = "canonical-run"
+    api_app._init_job(
+        run_id,
+        api_app.JOB_TYPE_CANONICAL_RUN,
+        payload={"request": {"spec_type": "market_stats"}},
+        status=api_app.JOB_STATUS_RUNNING_CANONICAL,
+    )
+
+    payload = api_app.run_detail_endpoint(run_id)
+
+    assert payload["run_id"] == run_id
+    assert payload["status"] == api_app.JOB_STATUS_RUNNING_CANONICAL
+    assert payload["job_type"] == api_app.JOB_TYPE_CANONICAL_RUN


### PR DESCRIPTION
### Motivation
- Découper la logique métier des endpoints `runs` pour réduire le couplage et garder les routes FastAPI fines (validation + appel de service).
- Faciliter le test unitaire et l'injection de dépendances pour le comportement lié aux runs (lookup job, mapping status, erreurs JSON).

### Description
- Ajout de `src/quant_engine/api/services/runs.py` implémentant `cancel_run`, `run_detail`, `run_result` et `run_artifacts` avec signatures paramétrées pour injecter les helpers nécessaires.
- Ajout de `src/quant_engine/api/services/__init__.py` pour exposer la couche service.
- Modification de `src/quant_engine/api/app.py` pour déléguer `POST /runs/{run_id}/cancel`, `GET /runs/{run_id}`, `GET /runs/{run_id}/result` et la logique d'artifacts à la nouvelle couche service afin de rendre les endpoints plus minces.
- Ajout du test `tests/api/test_runs_service_endpoints.py` qui vérifie la compatibilité des réponses (404 JSON, 409 conflict, payload canonique) après la refactorisation.

### Testing
- Exécuté `poetry run pytest -q tests/api` et obtenu des échecs (6 tests failing) dans le flux de benchmark DCA existant où des jobs canoniques restent `QUEUED` avec une erreur `'NoneType' object is not iterable'`, problème constaté comme indépendant de l'extraction des endpoints.
- Exécuté `PYTHONPATH=src poetry run pytest -q tests/api/test_dca_artifact_endpoints.py tests/api/test_runs_service_endpoints.py` et obtenu un succès (6 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95071d36c8323b75b8ee33f86c4d2)