### PR TITLE
PY-MI-3.6: Centralize MI toggle resolution and add consistency matrix tests

### DIFF
--- a/src/quant_engine/backtest/runner.py
+++ b/src/quant_engine/backtest/runner.py
@@ -17,7 +17,7 @@ from ..core import dataset
 from ..core.contracts import MarketIntelligenceService
 from ..core.features import atr
 from ..core.spec import DataSpec, parse_data_spec, uses_strategy_sources
-from ..config import get_settings
+from ..config import resolve_market_intelligence_enabled
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
 from ..performance.backtest_builder import build_backtest_payload
@@ -154,12 +154,10 @@ def _resolve_market_features(
     rows: List[Dict[str, Any]],
     symbol: str,
     mi_service: MarketIntelligenceService | None,
+    spec: Mapping[str, Any],
 ) -> Mapping[str, Any]:
-    mi_env_raw = os.getenv("MARKET_INTELLIGENCE_ENABLED")
-    mi_enabled = get_settings().market_intelligence_enabled
-    if mi_env_raw is None:
-        service = mi_service or _NullMarketIntelligenceService()
-    elif mi_enabled and mi_service is not None:
+    mi_enabled = resolve_market_intelligence_enabled(spec, default_enabled=True)
+    if mi_enabled and mi_service is not None:
         service = mi_service
     else:
         service = _NullMarketIntelligenceService()
@@ -289,7 +287,7 @@ def run_backtest_from_spec(
             pruning_cfg = candidate_pruning
 
     symbol = _detect_symbol(rows)
-    features = _resolve_market_features(rows, symbol, mi_service)
+    features = _resolve_market_features(rows, symbol, mi_service, spec)
     t_signal = time.monotonic()
     signal = _build_signal(spec, rows, features)
     _perf_log("backtest.build_signal", t_signal)

--- a/src/quant_engine/config.py
+++ b/src/quant_engine/config.py
@@ -12,6 +12,7 @@ variables at runtime.
 from dataclasses import dataclass
 import os
 from functools import lru_cache
+from typing import Any, Mapping
 
 
 @dataclass
@@ -32,6 +33,48 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     if lowered in {"0", "false", "no", "n", "off"}:
         return False
     return default
+
+
+def _coerce_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return None
+
+
+def resolve_market_intelligence_enabled(
+    spec: Mapping[str, Any] | None,
+    *,
+    default_enabled: bool,
+) -> bool:
+    """Resolve the MI toggle from spec override + env settings.
+
+    Precedence:
+    1. Spec override (`market_intelligence.enabled` or `mi.enabled`) when valid.
+    2. `MARKET_INTELLIGENCE_ENABLED` when explicitly present in env.
+    3. Caller-provided legacy default.
+    """
+
+    payload = spec or {}
+    for key in ("market_intelligence", "mi"):
+        mi_cfg = payload.get(key)
+        if isinstance(mi_cfg, Mapping) and "enabled" in mi_cfg:
+            resolved = _coerce_optional_bool(mi_cfg.get("enabled"))
+            if resolved is not None:
+                return resolved
+
+    if os.getenv("MARKET_INTELLIGENCE_ENABLED") is None:
+        return default_enabled
+    return get_settings().market_intelligence_enabled
 
 
 @lru_cache()

--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -18,7 +18,7 @@ from sqlalchemy import create_engine, inspect, text
 
 from . import create_strategy
 from .base import StrategySignal
-from ..config import get_settings
+from ..config import resolve_market_intelligence_enabled
 from ..integrations import java_client
 from ..filters.utils import apply_filter_stack, FilterValidationError
 from ..filters.trade_filter_service import score_filter_rules
@@ -142,15 +142,7 @@ def _extract_features_rows_by_ts(df: pd.DataFrame) -> Dict[pd.Timestamp, Dict[st
 
 
 def _market_intelligence_enabled(spec: Mapping[str, Any]) -> bool:
-    mi_cfg = spec.get("market_intelligence") or {}
-    if isinstance(mi_cfg, Mapping) and "enabled" in mi_cfg:
-        value = mi_cfg.get("enabled")
-        if isinstance(value, bool):
-            return value
-    mi_env_raw = os.getenv("MARKET_INTELLIGENCE_ENABLED")
-    if mi_env_raw is None:
-        return True
-    return get_settings().market_intelligence_enabled
+    return resolve_market_intelligence_enabled(spec, default_enabled=True)
 
 
 def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[str, pd.DataFrame]]:

--- a/tests/integration/test_mi_toggle_consistency_matrix.py
+++ b/tests/integration/test_mi_toggle_consistency_matrix.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+import sys
+import types
+
+import pandas as pd
+import pytest
+
+pymysql_module = types.ModuleType("pymysql")
+cursors_module = types.ModuleType("pymysql.cursors")
+cursors_module.DictCursor = object
+pymysql_module.cursors = cursors_module
+sys.modules.setdefault("pymysql", pymysql_module)
+sys.modules.setdefault("pymysql.cursors", cursors_module)
+
+from quant_engine.backtest import runner as backtest_runner
+from quant_engine.config import reset_settings_cache
+from quant_engine.strategies.base import StrategySignal
+from quant_engine.strategies import runner as strategies_runner
+
+
+class _DummyMIService:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, int]] = []
+
+    def build_snapshot(self, symbol: str, ohlcv: pd.DataFrame) -> Dict[str, Any]:
+        self.calls.append((symbol, len(ohlcv)))
+        return {"symbol": symbol, "features": {"mi_mode": "on"}, "ohlcv_rows": len(ohlcv)}
+
+
+class _FeatureAwareDummyStrategy:
+    def __init__(self, strategy_id: str, params: Dict[str, Any]) -> None:
+        self.strategy_id = strategy_id
+        self.params = params
+        self.rows: list[tuple[pd.Timestamp, Optional[Mapping[str, Any]]]] = []
+
+    def on_bar(
+        self,
+        bar: pd.Series,
+        context: Dict[str, Any],
+        features_row: Optional[Mapping[str, Any]] = None,
+    ) -> List[StrategySignal]:
+        self.rows.append((pd.Timestamp(bar.name), features_row))
+        return []
+
+
+def _build_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "EURUSD",
+            "open": 1.1,
+            "high": 1.2,
+            "low": 1.0,
+            "close": 1.15,
+            "volume": 100,
+        },
+        {
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "EURUSD",
+            "open": 1.2,
+            "high": 1.3,
+            "low": 1.1,
+            "close": 1.25,
+            "volume": 110,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("env_value", "spec_enabled", "expected_enabled"),
+    [
+        (None, None, True),
+        ("true", None, True),
+        ("false", None, False),
+        ("false", True, True),
+        ("true", False, False),
+    ],
+)
+def test_mi_toggle_consistency_matrix_backtest(monkeypatch, env_value, spec_enabled, expected_enabled) -> None:
+    monkeypatch.setattr(backtest_runner, "_load_rows", lambda *_args, **_kwargs: (_build_rows(), None))
+
+    observed: dict[str, Any] = {}
+    original_build_signal = backtest_runner._build_signal
+
+    def wrapped_build_signal(spec_input, rows, features=None):
+        observed["features"] = features
+        return original_build_signal(spec_input, rows, features)
+
+    monkeypatch.setattr(backtest_runner, "_build_signal", wrapped_build_signal)
+
+    if env_value is None:
+        monkeypatch.delenv("MARKET_INTELLIGENCE_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", env_value)
+    reset_settings_cache()
+
+    spec: Dict[str, Any] = {
+        "data": {"source": "csv", "path": "unused.csv", "symbol": "EURUSD", "start": "2024-01-01", "end": "2024-01-02"},
+        "strategy": {"asset_class": "FX"},
+        "signal": {"type": "ema_cross", "params": {"fast": 1, "slow": 2}},
+    }
+    if spec_enabled is not None:
+        spec["market_intelligence"] = {"enabled": spec_enabled}
+
+    mi_service = _DummyMIService()
+    backtest_runner.run_backtest_from_spec(spec, mi_service=mi_service)
+
+    if expected_enabled:
+        assert mi_service.calls
+        assert observed["features"]["features"]["mi_mode"] == "on"
+    else:
+        assert mi_service.calls == []
+        assert observed["features"]["features"] == {}
+
+
+@pytest.mark.parametrize(
+    ("env_value", "spec_enabled", "expected_enabled"),
+    [
+        (None, None, True),
+        ("true", None, True),
+        ("false", None, False),
+        ("false", True, True),
+        ("true", False, False),
+    ],
+)
+def test_mi_toggle_consistency_matrix_strategies(monkeypatch, env_value, spec_enabled, expected_enabled) -> None:
+    observed: Dict[str, Any] = {}
+
+    def _factory(strategy_type: str, strategy_id: str, params: Dict[str, Any]):
+        strategy = _FeatureAwareDummyStrategy(strategy_id=strategy_id, params=params)
+        observed["strategy"] = strategy
+        return strategy
+
+    df = pd.DataFrame(
+        {
+            "ts": pd.to_datetime(["2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"], utc=True),
+            "open": [100.0, 101.0],
+            "high": [101.0, 102.0],
+            "low": [99.0, 100.0],
+            "close": [100.5, 101.5],
+            "volume": [1000.0, 1100.0],
+            "feat_regime": ["trend", "range"],
+        }
+    )
+
+    monkeypatch.setattr(strategies_runner, "create_strategy", _factory)
+    monkeypatch.setattr(
+        strategies_runner,
+        "_fetch_ohlc_for_symbol",
+        lambda symbol, asset_class, data_spec, instrument_spec: df.copy(),
+    )
+
+    if env_value is None:
+        monkeypatch.delenv("MARKET_INTELLIGENCE_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("MARKET_INTELLIGENCE_ENABLED", env_value)
+    reset_settings_cache()
+
+    spec: Dict[str, Any] = {
+        "strategy": {"type": "dummy", "strategy_id": "s1", "params": {}},
+        "universe": [{"symbol": "SPY", "asset_class": "ETF"}],
+        "data": {"source": "csv", "path": "unused.csv"},
+    }
+    if spec_enabled is not None:
+        spec["market_intelligence"] = {"enabled": spec_enabled}
+
+    strategies_runner.run_backtest_from_spec(spec)
+
+    if expected_enabled:
+        assert observed["strategy"].rows[-1][1] == {"feat_regime": "range"}
+    else:
+        assert all(features is None for _, features in observed["strategy"].rows)


### PR DESCRIPTION
### Motivation
- Ensure a single source of truth for Market Intelligence (MI) enablement to avoid divergent behavior between env, settings and spec handling.
- Cover all relevant combinations of env/spec overrides and preserve legacy default behavior when env is absent.
- Apply consistent resolution for both backtest and strategy runners to remove duplicated logic.

### Description
- Added `resolve_market_intelligence_enabled(spec, *, default_enabled)` in `src/quant_engine/config.py` which resolves MI enablement with precedence: spec override (`market_intelligence.enabled` or `mi.enabled`) → explicit `MARKET_INTELLIGENCE_ENABLED` env → caller-provided legacy default.
- Updated `src/quant_engine/backtest/runner.py` to import and use `resolve_market_intelligence_enabled`, pass the `spec` into `_resolve_market_features`, and select the MI service accordingly.
- Updated `src/quant_engine/strategies/runner.py` to delegate `_market_intelligence_enabled` to `resolve_market_intelligence_enabled` for consistent behavior.
- Added integration tests `tests/integration/test_mi_toggle_consistency_matrix.py` covering env absent, env true/false, spec override true/false, and env/spec conflict cases for both backtest and strategies.

### Testing
- Ran `poetry run pytest -q tests/integration/test_mi_toggle_on_off.py tests/integration/test_mi_toggle_consistency_matrix.py` and received all tests passing.
- Test result: `12 passed` (with warnings only), validating the consistency matrix and compatibility with existing MI toggle tests.
- Changes were exercised by the new parametrized test matrix which asserts MI service calls and feature injection across combinations of env and spec values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97765510883238a28812f5adf8c90)