### PR TITLE
PY-MI-EPIC-5A: extract stats handlers to service, add DI smoke tests and update MI runbook

### DIFF
--- a/docs/market_intelligence_runbook.md
+++ b/docs/market_intelligence_runbook.md
@@ -203,3 +203,21 @@ Procédure minimale de validation doc :
 2. vérifier la CLI disponible localement via `qe --help`,
 3. consigner les écarts éventuels (ex. sous-commande non exposée dans ce build) avant exécution en production.
 
+
+## 8) Commandes de non-régression et preuves
+
+Exécuter les checks suivants avant validation d'un changement MI/legacy:
+
+```bash
+poetry run pytest -q tests/api
+poetry run pytest -q tests/architecture/test_import_rules.py
+poetry run pytest -q tests/integration/test_kpi_non_regression_mi.py
+poetry run pytest -q
+```
+
+À archiver dans la PR/ticket:
+
+- commande exécutée,
+- statut (pass/fail),
+- extrait de sortie (ou lien artifact CI),
+- horodatage et commit SHA.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -35,7 +35,6 @@ from ..io.dca_artifacts import SCHEMA_VERSION
 from ..persistence import db, RunsRepository, MetricsRepository, TrialsRepository, extract_dca_run_metrics
 from ..stats import runner as stats_runner
 from ..stats import conditions as stats_conditions
-from ..stats.estimators import freq_with_wilson
 from ..seasonality import runner as seasonality_runner
 from ..seasonality.optimize import run_optimization as seasonality_run_optimization
 from ..strategies import runner as strategies_runner
@@ -43,6 +42,7 @@ from ..performance import stress_tests as stress_tests_runner
 from ..filters import list_filter_types
 from . import schemas
 from .services import runs as runs_service
+from .services import stats as stats_service
 from .run_request_input import validate_run_request_input
 from .validation_errors import (
     ApiValidationException,
@@ -3330,59 +3330,20 @@ def list_stats(
     page_size: int = 50,
 ) -> List[Dict[str, Any]]:
     """Return statistics rows filtered and ordered according to parameters."""
-
-    with db.session() as conn:
-        query = "SELECT * FROM market_stats"
-        params: List[Any] = []
-        clauses: List[str] = []
-        if symbol:
-            clauses.append("symbol = ?")
-            params.append(symbol)
-        if timeframe:
-            clauses.append("timeframe = ?")
-            params.append(timeframe)
-        if event:
-            clauses.append("event = ?")
-            params.append(event)
-        if condition_name:
-            clauses.append("condition_name = ?")
-            params.append(condition_name)
-        if target:
-            clauses.append("target = ?")
-            params.append(target)
-        if split:
-            clauses.append("split = ?")
-            params.append(split)
-        if min_n is not None:
-            clauses.append("n >= ?")
-            params.append(min_n)
-        if clauses:
-            query += " WHERE " + " AND ".join(clauses)
-
-        rows = conn.execute(query, params).fetchall()
-
-    out = [dict(r) for r in rows]
-
-    for r in out:
-        if "lift_freq" not in r and "lift" in r:
-            r["lift_freq"] = r.get("lift")
-        if "lift_bayes" not in r:
-            r["lift_bayes"] = r.get("lift_freq")
-
-    if significant_only:
-        out = [
-            r
-            for r in out
-            if r.get("significant")
-            or (r.get("q_value") is not None and r["q_value"] <= alpha)
-        ]
-
-    key = "lift_bayes" if method == "bayes" else "lift_freq"
-    out.sort(key=lambda r: r.get(key, 0), reverse=True)
-
-    start = (page - 1) * page_size
-    end = start + page_size
-    return out[start:end]
+    return stats_service.list_stats(
+        symbol=symbol,
+        timeframe=timeframe,
+        event=event,
+        condition_name=condition_name,
+        target=target,
+        split=split,
+        min_n=min_n,
+        significant_only=significant_only,
+        method=method,
+        alpha=alpha,
+        page=page,
+        page_size=page_size,
+    )
 
 
 def stats_summary(
@@ -3390,44 +3351,7 @@ def stats_summary(
     timeframe: str | None = None,
     event: str | None = None,
 ) -> List[Dict[str, Any]]:
-    with db.session() as conn:
-        query = (
-            "SELECT condition_name, condition_value, target, SUM(n) as n, "
-            "SUM(successes) as successes FROM market_stats"
-        )
-        params: List[Any] = []
-        clauses: List[str] = []
-        if symbol:
-            clauses.append("symbol = ?")
-            params.append(symbol)
-        if timeframe:
-            clauses.append("timeframe = ?")
-            params.append(timeframe)
-        if event:
-            clauses.append("event = ?")
-            params.append(event)
-        if clauses:
-            query += " WHERE " + " AND ".join(clauses)
-        query += " GROUP BY condition_name, condition_value, target"
-        rows = conn.execute(query, params).fetchall()
-        out: List[Dict[str, Any]] = []
-        for r in rows:
-            n = int(r["n"])
-            successes = int(r["successes"])
-            p_hat, ci_low, ci_high = freq_with_wilson(successes, n)
-            out.append(
-                {
-                    "condition_name": r["condition_name"],
-                    "condition_value": r["condition_value"],
-                    "target": r["target"],
-                    "n": n,
-                    "successes": successes,
-                    "p_hat": p_hat,
-                    "ci_low": ci_low,
-                    "ci_high": ci_high,
-                }
-            )
-        return out
+    return stats_service.stats_summary(symbol=symbol, timeframe=timeframe, event=event)
 
 
 def stats_heatmap(
@@ -3438,27 +3362,13 @@ def stats_heatmap(
     condition_name: str,
 ) -> List[Dict[str, Any]]:
     """Return heatmap-style bins for a condition."""
-
-    base_query = (
-        "SELECT condition_value as bin, p_hat, ci_low, ci_high, n, lift "
-        "FROM market_stats WHERE symbol = ? AND timeframe = ? AND event = ? "
-        "AND target = ? AND condition_name = ?"
+    return stats_service.stats_heatmap(
+        symbol=symbol,
+        timeframe=timeframe,
+        event=event,
+        target=target,
+        condition_name=condition_name,
     )
-    params = [symbol, timeframe, event, target, condition_name]
-    with db.session() as conn:
-        rows = conn.execute(base_query + " AND split = 'test'", params).fetchall()
-        if not rows:
-            rows = conn.execute(base_query, params).fetchall()
-    out = [dict(r) for r in rows]
-
-    def sort_key(r: Dict[str, Any]):
-        try:
-            return float(r["bin"])
-        except (TypeError, ValueError):
-            return r["bin"]
-
-    out.sort(key=sort_key)
-    return out
 
 
 def stats_top(
@@ -3469,32 +3379,13 @@ def stats_top(
     significant_only: bool = False,
 ) -> List[Dict[str, Any]]:
     """Return top-k patterns ordered by lift for the chosen method."""
-
-    base_query = "SELECT * FROM market_stats WHERE symbol = ? AND timeframe = ?"
-    params = [symbol, timeframe]
-    with db.session() as conn:
-        rows = conn.execute(base_query + " AND split = 'test'", params).fetchall()
-        if not rows:
-            rows = conn.execute(base_query, params).fetchall()
-
-    data = [dict(r) for r in rows]
-
-    for r in data:
-        if "lift_freq" not in r and "lift" in r:
-            r["lift_freq"] = r.get("lift")
-        if "lift_bayes" not in r:
-            r["lift_bayes"] = r.get("lift_freq")
-
-    if significant_only:
-        data = [
-            r
-            for r in data
-            if r.get("significant") or (r.get("q_value") is not None and r["q_value"] <= 0.05)
-        ]
-
-    key = "lift_bayes" if method == "bayes" else "lift_freq"
-    rows_sorted = sorted(data, key=lambda r: abs(r.get(key, 0)), reverse=True)[:k]
-    return rows_sorted
+    return stats_service.stats_top(
+        symbol=symbol,
+        timeframe=timeframe,
+        k=k,
+        method=method,
+        significant_only=significant_only,
+    )
 
 
 

--- a/src/quant_engine/api/services/stats.py
+++ b/src/quant_engine/api/services/stats.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ...persistence import db
+from ...stats.estimators import freq_with_wilson
+
+
+def list_stats(
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    event: str | None = None,
+    condition_name: str | None = None,
+    target: str | None = None,
+    split: str | None = None,
+    min_n: int | None = None,
+    significant_only: bool = False,
+    method: str = "freq",
+    alpha: float = 0.05,
+    page: int = 1,
+    page_size: int = 50,
+) -> List[Dict[str, Any]]:
+    with db.session() as conn:
+        query = "SELECT * FROM market_stats"
+        params: List[Any] = []
+        clauses: List[str] = []
+        if symbol:
+            clauses.append("symbol = ?")
+            params.append(symbol)
+        if timeframe:
+            clauses.append("timeframe = ?")
+            params.append(timeframe)
+        if event:
+            clauses.append("event = ?")
+            params.append(event)
+        if condition_name:
+            clauses.append("condition_name = ?")
+            params.append(condition_name)
+        if target:
+            clauses.append("target = ?")
+            params.append(target)
+        if split:
+            clauses.append("split = ?")
+            params.append(split)
+        if min_n is not None:
+            clauses.append("n >= ?")
+            params.append(min_n)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        rows = conn.execute(query, params).fetchall()
+
+    out = [dict(r) for r in rows]
+    for row in out:
+        if "lift_freq" not in row and "lift" in row:
+            row["lift_freq"] = row.get("lift")
+        if "lift_bayes" not in row:
+            row["lift_bayes"] = row.get("lift_freq")
+
+    if significant_only:
+        out = [
+            row
+            for row in out
+            if row.get("significant") or (row.get("q_value") is not None and row["q_value"] <= alpha)
+        ]
+
+    key = "lift_bayes" if method == "bayes" else "lift_freq"
+    out.sort(key=lambda row: row.get(key, 0), reverse=True)
+
+    start = (page - 1) * page_size
+    end = start + page_size
+    return out[start:end]
+
+
+def stats_summary(
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    event: str | None = None,
+) -> List[Dict[str, Any]]:
+    with db.session() as conn:
+        query = (
+            "SELECT condition_name, condition_value, target, SUM(n) as n, "
+            "SUM(successes) as successes FROM market_stats"
+        )
+        params: List[Any] = []
+        clauses: List[str] = []
+        if symbol:
+            clauses.append("symbol = ?")
+            params.append(symbol)
+        if timeframe:
+            clauses.append("timeframe = ?")
+            params.append(timeframe)
+        if event:
+            clauses.append("event = ?")
+            params.append(event)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " GROUP BY condition_name, condition_value, target"
+        rows = conn.execute(query, params).fetchall()
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        n = int(row["n"])
+        successes = int(row["successes"])
+        p_hat, ci_low, ci_high = freq_with_wilson(successes, n)
+        out.append(
+            {
+                "condition_name": row["condition_name"],
+                "condition_value": row["condition_value"],
+                "target": row["target"],
+                "n": n,
+                "successes": successes,
+                "p_hat": p_hat,
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+            }
+        )
+    return out
+
+
+def stats_heatmap(
+    symbol: str,
+    timeframe: str,
+    event: str,
+    target: str,
+    condition_name: str,
+) -> List[Dict[str, Any]]:
+    base_query = (
+        "SELECT condition_value as bin, p_hat, ci_low, ci_high, n, lift "
+        "FROM market_stats WHERE symbol = ? AND timeframe = ? AND event = ? "
+        "AND target = ? AND condition_name = ?"
+    )
+    params = [symbol, timeframe, event, target, condition_name]
+    with db.session() as conn:
+        rows = conn.execute(base_query + " AND split = 'test'", params).fetchall()
+        if not rows:
+            rows = conn.execute(base_query, params).fetchall()
+
+    out = [dict(r) for r in rows]
+
+    def sort_key(row: Dict[str, Any]):
+        try:
+            return float(row["bin"])
+        except (TypeError, ValueError):
+            return row["bin"]
+
+    out.sort(key=sort_key)
+    return out
+
+
+def stats_top(
+    symbol: str,
+    timeframe: str,
+    k: int = 10,
+    method: str = "freq",
+    significant_only: bool = False,
+) -> List[Dict[str, Any]]:
+    base_query = "SELECT * FROM market_stats WHERE symbol = ? AND timeframe = ?"
+    params = [symbol, timeframe]
+    with db.session() as conn:
+        rows = conn.execute(base_query + " AND split = 'test'", params).fetchall()
+        if not rows:
+            rows = conn.execute(base_query, params).fetchall()
+
+    data = [dict(row) for row in rows]
+    for row in data:
+        if "lift_freq" not in row and "lift" in row:
+            row["lift_freq"] = row.get("lift")
+        if "lift_bayes" not in row:
+            row["lift_bayes"] = row.get("lift_freq")
+
+    if significant_only:
+        data = [
+            row
+            for row in data
+            if row.get("significant") or (row.get("q_value") is not None and row["q_value"] <= 0.05)
+        ]
+
+    key = "lift_bayes" if method == "bayes" else "lift_freq"
+    rows_sorted = sorted(data, key=lambda row: abs(row.get(key, 0)), reverse=True)[:k]
+    return rows_sorted

--- a/tests/api/test_di_smoke_paths.py
+++ b/tests/api/test_di_smoke_paths.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+
+if "pymysql" not in sys.modules:
+    pymysql_stub = types.ModuleType("pymysql")
+    pymysql_stub.connect = lambda *args, **kwargs: None
+    cursors_stub = types.ModuleType("pymysql.cursors")
+    cursors_stub.DictCursor = object
+    pymysql_stub.cursors = cursors_stub
+    sys.modules["pymysql"] = pymysql_stub
+    sys.modules["pymysql.cursors"] = cursors_stub
+
+from quant_engine.api import app as api_app
+
+
+@dataclass
+class _FakeParsedRequest:
+    payload: dict
+
+    def model_dump(self, mode: str = "json") -> dict:  # noqa: ARG002
+        return self.payload
+
+
+def test_optimize_path_smoke_uses_submit_dependency_injection(monkeypatch):
+    captured: dict = {}
+
+    def fake_run_job(job_type: str, payload: dict):
+        captured["job_type"] = job_type
+        captured["payload"] = payload
+        return "opt-job", {"ok": True}
+
+    monkeypatch.setattr(api_app, "_run_job", fake_run_job)
+
+    spec = api_app.Spec(
+        data=api_app.spec_module.DataSpec(
+            dataset_path="tests/data/ohlcv_dca_benchmark_daily.csv",
+            mysql=None,
+            symbols=["BTCUSDT"],
+            timeframe="1h",
+            start="2025-01-01T00:00:00Z",
+            end="2025-01-02T00:00:00Z",
+        ),
+        strategy=api_app.spec_module.StrategySpec(
+            filters=api_app.spec_module.FiltersSpec(ema_fast=10, ema_slow=20),
+            tpsl=api_app.spec_module.TPSLSpec(atr_k=1.0),
+            validation=api_app.spec_module.ValidationSpec(),
+            objective="sharpe",
+            search_space={"ema_fast": [10]},
+        ),
+    )
+    response = api_app.submit(spec)
+
+    assert response.id == "opt-job"
+    assert captured["job_type"] == api_app.JOB_TYPE_OPTIMIZATION
+    assert captured["payload"]["spec"]["data"]["symbols"] == ["BTCUSDT"]
+
+
+def test_backtest_path_smoke_queues_canonical_run_with_injected_dependencies(monkeypatch):
+    monkeypatch.setattr(
+        api_app,
+        "validate_run_request_input",
+        lambda payload: _FakeParsedRequest(payload),
+    )
+    monkeypatch.setattr(api_app, "_validate_canonical_market_stats_params", lambda payload: None)
+    monkeypatch.setattr(api_app, "_normalize_request_id", lambda _: None)
+    monkeypatch.setattr(api_app.ids, "generate_id", lambda: "run-di-001")
+    monkeypatch.setattr(api_app, "_canonical_job_defaults", lambda: (3, 900))
+
+    captured: dict = {}
+
+    def fake_init_job(job_id, job_type, payload, *, status, max_attempts, timeout_seconds):
+        captured.update(
+            {
+                "job_id": job_id,
+                "job_type": job_type,
+                "payload": payload,
+                "status": status,
+                "max_attempts": max_attempts,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+
+    monkeypatch.setattr(api_app, "_init_job", fake_init_job)
+
+    response = api_app.enqueue_run_request(
+        {
+            "spec_type": "backtest",
+            "request_id": None,
+            "data": {"symbol": "BTCUSDT", "timeframe": "1h"},
+        }
+    )
+
+    assert response.run_id == "run-di-001"
+    assert response.status == api_app.JOB_STATUS_QUEUED
+    assert captured["job_type"] == api_app.JOB_TYPE_CANONICAL_RUN
+
+
+def test_mi_path_smoke_stats_run_uses_injected_job_runner(monkeypatch):
+    captured: dict = {}
+
+    def fake_run_job(job_type: str, payload: dict):
+        captured["job_type"] = job_type
+        captured["payload"] = payload
+        return "stats-job", {"rows": 1}
+
+    monkeypatch.setattr(api_app, "_run_job", fake_run_job)
+
+    spec = api_app.schemas.StatsSpec(
+        data=api_app.schemas.StatsDataSpec(
+            symbols=["BTCUSDT"],
+            timeframe="1h",
+            start="2025-01-01T00:00:00Z",
+            end="2025-01-02T00:00:00Z",
+        ),
+        events=[api_app.schemas.StatsEventSpec(name="next_n_bars", params={"n": 3, "direction": "up"})],
+        conditions=[],
+        targets=[api_app.schemas.StatsTargetSpec(name="up_3", params={"horizon": 3})],
+    )
+
+    response = api_app.stats_run(spec)
+
+    assert response.id == "stats-job"
+    assert response.status == "completed"
+    assert captured["job_type"] == api_app.JOB_TYPE_STATS


### PR DESCRIPTION
### Motivation
- Reduce the monolithic `api/app.py` by moving market-stats read/aggregation logic out of the API layer into a dedicated service to improve separation of concerns and make DI/testing easier.
- Add lightweight dependency-injection smoke tests for critical paths (optimize, canonical run/backtest enqueue, MI stats run) to catch regressions early without full integration stack.
- Document the non-regression commands and evidence to archive for MI/legacy migrations in the runbook so reviewers can reproduce validation steps.

### Description
- Extracted market statistics logic into a new service module `src/quant_engine/api/services/stats.py` implementing `list_stats`, `stats_summary`, `stats_heatmap`, and `stats_top` and preserved original behavior (SQL, aggregation, sorting, significance filtering).
- Updated `src/quant_engine/api/app.py` to import `stats_service` and delegate the thin API helper functions (`list_stats`, `stats_summary`, `stats_heatmap`, `stats_top`) to that service, reducing inline business logic.
- Added DI smoke tests in `tests/api/test_di_smoke_paths.py` that monkeypatch internal runners and repositories to assert orchestration contracts for optimization, canonical run enqueue, and stats-run submission.
- Extended `docs/market_intelligence_runbook.md` with a new section `## 8) Commandes de non-régression et preuves` listing the exact `pytest` commands and what to archive in PRs.

### Testing
- Ran `poetry run pytest -q tests/api/test_di_smoke_paths.py` and it passed (3 passed). 
- Ran `poetry run pytest -q tests/architecture/test_import_rules.py` and it passed (3 passed).
- Ran `poetry run pytest -q tests/integration/test_kpi_non_regression_mi.py` and it passed (1 passed).
- Ran `poetry run pytest -q tests/api` which produced remaining failures focused on DCA benchmark tests (5 failing in `tests/api/test_dca_benchmark_submit_api.py`).
- Ran full `poetry run pytest -q` which surfaced collection errors in HTTP contract tests (`TestClient` init issues) unrelated to the stats refactor; the failures and collection errors are documented above for follow-up investigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9696c99f883238cdbcdf0bc8581cb)