### PR TITLE
PY-MI-EPIC-4A: normalize UTC timestamps for seasonality MI label joins

### DIFF
--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -44,14 +44,33 @@ def _rows_to_polars(rows: Sequence[Dict[str, Any]]) -> pl.DataFrame:
         return pl.DataFrame()
     df = pl.DataFrame(rows)
     if "timestamp" in df.columns:
-        ts_dtype = df.schema.get("timestamp")
-        if ts_dtype == pl.Utf8:
-            df = df.with_columns(
-                pl.col("timestamp").str.strptime(pl.Datetime, strict=False)
-            )
-        elif ts_dtype != pl.Datetime:
-            df = df.with_columns(pl.col("timestamp").cast(pl.Datetime))
+        df = _ensure_utc_timestamp(df, "timestamp")
     return df
+
+
+def _ensure_utc_timestamp(dataset: pl.DataFrame, column: str) -> pl.DataFrame:
+    """Normalise a Polars datetime column to timezone-aware UTC."""
+
+    if column not in dataset.columns:
+        return dataset
+
+    dtype = dataset.schema.get(column)
+    if dtype == pl.Utf8:
+        expr = pl.col(column).str.to_datetime(strict=False, utc=True)
+    elif dtype == pl.Datetime:
+        expr = pl.col(column).dt.replace_time_zone("UTC")
+    elif isinstance(dtype, pl.Datetime):
+        tz = getattr(dtype, "time_zone", None)
+        if tz == "UTC":
+            return dataset
+        expr = (
+            pl.col(column).dt.replace_time_zone("UTC")
+            if tz is None
+            else pl.col(column).dt.convert_time_zone("UTC")
+        )
+    else:
+        expr = pl.col(column).cast(pl.Datetime).dt.replace_time_zone("UTC")
+    return dataset.with_columns(expr.alias(column))
 
 
 def _rows_to_pandas(rows: Sequence[Dict[str, Any]]) -> pd.DataFrame:
@@ -302,6 +321,8 @@ def _attach_mi_labels(dataset: pl.DataFrame, enabled: bool) -> pl.DataFrame:
     if not enabled or dataset.is_empty() or "timestamp" not in dataset.columns or "symbol" not in dataset.columns:
         return dataset
 
+    dataset = _ensure_utc_timestamp(dataset, "timestamp")
+
     labels_frames: list[pl.DataFrame] = []
     for symbol in dataset.get_column("symbol").drop_nulls().unique().to_list():
         symbol_df = dataset.filter(pl.col("symbol") == symbol).sort("timestamp")
@@ -313,14 +334,14 @@ def _attach_mi_labels(dataset: pl.DataFrame, enabled: bool) -> pl.DataFrame:
         labels = mi_label_regimes(features).reset_index().rename(columns={"ts": "timestamp"})
         labels["symbol"] = symbol
         labels_pl = pl.from_pandas(labels)
-        if "timestamp" in labels_pl.columns and labels_pl.schema.get("timestamp") != pl.Datetime:
-            labels_pl = labels_pl.with_columns(pl.col("timestamp").cast(pl.Datetime))
+        labels_pl = _ensure_utc_timestamp(labels_pl, "timestamp")
         labels_frames.append(labels_pl)
 
     if not labels_frames:
         return dataset
 
     all_labels = pl.concat(labels_frames, how="vertical", rechunk=True)
+    all_labels = _ensure_utc_timestamp(all_labels, "timestamp")
     join_cols = ["symbol", "timestamp"]
     label_cols = [col for col in all_labels.columns if col.startswith("label_")]
     if not label_cols:

--- a/tests/integration/test_seasonality_with_mi_labels.py
+++ b/tests/integration/test_seasonality_with_mi_labels.py
@@ -76,3 +76,23 @@ def test_seasonality_profiles_include_global_and_mi_segmented_stats() -> None:
     assert segmented_rows.height > 0
     assert set(segmented_rows.get_column("mi_label_name").unique().to_list()) == {"label_regime"}
     assert all(v is not None for v in segmented_rows.get_column("mi_label_value").to_list())
+
+
+def test_timestamp_keys_are_normalized_to_utc_before_join() -> None:
+    df = pl.DataFrame(
+        {
+            "timestamp": ["2025-01-01T00:00:00", "2025-01-01T01:00:00"],
+            "symbol": ["BTC-USD", "BTC-USD"],
+            "open": [100.0, 100.5],
+            "high": [101.0, 101.2],
+            "low": [99.8, 100.1],
+            "close": [100.5, 100.8],
+            "volume": [1000, 1001],
+        }
+    )
+
+    normalized = runner._ensure_utc_timestamp(df, "timestamp")
+    timestamp_dtype = normalized.schema["timestamp"]
+
+    assert isinstance(timestamp_dtype, pl.Datetime)
+    assert timestamp_dtype.time_zone == "UTC"


### PR DESCRIPTION
### Motivation
- Fix joins between seasonality features and MI labels that failed when keys mixed naive `datetime` and timezone-aware `Datetime[UTC]` types.
- Ensure `segment_by_mi_labels` path is robust and does not silently drop segmented MI stats due to timestamp dtype mismatch.
- Keep analytics snapshot payload shape (global + segmented MI outputs) stable while eliminating timezone-related join flakiness.

### Description
- Added helper ` _ensure_utc_timestamp(dataset, column)` to normalise a Polars datetime column to timezone-aware UTC and return a dataset with `Datetime[UTC]` timestamps.
- Applied ` _ensure_utc_timestamp` to row ingestion (`_rows_to_polars`) and to the MI label attachment path so both sides of the join are normalised before merging (`_attach_mi_labels` applies it to the dataset, each per-symbol labels frame, and the concatenated `all_labels`).
- Replaced ad-hoc casts with the new helper to handle `Utf8`, naive `Datetime`, and timezone-bearing `Datetime` variants deterministically.
- Added an integration regression test `test_timestamp_keys_are_normalized_to_utc_before_join` in `tests/integration/test_seasonality_with_mi_labels.py` that asserts the `timestamp` column becomes `Datetime[UTC]` after normalization.

### Testing
- Ran `poetry run pytest -q tests/integration/test_seasonality_with_mi_labels.py`, which was skipped in this environment due to `polars` being gated by `pytest.importorskip("polars")` (test added and exercised where `polars` is available).
- Ran `poetry run pytest -q tests/integration/test_analytics_snapshots.py`, which passed (1 passed).
- Ran the broader suite with `poetry run pytest -q tests/stats tests/integration tests/io`, which surfaced a pre-existing unrelated failure in `tests/integration/test_dca_benchmark_specs.py::test_benchmark_specs_run_and_share_output_schema` causing the run to fail; the failure is not caused by the timezone normalization changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9683a0a7483238419ca5d5345a2d9)