### PR TITLE
test: renforcer les règles d'import d'architecture

### DIFF
--- a/tests/architecture/test_import_rules.py
+++ b/tests/architecture/test_import_rules.py
@@ -6,14 +6,23 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SOURCE_ROOT = PROJECT_ROOT / "src" / "quant_engine"
 
-# module -> forbidden top-level package imports
+# module critique -> imports top-level interdits
 FORBIDDEN_IMPORTS: dict[str, set[str]] = {
-    "core": {"api", "backtest", "optimize"},
+    "core": {"api", "backtest", "cli", "live", "optimize", "performance", "seasonality"},
+    "market_intelligence": {"api", "backtest", "cli", "live", "optimize", "performance"},
+    "strategies": {"api", "cli"},
+    "stats": {"cli"},
 }
 
+REMEDIATION_MESSAGE = (
+    "Remédiation: déplacer les contrats/types partagés dans quant_engine.core "
+    "(ou quant_engine.market_intelligence pour les features de marché), "
+    "puis injecter les dépendances depuis les couches d'orchestration (api/cli/live)."
+)
 
-def _module_name_from_path(file_path: Path) -> str:
-    relative = file_path.relative_to(SOURCE_ROOT)
+
+def _module_name_from_path(file_path: Path, *, source_root: Path = SOURCE_ROOT) -> str:
+    relative = file_path.relative_to(source_root)
     return ".".join(("quant_engine",) + relative.with_suffix("").parts)
 
 
@@ -32,8 +41,8 @@ def _resolve_imported_module(current_module: str, node: ast.ImportFrom) -> str |
     return ".".join(resolved_parts)
 
 
-def _iter_project_import_targets(file_path: Path) -> list[str]:
-    module_name = _module_name_from_path(file_path)
+def _iter_project_import_targets(file_path: Path, *, source_root: Path = SOURCE_ROOT) -> list[str]:
+    module_name = _module_name_from_path(file_path, source_root=source_root)
     tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
     targets: list[str] = []
 
@@ -48,17 +57,21 @@ def _iter_project_import_targets(file_path: Path) -> list[str]:
     return [target for target in targets if target.startswith("quant_engine.")]
 
 
-def test_architecture_forbidden_imports() -> None:
+def _collect_forbidden_import_violations(
+    *,
+    source_root: Path,
+    forbidden_imports: dict[str, set[str]],
+) -> list[str]:
     violations: list[str] = []
 
-    for file_path in SOURCE_ROOT.rglob("*.py"):
-        source_module = _module_name_from_path(file_path)
+    for file_path in source_root.rglob("*.py"):
+        source_module = _module_name_from_path(file_path, source_root=source_root)
         source_package = source_module.split(".")[1]
-        forbidden_targets = FORBIDDEN_IMPORTS.get(source_package, set())
+        forbidden_targets = forbidden_imports.get(source_package, set())
         if not forbidden_targets:
             continue
 
-        for imported_module in _iter_project_import_targets(file_path):
+        for imported_module in _iter_project_import_targets(file_path, source_root=source_root):
             imported_parts = imported_module.split(".")
             if len(imported_parts) < 2:
                 continue
@@ -69,4 +82,48 @@ def test_architecture_forbidden_imports() -> None:
                     f"(règle: {source_package} ne doit pas dépendre de {target_package})"
                 )
 
-    assert not violations, "Dépendances interdites détectées:\n- " + "\n- ".join(sorted(violations))
+    return sorted(violations)
+
+
+def test_architecture_forbidden_imports() -> None:
+    violations = _collect_forbidden_import_violations(
+        source_root=SOURCE_ROOT,
+        forbidden_imports=FORBIDDEN_IMPORTS,
+    )
+
+    assert not violations, (
+        "Dépendances interdites détectées:\n- "
+        + "\n- ".join(violations)
+        + "\n\n"
+        + REMEDIATION_MESSAGE
+    )
+
+
+def test_architecture_forbidden_imports_detects_synthetic_violation(tmp_path: Path) -> None:
+    source_root = tmp_path / "src" / "quant_engine"
+    core_dir = source_root / "core"
+    api_dir = source_root / "api"
+    core_dir.mkdir(parents=True)
+    api_dir.mkdir(parents=True)
+
+    (source_root / "__init__.py").write_text("", encoding="utf-8")
+    (core_dir / "__init__.py").write_text("", encoding="utf-8")
+    (api_dir / "__init__.py").write_text("", encoding="utf-8")
+    (core_dir / "service.py").write_text("from quant_engine.api import app\n", encoding="utf-8")
+
+    violations = _collect_forbidden_import_violations(
+        source_root=source_root,
+        forbidden_imports={"core": {"api"}},
+    )
+
+    assert violations == [
+        "quant_engine.core.service -> quant_engine.api interdit "
+        "(règle: core ne doit pas dépendre de api)"
+    ]
+
+
+def test_architecture_forbidden_imports_remediation_message() -> None:
+    message = "Dépendances interdites détectées:\n- foo\n\n" + REMEDIATION_MESSAGE
+
+    assert "Remédiation:" in message
+    assert "injecter les dépendances" in message


### PR DESCRIPTION
### Motivation
- Renforcer la protection de l'architecture en élargissant les règles d'import interdits aux modules critiques identifiés dans le schéma d'architecture.
- Faciliter la maintenance et la vérification par des tests automatisés et un message de remédiation clair lorsqu'une violation est détectée.

### Description
- Étend `FORBIDDEN_IMPORTS` pour couvrir `core`, `market_intelligence`, `strategies` et `stats` avec leurs dépendances interdites.
- Factorise la logique de collecte des violations dans `_collect_forbidden_import_violations(...)` pour réutilisation et testabilité.
- Ajoute un `REMEDIATION_MESSAGE` explicite intégré à l'assert principal pour guider la correction des violations.
- Ajoute deux tests supplémentaires: un test synthétique qui crée une violation artificielle et un test qui valide la présence du message de remédiation.

### Testing
- Exécuté `poetry run pytest -q tests/architecture/test_import_rules.py` et obtenu `3 passed`.
- Les tests vérifient le scan réel du codebase, la détection d'un cas synthétique et la présence du message de remédiation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95d0ccf988323bb27b92ade4f88bd)