### PR TITLE
PY-MI-5.7: normalize MI/stats deprecation warnings and expand coverage

### DIFF
--- a/docs/migration_legacy_wrappers.md
+++ b/docs/migration_legacy_wrappers.md
@@ -35,11 +35,18 @@ Ce document décrit la migration progressive des wrappers legacy vers les module
 - `quant_engine.stats.events.gap_down` -> `quant_engine.market_intelligence.events.gap_down`
 - `quant_engine.stats.events.always_true` -> `quant_engine.market_intelligence.events.always_true`
 
+### Market Intelligence adapters
+
+- `quant_engine.market_intelligence.adapters.LegacyFiltersAdapter` -> `quant_engine.filters.trade_filter_service.score_filter_rules`
+- `quant_engine.market_intelligence.adapters.LegacyStatsAdapter` -> `quant_engine.stats.runner.run_stats`
+
 ## Exemple de warning
 
 Message attendu :
 
 `quant_engine.stats.events.gap_up is deprecated and will be removed in v0.15.0 (target date: 2026-04-30); use quant_engine.market_intelligence.events instead.`
+
+`quant_engine.market_intelligence.adapters.LegacyFiltersAdapter is deprecated and will be removed in v0.15.0 (target date: 2026-04-30); use quant_engine.filters.trade_filter_service.score_filter_rules instead.`
 
 ## Recommandation projet
 

--- a/src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py
+++ b/src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py
@@ -2,11 +2,27 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+import warnings
 from typing import Any
 
 import pandas as pd
 
 _FILTER_COLUMNS = ("hard_mask", "score", "score_pct", "final_mask")
+_DEPRECATION_TARGET_VERSION = "v0.15.0"
+_DEPRECATION_TARGET_DATE = "2026-04-30"
+
+
+def _warn_deprecated() -> None:
+    warnings.warn(
+        (
+            "quant_engine.market_intelligence.adapters.LegacyFiltersAdapter is deprecated "
+            f"and will be removed in {_DEPRECATION_TARGET_VERSION} "
+            f"(target date: {_DEPRECATION_TARGET_DATE}); use "
+            "quant_engine.filters.trade_filter_service.score_filter_rules instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 def _default_runner(*args: Any, **kwargs: Any) -> Mapping[str, Any]:
@@ -34,6 +50,7 @@ class LegacyFiltersAdapter:
         self,
         runner: Callable[..., Mapping[str, Any]] = _default_runner,
     ) -> None:
+        _warn_deprecated()
         self._runner = runner
 
     def run(

--- a/src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py
+++ b/src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import warnings
 from typing import Any
 
 import pandas as pd
@@ -30,12 +31,29 @@ _DEFAULT_COLUMNS = [
     "significant",
 ]
 
+
 _RENAME_MAP = {
     "p": "p_hat",
     "probability": "p_hat",
     "count": "n",
     "wins": "successes",
 }
+
+_DEPRECATION_TARGET_VERSION = "v0.15.0"
+_DEPRECATION_TARGET_DATE = "2026-04-30"
+
+
+def _warn_deprecated() -> None:
+    warnings.warn(
+        (
+            "quant_engine.market_intelligence.adapters.LegacyStatsAdapter is deprecated "
+            f"and will be removed in {_DEPRECATION_TARGET_VERSION} "
+            f"(target date: {_DEPRECATION_TARGET_DATE}); use "
+            "quant_engine.stats.runner.run_stats instead."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 def _default_runner(spec: Any) -> pd.DataFrame:
@@ -48,6 +66,7 @@ class LegacyStatsAdapter:
     """Execute legacy stats runner and normalize output for market-intelligence consumers."""
 
     def __init__(self, runner: Callable[[Any], pd.DataFrame] = _default_runner) -> None:
+        _warn_deprecated()
         self._runner = runner
 
     def run(self, spec: Any) -> pd.DataFrame:

--- a/tests/integration/test_deprecation_paths.py
+++ b/tests/integration/test_deprecation_paths.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from quant_engine.market_intelligence.adapters.legacy_filters_adapter import LegacyFiltersAdapter
+from quant_engine.market_intelligence.adapters.legacy_stats_adapter import LegacyStatsAdapter
 from quant_engine.stats import conditions as stats_conditions
 from quant_engine.stats import events as stats_events
 
@@ -20,15 +22,49 @@ def _sample_df() -> pd.DataFrame:
     )
 
 
-def test_stats_event_deprecation_warning_contains_target_version_and_date() -> None:
+def test_stats_event_deprecation_warning_contains_version_date_and_alternative() -> None:
     df = _sample_df()
 
-    with pytest.warns(DeprecationWarning, match=r"v0\.15\.0.*2026-04-30"):
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            r"quant_engine\.stats\.events\.gap_up.*v0\.15\.0.*2026-04-30"
+            r".*quant_engine\.market_intelligence\.events"
+        ),
+    ):
         _ = stats_events.gap_up(df)
 
 
-def test_stats_condition_deprecation_warning_contains_target_version_and_date() -> None:
+def test_stats_condition_deprecation_warning_contains_version_date_and_alternative() -> None:
     df = _sample_df()
 
-    with pytest.warns(DeprecationWarning, match=r"v0\.15\.0.*2026-04-30"):
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            r"quant_engine\.stats\.conditions\.day_of_week.*v0\.15\.0.*2026-04-30"
+            r".*quant_engine\.market_intelligence\.conditions"
+        ),
+    ):
         _ = stats_conditions.day_of_week(df)
+
+
+def test_legacy_filters_adapter_warning_contains_version_date_and_alternative() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            r"LegacyFiltersAdapter.*v0\.15\.0.*2026-04-30"
+            r".*quant_engine\.filters\.trade_filter_service\.score_filter_rules"
+        ),
+    ):
+        _ = LegacyFiltersAdapter(runner=lambda *_args, **_kwargs: {})
+
+
+def test_legacy_stats_adapter_warning_contains_version_date_and_alternative() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            r"LegacyStatsAdapter.*v0\.15\.0.*2026-04-30"
+            r".*quant_engine\.stats\.runner\.run_stats"
+        ),
+    ):
+        _ = LegacyStatsAdapter(runner=lambda _spec: pd.DataFrame())

--- a/tests/stats/test_stats_compat_wrappers.py
+++ b/tests/stats/test_stats_compat_wrappers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pandas as pd
 import pytest
 
@@ -22,21 +24,56 @@ def _sample_df() -> pd.DataFrame:
     )
 
 
-def test_stats_event_wrapper_matches_mi_and_warns() -> None:
+@pytest.mark.parametrize(
+    ("name", "call"),
+    [
+        ("k_consecutive", lambda mod, df: mod.k_consecutive(df, k=2, direction="up")),
+        ("shock_atr", lambda mod, df: mod.shock_atr(df, mult=1.5, window=3)),
+        ("breakout_hhll", lambda mod, df: mod.breakout_hhll(df, lookback=2, type="hh")),
+        ("bullish_candle", lambda mod, df: mod.bullish_candle(df)),
+        ("bearish_candle", lambda mod, df: mod.bearish_candle(df)),
+        ("bullish_engulfing", lambda mod, df: mod.bullish_engulfing(df)),
+        ("bearish_engulfing", lambda mod, df: mod.bearish_engulfing(df)),
+        ("bullish_streak", lambda mod, df: mod.bullish_streak(df, k=2)),
+        ("bearish_streak", lambda mod, df: mod.bearish_streak(df, k=2)),
+        ("gap_up", lambda mod, df: mod.gap_up(df)),
+        ("gap_down", lambda mod, df: mod.gap_down(df)),
+        ("always_true", lambda mod, df: mod.always_true(df)),
+    ],
+)
+def test_stats_event_wrapper_matches_mi_and_warns(name: str, call: Callable[..., pd.Series]) -> None:
     df = _sample_df()
 
-    expected = mi_events.gap_up(df)
-    with pytest.warns(DeprecationWarning):
-        observed = stats_events.gap_up(df)
+    expected = call(mi_events, df)
+    with pytest.warns(
+        DeprecationWarning,
+        match=rf"quant_engine\.stats\.events\.{name}.*v0\.15\.0.*2026-04-30.*market_intelligence\.events",
+    ):
+        observed = call(stats_events, df)
 
     pd.testing.assert_series_equal(observed, expected)
 
 
-def test_stats_condition_wrapper_matches_mi_and_warns() -> None:
+@pytest.mark.parametrize(
+    ("name", "call"),
+    [
+        ("htf_trend", lambda mod, df: mod.htf_trend(df, tf_multiplier=2, ema_period=2)),
+        ("vol_tertile", lambda mod, df: mod.vol_tertile(df, window=3)),
+        ("session", lambda mod, df: mod.session(df)),
+        ("hour_bin", lambda mod, df: mod.hour_bin(df)),
+        ("day_of_week", lambda mod, df: mod.day_of_week(df)),
+        ("month_of_year", lambda mod, df: mod.month_of_year(df)),
+        ("session_from_ts", lambda mod, df: mod.session_from_ts(df)),
+    ],
+)
+def test_stats_condition_wrapper_matches_mi_and_warns(name: str, call: Callable[..., pd.Series]) -> None:
     df = _sample_df()
 
-    expected = mi_conditions.day_of_week(df)
-    with pytest.warns(DeprecationWarning):
-        observed = stats_conditions.day_of_week(df)
+    expected = call(mi_conditions, df)
+    with pytest.warns(
+        DeprecationWarning,
+        match=rf"quant_engine\.stats\.conditions\.{name}.*v0\.15\.0.*2026-04-30.*market_intelligence\.conditions",
+    ):
+        observed = call(stats_conditions, df)
 
     pd.testing.assert_series_equal(observed, expected)


### PR DESCRIPTION
### Motivation

- Finish wave-2 deprecation cleanup by making remaining legacy MI/stats wrapper paths auditable and homogeneous in message content (target version, target date, canonical alternative).
- Ensure tests cover all legacy wrapper entry points so the deprecation surface is fully exercised.

### Description

- Add normalized deprecation warnings to `LegacyFiltersAdapter` and `LegacyStatsAdapter` via `_warn_deprecated()` and invoke the warning at adapter instantiation so the adapter path is auditable in tests. (`src/quant_engine/market_intelligence/adapters/legacy_filters_adapter.py`, `src/quant_engine/market_intelligence/adapters/legacy_stats_adapter.py`).
- Standardize message format to include the target version `v0.15.0`, date `2026-04-30`, and the canonical alternative module/function in the warning text.
- Expand and tighten tests to assert version/date/alternative appear in warnings and to enumerate all legacy event/condition wrappers while verifying parity with MI implementations. (`tests/integration/test_deprecation_paths.py`, `tests/stats/test_stats_compat_wrappers.py`).
- Align migration documentation to list the new MI adapter migration mappings and include the normalized warning example. (`docs/migration_legacy_wrappers.md`).

### Testing

- Ran `poetry run pytest -q tests/integration/test_deprecation_paths.py tests/stats/test_stats_compat_wrappers.py` and the suite completed successfully with `23 passed`.
- The added tests assert presence of target version/date/alternative in `DeprecationWarning` messages and verify behavior parity between `quant_engine.stats.*` wrappers and `quant_engine.market_intelligence.*` implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97888700c8323983211410ad38561)