### PR TITLE
[Follow-up] Fix zoned timestamp UTC normalization in seasonality joins

### DIFF
--- a/src/quant_engine/seasonality/runner.py
+++ b/src/quant_engine/seasonality/runner.py
@@ -57,8 +57,6 @@ def _ensure_utc_timestamp(dataset: pl.DataFrame, column: str) -> pl.DataFrame:
     dtype = dataset.schema.get(column)
     if dtype == pl.Utf8:
         expr = pl.col(column).str.to_datetime(strict=False, utc=True)
-    elif dtype == pl.Datetime:
-        expr = pl.col(column).dt.replace_time_zone("UTC")
     elif isinstance(dtype, pl.Datetime):
         tz = getattr(dtype, "time_zone", None)
         if tz == "UTC":

--- a/tests/integration/test_seasonality_with_mi_labels.py
+++ b/tests/integration/test_seasonality_with_mi_labels.py
@@ -96,3 +96,23 @@ def test_timestamp_keys_are_normalized_to_utc_before_join() -> None:
 
     assert isinstance(timestamp_dtype, pl.Datetime)
     assert timestamp_dtype.time_zone == "UTC"
+
+
+def test_existing_time_zones_are_converted_to_utc_without_shifting_instants() -> None:
+    df = pl.DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 1, 1, 1, 0, tzinfo=timezone.utc),
+            ],
+            "symbol": ["BTC-USD", "BTC-USD"],
+        }
+    ).with_columns(pl.col("timestamp").dt.convert_time_zone("America/New_York"))
+
+    normalized = runner._ensure_utc_timestamp(df, "timestamp")
+
+    assert normalized.schema["timestamp"].time_zone == "UTC"
+    assert normalized.get_column("timestamp").to_list() == [
+        datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
+        datetime(2025, 1, 1, 1, 0, tzinfo=timezone.utc),
+    ]


### PR DESCRIPTION
### Motivation
- Polars `pl.Datetime` schema can represent timezone-aware datetimes and was accidentally handled by a branch that used `replace_time_zone("UTC")`, which relabels wall-clock values and shifts instants for zoned inputs.
- This could skew seasonality bins and MI label joins when ingesting non-UTC timezone-aware timestamps.

### Description
- Reworked `_ensure_utc_timestamp` in `src/quant_engine/seasonality/runner.py` to detect Polars datetime dtypes using `isinstance(dtype, pl.Datetime)` so timezone-aware dtypes are handled in the correct branch.
- Use `convert_time_zone("UTC")` for already-zoned datetimes and `replace_time_zone("UTC")` only for naive datetimes or casts, preserving instant times when converting zones.
- Added an integration regression test `test_existing_time_zones_are_converted_to_utc_without_shifting_instants` in `tests/integration/test_seasonality_with_mi_labels.py` to assert zoned timestamps are converted to `Datetime[UTC]` without changing the instant values.

### Testing
- Ran `poetry run pytest -q tests/integration/test_seasonality_with_mi_labels.py`, which was skipped in this environment due to `polars` being gated via `pytest.importorskip("polars")` (test present and exercises the fix where `polars` is available).
- Ran `poetry run pytest -q tests/integration/test_analytics_snapshots.py`, which passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96c01862c83238e94b56b21aef6df)