### PR TITLE
Shim TestClient/httpx compatibility and add optional pymysql stub for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,55 @@
+"""Shared pytest configuration for local test shims.
+
+This project still runs with Starlette's legacy ``TestClient`` implementation,
+which passes an ``app=...`` keyword to ``httpx.Client``. ``httpx>=0.28``
+removed that argument, so we provide a tiny compatibility shim at test import
+time to keep API tests collectable until dependencies are upgraded in lockstep.
+"""
+
+import inspect
 import sys
+import types
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def _install_testclient_httpx_compat() -> None:
+    import httpx
+
+    if "app" in inspect.signature(httpx.Client.__init__).parameters:
+        return
+
+    original_init = httpx.Client.__init__
+
+    def _compat_init(self, *args, app=None, **kwargs):
+        return original_init(self, *args, **kwargs)
+
+    httpx.Client.__init__ = _compat_init
+
+
+def _install_optional_pymysql_stub() -> None:
+    if "pymysql" in sys.modules:
+        return
+    try:
+        __import__("pymysql")
+    except ModuleNotFoundError:
+        stub = types.ModuleType("pymysql")
+
+        def _missing(*_args, **_kwargs):
+            raise ModuleNotFoundError("pymysql is required for MySQL-backed flows")
+
+        cursors = types.ModuleType("pymysql.cursors")
+
+        class DictCursor:  # pragma: no cover - used only for import compatibility
+            pass
+
+        cursors.DictCursor = DictCursor
+        stub.connect = _missing
+        stub.cursors = cursors
+        sys.modules["pymysql"] = stub
+        sys.modules["pymysql.cursors"] = cursors
+
+
+_install_testclient_httpx_compat()
+_install_optional_pymysql_stub()

--- a/tests/test_api_http_contract.py
+++ b/tests/test_api_http_contract.py
@@ -24,3 +24,11 @@ def test_filters_list_http_contract():
     assert isinstance(payload, list)
     assert "adx" in payload
     assert all(isinstance(item, str) for item in payload)
+
+
+def test_testclient_bootstrap_compatibility() -> None:
+    # Guardrail: this should keep working even when httpx drops ``app=`` in Client.__init__.
+    fresh_client = TestClient(api_app.fastapi_app)
+
+    response = fresh_client.get("/stats/conditions")
+    assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Tests failed to collect due to `TestClient` passing an `app=` kwarg while `httpx.Client.__init__` in newer `httpx` releases no longer accepts that parameter.  
- API import also raised `ModuleNotFoundError` for `pymysql` during collection in environments where MySQL extras are not installed.  

### Description
- Add a test-time compatibility shim in `tests/conftest.py` that patches `httpx.Client.__init__` to accept and ignore the legacy `app=` keyword so `fastapi.testclient.TestClient` can instantiate against `httpx>=0.28`.  
- Add an optional import-time `pymysql` stub (including a `pymysql.cursors.DictCursor` placeholder) in `tests/conftest.py` so imports succeed when MySQL extras are not present while still surfacing errors if MySQL functionality is actually invoked.  
- Add a focused guardrail test in `tests/test_api_http_contract.py` (`test_testclient_bootstrap_compatibility`) that re-instantiates `TestClient` and exercises `/stats/conditions` to detect regressions in the compatibility shim.  

### Testing
- Ran `poetry run pytest -q tests/test_api_http_contract.py tests/test_api_validation_error_format.py` and the targeted API tests passed (`5 passed`).  
- Ran `poetry run pytest -q tests/api` which progressed past the previous collection error but shows unrelated failures in `tests/api/test_dca_benchmark_submit_api.py` (existing DCA benchmark signal assertions).  
- Ran full suite with `poetry run pytest -q` and the run progresses past the original TestClient collection failure; remaining failures are unrelated to the TestClient/httpx compatibility fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97f3bd1788323a677b006b3455a1d)