### PR TITLE
ci: add blocking pytest regression gate with artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,24 @@ jobs:
         run: poetry run black --check .
       - name: Type-check (mypy)
         run: poetry run mypy src
-      - name: Tests
-        run: poetry run pytest -q --disable-warnings
+      - name: Run full regression gate (pytest)
+        shell: bash
+        run: |
+          mkdir -p test-results
+          set +e
+          poetry run pytest -q --junitxml=test-results/junit.xml 2>&1 | tee test-results/pytest.log
+          test_exit_code=${PIPESTATUS[0]}
+          echo "pytest_exit_code=${test_exit_code}" >> "$GITHUB_OUTPUT"
+          if [ "${test_exit_code}" -ne 0 ]; then
+            echo "Regression gate failed: poetry run pytest -q"
+            exit 1
+          fi
+        id: regression_gate
+
+      - name: Upload regression artifacts (junit/log)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-gate-results
+          path: test-results/
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ export $(grep -v '^#' .env | xargs)
 - [Live Trading Runner](docs/live.md)
 - [High-level Strategies](docs/strategies_overview.md)
 
+## Reproduire la gate de régression CI en local
+Exécuter la suite complète de tests comme dans la CI :
+
+```bash
+poetry run pytest -q
+```
+
+Optionnel (si installé/projet configuré) :
+
+```bash
+poetry run ruff check src tests
+```
+
 ## Lancer l'API
 ```bash
 poetry run uvicorn quant_engine.api.app:app --reload --app-dir src
@@ -1150,4 +1163,3 @@ Outre `month` / `month_of_year`, vous pouvez analyser `quarter` (1–4) et les f
 
 - [Architecture & Récap Fonctionnel](docs/architecture_overview.md)
 - [Market Stats – Notes & Garde-fous](docs/market_stats_guidelines.md)
-


### PR DESCRIPTION
### Motivation
- The migration/hardening DoD requires running the full test suite via `poetry run pytest -q` as a blocking regression gate.
- Test results must be preserved as artifacts (JUnit and logs) for post-mortem on both success and failure.
- The CI must explicitly fail when tests fail so PR status remains blocking. 

### Description
- Update `.github/workflows/ci.yml` to run the full regression gate using `poetry run pytest -q --junitxml=test-results/junit.xml` and capture stdout to `test-results/pytest.log` while propagating pytest exit codes to fail the job. 
- Add an `actions/upload-artifact@v4` step with `if: always()` to publish the `test-results/` folder (JUnit + log) on success or failure. 
- Add a short reproduction note in `README.md` documenting `poetry run pytest -q` and optional `poetry run ruff check src tests` for local verification.

### Testing
- Ran `poetry run pytest -q` locally and the command exited with errors during test collection (`TypeError` from `TestClient` incompatibility), so the test run failed. 
- Ran `poetry run ruff check src tests` locally and it returned multiple pre-existing lint violations, so the lint check failed. 
- The CI workflow changes are present and will upload artifacts on every run, and the pytest step is implemented to fail the job when pytest returns a non-zero exit code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a975508ba883238898ded71ab0daa8)