### PR TITLE
Fix DCA benchmark specs returning empty signals

### DIFF
--- a/src/quant_engine/strategies/runner.py
+++ b/src/quant_engine/strategies/runner.py
@@ -17,7 +17,7 @@ import requests
 from sqlalchemy import create_engine, inspect, text
 
 from . import create_strategy
-from .base import StrategySignal
+from .base import Strategy, StrategySignal
 from ..config import resolve_market_intelligence_enabled
 from ..integrations import java_client
 from ..filters.utils import apply_filter_stack, FilterValidationError
@@ -271,7 +271,9 @@ def _run_backtest_core(spec: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[st
             if feature_rows_by_ts:
                 context["features_by_ts"] = feature_rows_by_ts
         on_bar = getattr(strategy, "on_bar", None)
-        if callable(on_bar):
+        on_bar_impl = getattr(type(strategy), "on_bar", None)
+        has_custom_on_bar = callable(on_bar) and callable(on_bar_impl) and on_bar_impl is not Strategy.on_bar
+        if has_custom_on_bar:
             normalized = df.copy()
             if "ts" in normalized.columns:
                 normalized["ts"] = pd.to_datetime(normalized["ts"], utc=True)


### PR DESCRIPTION
### Motivation

- The integration test `tests/integration/test_dca_benchmark_specs.py` was failing because benchmark DCA specs produced `signals = []`, indicating `dca_benchmark` `backtest` was not being executed.
- Root cause: the runner dispatched to `on_bar` whenever `callable(strategy.on_bar)` was true, but `on_bar` exists on the `Strategy` protocol so that check returned true even when concrete strategies only implement `backtest`.

### Description

- Adjusted runner dispatch logic in `src/quant_engine/strategies/runner.py` to import the `Strategy` protocol and detect whether a concrete strategy actually overrides `on_bar` by comparing `getattr(type(strategy), "on_bar", None)` to `Strategy.on_bar` before iterating bars.
- Added `has_custom_on_bar = callable(on_bar) and callable(on_bar_impl) and on_bar_impl is not Strategy.on_bar` and only use the `on_bar` loop when this is true, otherwise call `strategy.backtest(df, context)` as intended.
- No changes to `dca_benchmark` strategy implementation or the `meta.benchmark` output schema were made, preserving existing output contracts.

### Testing

- Ran `poetry run pytest -q tests/integration/test_dca_benchmark_specs.py` and it passed (`1 passed`).
- Ran `poetry run pytest -q tests/strategies` and it passed (`8 passed`).
- Ran the broader suite `poetry run pytest -q tests/backtest tests/strategies tests/integration` and it passed (`57 passed, 1 skipped`, with warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98006ced48323915a9bf5a30c876a)