### PR TITLE
PY-MI-EPIC-1A: fix MI injection, restore on_bar feature propagation, add import smoke test

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -155,11 +155,12 @@ def _resolve_market_features(
     symbol: str,
     mi_service: MarketIntelligenceService | None,
 ) -> Mapping[str, Any]:
-    settings = get_settings()
-    if not settings.market_intelligence_enabled:
+    if mi_service is not None:
+        service = mi_service
+    elif get_settings().market_intelligence_enabled:
         service = _NullMarketIntelligenceService()
     else:
-        service = mi_service or _NullMarketIntelligenceService()
+        service = _NullMarketIntelligenceService()
     frame = _rows_to_frame(rows)
     return service.build_snapshot(symbol, frame)
 

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -165,7 +165,6 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
     screening_cfg = optimization_cfg.get("screening") or spec.get("screening") or {}
     cache_cfg = optimization_cfg.get("cache_features") or {}
     cache_enabled = bool(cache_cfg) and cache_cfg.get("enabled", True) is not False
-    mi_enabled = _market_intelligence_enabled(spec)
     universe: Iterable[Mapping[str, Any]] = _expand_universe(spec)
     signals_by_symbol: Dict[str, List[Dict[str, Any]]] = {}
     counts: Dict[str, int] = {}
@@ -269,7 +268,7 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
         t_signals = time.monotonic()
         context = {"symbol": symbol, "asset_class": asset_class, "screening": screening_cfg}
         context = universe_adapter.adapt_context(context, universe_rules)
-        feature_rows_by_ts = _extract_features_rows_by_ts(df) if mi_enabled else {}
+        feature_rows_by_ts = _extract_features_rows_by_ts(df)
         if feature_rows_by_ts:
             context["features_by_ts"] = feature_rows_by_ts
         on_bar = getattr(strategy, "on_bar", None)

--- a/tests/core/test_core_import_compat_smoke.py
+++ b/tests/core/test_core_import_compat_smoke.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+
+def test_consumer_layers_can_import_core_packages() -> None:
+    backtest_runner = importlib.import_module("quant_engine.backtest.runner")
+    strategies_runner = importlib.import_module("quant_engine.strategies.runner")
+
+    core_domain = importlib.import_module("quant_engine.core.domain")
+    core_contracts = importlib.import_module("quant_engine.core.contracts")
+
+    assert backtest_runner is not None
+    assert strategies_runner is not None
+    assert hasattr(core_domain, "Candle")
+    assert hasattr(core_contracts, "MarketIntelligenceService")


### PR DESCRIPTION
### Motivation
- Finalize EPIC-1 non-regression by ensuring explicit market-intelligence injection is honored and that timestamp-aligned MI features continue to be delivered to `on_bar` strategies while keeping core contracts importable from consumer layers.

### Description
- Prefer an explicitly provided `mi_service` in `quant_engine.backtest.runner._resolve_market_features` so a passed service is always used to build the snapshot.
- Always extract timestamp-aligned feature rows in `quant_engine.strategies.runner` via `_extract_features_rows_by_ts` and pass `features_row` to `on_bar` calls to preserve existing behavior.
- Add a smoke test `tests/core/test_core_import_compat_smoke.py` that stubs `pymysql` and asserts consumer layers can import `quant_engine.core.domain` and `quant_engine.core.contracts`.

### Testing
- Ran `poetry run pytest -q tests/architecture/test_import_rules.py` and observed `3 passed in 0.19s`.
- Ran `poetry run pytest -q tests/backtest tests/strategies` and observed `23 passed, 2 warnings in 1.32s`.
- Ran `poetry run pytest -q tests/core/test_core_import_compat_smoke.py` and observed `1 passed in 1.08s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96499d300832398235645b8110a6d)