### PR TITLE
PY-MI-1.5: Align FeatureStore contract, add ADR and update tests

### DIFF
--- a/docs/architecture_market_intelligence_refactor.md
+++ b/docs/architecture_market_intelligence_refactor.md
@@ -180,8 +180,18 @@ from typing import Protocol
 import pandas as pd
 
 class FeatureStore(Protocol):
-    def get(self, feature_set: str, symbol: str, timeframe: str) -> pd.DataFrame | None: ...
-    def put(self, feature_set: str, symbol: str, timeframe: str, frame: pd.DataFrame) -> None: ...
+    def get(self, feature_set: str, symbol: str, timeframe: str, version: str) -> object: ...
+    def put(
+        self,
+        feature_set: str,
+        symbol: str,
+        timeframe: str,
+        version: str,
+        payload: object,
+        *,
+        overwrite: bool = False,
+    ) -> None: ...
+    def exists(self, feature_set: str, symbol: str, timeframe: str, version: str) -> bool: ...
 
 class FeaturePipeline(Protocol):
     name: str
@@ -425,3 +435,31 @@ Les noms et l’ordre des colonnes sont contractuels :
   - `feat_corr_close_volume_5`: NaN de corrélation roulante remplacés par `0.0`.
 
 Cette politique garantit des features immédiatement consommables par les couches stratégie, filtre et risque sans nettoyage supplémentaire.
+
+## 8) ADR courte — convergence des signatures (PY-MI-1.5)
+
+Statut: **accepté**.
+
+### Comparaison cible vs contrats actuels
+
+- `core.contracts.MarketIntelligenceService`:
+  - cible historique du doc: API riche (`compute_features`, `get_feature_slice`, `label_regimes`, `liquidity_flags`).
+  - contrat actuel: `build_snapshot(symbol, ohlcv) -> Mapping[str, Any]`.
+  - décision: **on fige `build_snapshot` en v1** (déjà consommé par `backtest` et tests d’intégration).
+- `core.contracts.FeatureStore`:
+  - cible historique du doc: `get/put` sans version.
+  - implémentation v1 (`InMemoryFeatureStore`): `get/put/exists(feature_set, symbol, timeframe, version, ...)`.
+  - décision: **alignement immédiat du contrat core** sur la signature versionnée avec `exists`.
+- `core.contracts.StrategyContract`:
+  - cible historique du doc: `Strategy.on_bar(...)`.
+  - contrat core actuel: `evaluate(ohlcv, context)`.
+  - décision: **divergence documentée**: `StrategyContract` couvre l’interface moteur/batch, tandis que `strategies.base.Strategy` couvre l’interface orientée barre (`on_bar`).
+
+### Plan de migration
+
+1. Introduire un adaptateur explicite `on_bar -> evaluate` dans `strategy_engine` pour unifier la consommation côté moteurs.
+2. Ajouter `StrategyContractV2` (ou renommer en `ExecutionStrategyContract`) quand les implémenteurs auront migré.
+3. Déprécier ensuite l’interface redondante restante avec fenêtre de compatibilité documentée.
+
+Résultat: les signatures v1 sont explicites et non ambiguës pour les implémenteurs; la convergence future est planifiée sans rupture immédiate.
+

--- a/src/quant_engine/core/contracts/feature_store.py
+++ b/src/quant_engine/core/contracts/feature_store.py
@@ -1,28 +1,38 @@
-"""Contract for feature-store components used to cache and retrieve engineered features."""
+"""Contract for feature-store components used by market-intelligence services."""
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class FeatureStore(Protocol):
-    """Store and retrieve computed feature vectors.
+    """Store and retrieve feature payloads identified by deterministic keys.
 
     Inputs:
-        name: Feature name (e.g. ``"ema_20"``).
-        dataset: Source rows used to compute feature values.
-        params: Deterministic feature parameters.
-        compute_fn: Callable used when values are not already available.
+        feature_set: Feature family identifier (e.g. ``"market_intelligence"``).
+        symbol: Canonical instrument identifier (e.g. ``"BTC-USD"``).
+        timeframe: Candle timeframe identifier (e.g. ``"1h"``).
+        version: Feature contract version (e.g. ``"1.0.0"``).
+        payload: Any serializable or in-memory object.
 
     Output:
-        Ordered sequence of numeric feature values aligned with ``dataset``.
+        Implementations define payload persistence and retrieval semantics.
     """
 
-    def get_or_compute(
+    def get(self, feature_set: str, symbol: str, timeframe: str, version: str) -> Any:
+        """Return stored payload for the key or raise ``KeyError`` when missing."""
+
+    def put(
         self,
-        name: str,
-        dataset: Sequence[Mapping[str, Any]],
-        params: Mapping[str, Any],
-        compute_fn: Callable[[Sequence[Mapping[str, Any]], Mapping[str, Any]], Sequence[float]],
-    ) -> Sequence[float]:
-        """Return cached values or compute and persist them."""
+        feature_set: str,
+        symbol: str,
+        timeframe: str,
+        version: str,
+        payload: Any,
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        """Persist payload for the key."""
+
+    def exists(self, feature_set: str, symbol: str, timeframe: str, version: str) -> bool:
+        """Return whether a key is present in the store."""

--- a/tests/core/test_contracts_imports.py
+++ b/tests/core/test_contracts_imports.py
@@ -11,8 +11,29 @@ class FakeMarketIntelligence:
 
 
 class FakeFeatureStore:
-    def get_or_compute(self, name: str, dataset: Sequence[Mapping[str, Any]], params: Mapping[str, Any], compute_fn):
-        return list(compute_fn(dataset, params))
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str, str, str], Any] = {}
+
+    def get(self, feature_set: str, symbol: str, timeframe: str, version: str) -> Any:
+        return self._store[(feature_set, symbol, timeframe, version)]
+
+    def put(
+        self,
+        feature_set: str,
+        symbol: str,
+        timeframe: str,
+        version: str,
+        payload: Any,
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        key = (feature_set, symbol, timeframe, version)
+        if key in self._store and not overwrite:
+            raise KeyError(key)
+        self._store[key] = payload
+
+    def exists(self, feature_set: str, symbol: str, timeframe: str, version: str) -> bool:
+        return (feature_set, symbol, timeframe, version) in self._store
 
 
 class FakeStrategy:
@@ -39,13 +60,11 @@ def test_fake_implementations_conform_to_contracts() -> None:
     assert snapshot["symbol"] == "BTC-USD"
     assert snapshot["rows"] == 2
 
-    values = fs.get_or_compute(
-        "ema_2",
-        [{"close": 1.0}, {"close": 2.0}],
-        {"period": 2},
-        lambda dataset, _: [float(row["close"]) for row in dataset],
-    )
-    assert values == [1.0, 2.0]
+    assert fs.exists("market_intelligence", "BTC-USD", "1h", "1.0.0") is False
+    fs.put("market_intelligence", "BTC-USD", "1h", "1.0.0", {"features": [1.0, 2.0]})
+    assert fs.exists("market_intelligence", "BTC-USD", "1h", "1.0.0") is True
+    payload = fs.get("market_intelligence", "BTC-USD", "1h", "1.0.0")
+    assert payload["features"] == [1.0, 2.0]
 
     signals = st.evaluate([{"close": 1.0}], {"mode": "backtest"})
     assert signals[0]["signal"] == "BUY"


### PR DESCRIPTION
### Motivation

- Clarify and freeze the v1 contracts used by the Market Intelligence layer so implementers have an explicit, stable API to rely on.
- Bring the `core.contracts.FeatureStore` signature into alignment with existing MI v1 implementations that use a versioned key model.
- Record an explicit decision for the remaining signature divergence between batch (`evaluate`) and on-bar (`on_bar`) strategy APIs and provide a migration path.

### Description

- Updated the `FeatureStore` Protocol in `src/quant_engine/core/contracts/feature_store.py` to a versioned key contract with `get(feature_set, symbol, timeframe, version)`, `put(..., payload, overwrite=False)` and `exists(...)` instead of the legacy `get_or_compute` shape.
- Updated `tests/core/test_contracts_imports.py` to reflect the new `FeatureStore` contract by providing a fake `FeatureStore` implementation and exercising `get`/`put`/`exists` semantics while keeping `MarketIntelligenceService` and `StrategyContract` import/runtime conformance checks.
- Augmented `docs/architecture_market_intelligence_refactor.md` to update the `FeatureStore` snippet and added a short ADR section (`PY-MI-1.5`) that: compares target vs current signatures, freezes `MarketIntelligenceService` v1 (`build_snapshot`) as the stable contract, documents the `FeatureStore` alignment decision, and outlines a migration plan for the `Strategy` API divergence (`on_bar` vs `evaluate`).

### Testing

- Ran `poetry run pytest -q tests/core/test_contracts_imports.py tests/architecture/test_import_rules.py` and all tests passed (`5 passed`).
- The updated contract is validated by the modified import/conformance test `tests/core/test_contracts_imports.py` which now asserts `FeatureStore` runtime conformance via the fake implementation.
- The architecture import rule test `tests/architecture/test_import_rules.py` was executed to ensure no forbidden dependency violations were introduced and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97806a8dc83239424513782789ae9)