### PR TITLE
PY-MI-5.9: extract canonical run-request logic into API service with unit evidence

### DIFF
--- a/docs/architecture_market_intelligence_refactor.md
+++ b/docs/architecture_market_intelligence_refactor.md
@@ -463,3 +463,26 @@ Statut: **accepté**.
 
 Résultat: les signatures v1 sont explicites et non ambiguës pour les implémenteurs; la convergence future est planifiée sans rupture immédiate.
 
+
+## API thin-handlers checklist (PY-MI-5.9)
+
+### Cible
+
+- Les endpoints `FastAPI` dans `api/app.py` ne font que:
+  1. validation HTTP/Pydantic,
+  2. mapping I/O (`Request`/`Response`),
+  3. appel d’un service `api/services/*`.
+- La logique métier (idempotence `request_id`, règles spécifiques `market_stats`, orchestration d’enqueue) est centralisée dans des services unit-testables.
+
+### Preuves de découplage
+
+- `api/services/run_requests.py` porte désormais l’enqueue canonique et la validation métier `market_stats`.
+- `api/app.py` conserve des wrappers de compatibilité (`enqueue_run_request`, `_validate_canonical_market_stats_params`) pour rollback rapide sans casser le contrat public Python.
+- Les tests `tests/api/test_run_requests_service.py` valident directement le service (sans HTTP), en complément des tests de contrat endpoint existants.
+
+### Checklist review PR
+
+- [ ] Handler endpoint sans branchement métier complexe (pas d’accès DB direct dans le handler).
+- [ ] Règles métier testées dans `tests/api/*service*`.
+- [ ] Contrats HTTP inchangés (status/payload) via tests endpoint.
+- [ ] Point de rollback: re-router temporairement un endpoint vers implémentation legacy tout en conservant les services extraits.

--- a/src/quant_engine/api/app.py
+++ b/src/quant_engine/api/app.py
@@ -42,6 +42,7 @@ from ..performance import stress_tests as stress_tests_runner
 from ..filters import list_filter_types
 from . import schemas
 from .services import runs as runs_service
+from .services import run_requests as run_requests_service
 from .services import stats as stats_service
 from .run_request_input import validate_run_request_input
 from .validation_errors import (
@@ -2058,131 +2059,24 @@ def result(job_id: str) -> schemas.ResultResponse:
 def enqueue_run_request(payload: Dict[str, Any]) -> schemas.RunEnqueueResponse:
     """Validate and enqueue a canonical run request."""
 
-    try:
-        parsed = validate_run_request_input(payload)
-    except ValidationError as exc:
-        raise ApiValidationException(normalize_pydantic_errors(exc)) from exc
-
-    canonical_payload = parsed.model_dump(mode="json")
-    _validate_canonical_market_stats_params(canonical_payload)
-    request_id = _normalize_request_id(canonical_payload.get("request_id"))
-    reused = False
-    if request_id is not None:
-        existing = _get_job(request_id)
-        if existing and existing.get("job_type") == JOB_TYPE_CANONICAL_RUN:
-            reused = True
-            status = _external_job_status(str(existing.get("status", "pending")))
-            return schemas.RunEnqueueResponse(run_id=request_id, status=status, reused=True)
-        if existing and existing.get("job_type") != JOB_TYPE_CANONICAL_RUN:
-            raise ApiValidationException(
-                single_validation_error("request_id", "conflict", "request_id already exists")
-            )
-    else:
-        request_id = ids.generate_id()
-
-    max_attempts, timeout_seconds = _canonical_job_defaults()
-    _init_job(
-        request_id,
-        JOB_TYPE_CANONICAL_RUN,
-        payload={"request": canonical_payload},
-        status=JOB_STATUS_QUEUED,
-        max_attempts=max_attempts,
-        timeout_seconds=timeout_seconds,
+    return run_requests_service.enqueue_run_request(
+        payload,
+        validate_input=validate_run_request_input,
+        validate_market_stats_params=_validate_canonical_market_stats_params,
+        normalize_request_id=_normalize_request_id,
+        get_job=_get_job,
+        init_job=_init_job,
+        canonical_job_defaults=_canonical_job_defaults,
+        external_job_status=_external_job_status,
+        canonical_job_type=JOB_TYPE_CANONICAL_RUN,
+        queued_status=JOB_STATUS_QUEUED,
     )
-    status = JOB_STATUS_QUEUED
-    return schemas.RunEnqueueResponse(run_id=request_id, status=status, reused=reused)
-
-
-def _coerce_int(value: Any) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        if value.is_integer():
-            return int(value)
-        return None
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            if "." in text:
-                maybe_float = float(text)
-                if maybe_float.is_integer():
-                    return int(maybe_float)
-                return None
-            return int(text)
-        except Exception:
-            return None
-    return None
 
 
 def _validate_canonical_market_stats_params(canonical_payload: Dict[str, Any]) -> None:
-    if str(canonical_payload.get("spec_type") or "").strip().lower() != "market_stats":
-        return
+    """Backwards-compatible wrapper around run request service validation."""
 
-    stats_block = canonical_payload.get("stats")
-    if not isinstance(stats_block, dict):
-        return
-
-    errors: List[Dict[str, str]] = []
-
-    def _require_positive_int(params: Dict[str, Any], field_prefix: str, name: str) -> None:
-        value = params.get(name)
-        field = f"{field_prefix}.{name}"
-        if value in (None, ""):
-            errors.append({"field": field, "code": "missing", "message": "Field required"})
-            return
-        coerced = _coerce_int(value)
-        if coerced is None:
-            errors.append({"field": field, "code": "int_parsing", "message": "Input should be a valid integer"})
-            return
-        if coerced < 1:
-            errors.append({"field": field, "code": "greater_than_equal", "message": "Input should be >= 1"})
-
-    def _require_direction(params: Dict[str, Any], field_prefix: str, name: str = "direction") -> None:
-        value = params.get(name)
-        field = f"{field_prefix}.{name}"
-        if value in (None, ""):
-            errors.append({"field": field, "code": "missing", "message": "Field required"})
-            return
-        token = str(value).strip().lower()
-        if token not in {"up", "down"}:
-            errors.append({"field": field, "code": "literal_error", "message": "Input should be 'up' or 'down'"})
-
-    event = stats_block.get("event")
-    if isinstance(event, dict):
-        event_id = str(event.get("id") or "").strip().lower()
-        event_params = event.get("params") if isinstance(event.get("params"), dict) else {}
-        if event_id == "k_consecutive":
-            base = "market_stats.stats.event.params"
-            _require_positive_int(event_params, base, "k")
-            _require_direction(event_params, base)
-
-    condition = stats_block.get("condition")
-    if isinstance(condition, dict):
-        condition_id = str(condition.get("id") or "").strip().lower()
-        condition_params = condition.get("params") if isinstance(condition.get("params"), dict) else {}
-        if condition_id == "htf_trend":
-            base = "market_stats.stats.condition.params"
-            _require_positive_int(condition_params, base, "tf_multiplier")
-            _require_positive_int(condition_params, base, "ema_period")
-
-    target = stats_block.get("target")
-    if isinstance(target, dict):
-        target_id = str(target.get("id") or "").strip().lower()
-        target_params = target.get("params") if isinstance(target.get("params"), dict) else {}
-        if target_id == "continuation_n":
-            base = "market_stats.stats.target.params"
-            _require_positive_int(target_params, base, "n")
-            _require_direction(target_params, base)
-        elif target_id == "time_to_reversal":
-            base = "market_stats.stats.target.params"
-            _require_positive_int(target_params, base, "max_horizon")
-
-    if errors:
-        raise ApiValidationException(errors)
+    run_requests_service.validate_market_stats_params(canonical_payload)
 
 
 def _normalize_request_id(request_id: Any) -> str | None:

--- a/src/quant_engine/api/services/__init__.py
+++ b/src/quant_engine/api/services/__init__.py
@@ -1,5 +1,5 @@
 """Application service layer for API endpoints."""
 
-from . import runs
+from . import run_requests, runs, stats
 
-__all__ = ["runs"]
+__all__ = ["run_requests", "runs", "stats"]

--- a/src/quant_engine/api/services/run_requests.py
+++ b/src/quant_engine/api/services/run_requests.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+from pydantic import ValidationError
+
+from ...io import ids
+from .. import schemas
+from ..validation_errors import ApiValidationException, normalize_pydantic_errors, single_validation_error
+
+
+ParsedRequestValidator = Callable[[Dict[str, Any]], Any]
+JobLookup = Callable[[str], Dict[str, Any] | None]
+JobInitializer = Callable[..., None]
+RequestIdNormalizer = Callable[[Any], str | None]
+JobDefaultsResolver = Callable[[], tuple[int | None, int | None]]
+StatusMapper = Callable[[str], str]
+
+
+def enqueue_run_request(
+    payload: Dict[str, Any],
+    *,
+    validate_input: ParsedRequestValidator,
+    validate_market_stats_params: Callable[[Dict[str, Any]], None],
+    normalize_request_id: RequestIdNormalizer,
+    get_job: JobLookup,
+    init_job: JobInitializer,
+    canonical_job_defaults: JobDefaultsResolver,
+    external_job_status: StatusMapper,
+    canonical_job_type: str,
+    queued_status: str,
+) -> schemas.RunEnqueueResponse:
+    """Validate and enqueue a canonical run request."""
+
+    try:
+        parsed = validate_input(payload)
+    except ValidationError as exc:
+        raise ApiValidationException(normalize_pydantic_errors(exc)) from exc
+
+    canonical_payload = parsed.model_dump(mode="json")
+    validate_market_stats_params(canonical_payload)
+
+    request_id = normalize_request_id(canonical_payload.get("request_id"))
+    reused = False
+    if request_id is not None:
+        existing = get_job(request_id)
+        if existing and existing.get("job_type") == canonical_job_type:
+            reused = True
+            status = external_job_status(str(existing.get("status", queued_status)))
+            return schemas.RunEnqueueResponse(run_id=request_id, status=status, reused=True)
+        if existing and existing.get("job_type") != canonical_job_type:
+            raise ApiValidationException(
+                single_validation_error("request_id", "conflict", "request_id already exists")
+            )
+    else:
+        request_id = ids.generate_id()
+
+    max_attempts, timeout_seconds = canonical_job_defaults()
+    init_job(
+        request_id,
+        canonical_job_type,
+        payload={"request": canonical_payload},
+        status=queued_status,
+        max_attempts=max_attempts,
+        timeout_seconds=timeout_seconds,
+    )
+    return schemas.RunEnqueueResponse(run_id=request_id, status=queued_status, reused=reused)
+
+
+def validate_market_stats_params(canonical_payload: Dict[str, Any]) -> None:
+    if str(canonical_payload.get("spec_type") or "").strip().lower() != "market_stats":
+        return
+
+    stats_block = canonical_payload.get("stats")
+    if not isinstance(stats_block, dict):
+        return
+
+    errors: List[Dict[str, str]] = []
+
+    def _require_positive_int(params: Dict[str, Any], field_prefix: str, name: str) -> None:
+        value = params.get(name)
+        field = f"{field_prefix}.{name}"
+        if value in (None, ""):
+            errors.append({"field": field, "code": "missing", "message": "Field required"})
+            return
+        coerced = _coerce_int(value)
+        if coerced is None:
+            errors.append({"field": field, "code": "int_parsing", "message": "Input should be a valid integer"})
+            return
+        if coerced < 1:
+            errors.append({"field": field, "code": "greater_than_equal", "message": "Input should be >= 1"})
+
+    def _require_direction(params: Dict[str, Any], field_prefix: str, name: str = "direction") -> None:
+        value = params.get(name)
+        field = f"{field_prefix}.{name}"
+        if value in (None, ""):
+            errors.append({"field": field, "code": "missing", "message": "Field required"})
+            return
+        token = str(value).strip().lower()
+        if token not in {"up", "down"}:
+            errors.append({"field": field, "code": "literal_error", "message": "Input should be 'up' or 'down'"})
+
+    event = stats_block.get("event")
+    if isinstance(event, dict):
+        event_id = str(event.get("id") or "").strip().lower()
+        event_params = event.get("params") if isinstance(event.get("params"), dict) else {}
+        if event_id == "k_consecutive":
+            base = "market_stats.stats.event.params"
+            _require_positive_int(event_params, base, "k")
+            _require_direction(event_params, base)
+
+    condition = stats_block.get("condition")
+    if isinstance(condition, dict):
+        condition_id = str(condition.get("id") or "").strip().lower()
+        condition_params = condition.get("params") if isinstance(condition.get("params"), dict) else {}
+        if condition_id == "htf_trend":
+            base = "market_stats.stats.condition.params"
+            _require_positive_int(condition_params, base, "tf_multiplier")
+            _require_positive_int(condition_params, base, "ema_period")
+
+    target = stats_block.get("target")
+    if isinstance(target, dict):
+        target_id = str(target.get("id") or "").strip().lower()
+        target_params = target.get("params") if isinstance(target.get("params"), dict) else {}
+        if target_id == "continuation_n":
+            base = "market_stats.stats.target.params"
+            _require_positive_int(target_params, base, "n")
+            _require_direction(target_params, base)
+        elif target_id == "time_to_reversal":
+            base = "market_stats.stats.target.params"
+            _require_positive_int(target_params, base, "max_horizon")
+
+    if errors:
+        raise ApiValidationException(errors)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            if "." in text:
+                maybe_float = float(text)
+                if maybe_float.is_integer():
+                    return int(maybe_float)
+                return None
+            return int(text)
+        except Exception:
+            return None
+    return None

--- a/tests/api/test_run_requests_service.py
+++ b/tests/api/test_run_requests_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from quant_engine.api import schemas
+from quant_engine.api.services import run_requests
+from quant_engine.api.validation_errors import ApiValidationException
+
+
+@dataclass
+class _ParsedPayload:
+    payload: dict
+
+    def model_dump(self, mode: str = "json") -> dict:  # noqa: ARG002
+        return self.payload
+
+
+def test_enqueue_run_request_creates_new_job(monkeypatch):
+    captured: dict = {}
+
+    monkeypatch.setattr(run_requests.ids, "generate_id", lambda: "run-generated")
+
+    response = run_requests.enqueue_run_request(
+        {"spec_type": "backtest", "data": {"symbol": "BTCUSDT"}},
+        validate_input=lambda payload: _ParsedPayload(payload),
+        validate_market_stats_params=lambda payload: None,
+        normalize_request_id=lambda _: None,
+        get_job=lambda _job_id: None,
+        init_job=lambda job_id, job_type, payload, **kwargs: captured.update(
+            {"job_id": job_id, "job_type": job_type, "payload": payload, **kwargs}
+        ),
+        canonical_job_defaults=lambda: (3, 120),
+        external_job_status=lambda status: status,
+        canonical_job_type="canonical_run",
+        queued_status="QUEUED",
+    )
+
+    assert isinstance(response, schemas.RunEnqueueResponse)
+    assert response.run_id == "run-generated"
+    assert response.status == "QUEUED"
+    assert response.reused is False
+    assert captured["job_id"] == "run-generated"
+    assert captured["job_type"] == "canonical_run"
+    assert captured["payload"]["request"]["spec_type"] == "backtest"
+
+
+def test_enqueue_run_request_reuses_existing_canonical_job():
+    response = run_requests.enqueue_run_request(
+        {"spec_type": "backtest", "request_id": "run-42"},
+        validate_input=lambda payload: _ParsedPayload(payload),
+        validate_market_stats_params=lambda payload: None,
+        normalize_request_id=lambda request_id: request_id,
+        get_job=lambda _job_id: {"job_type": "canonical_run", "status": "RUNNING"},
+        init_job=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not enqueue")),
+        canonical_job_defaults=lambda: (3, None),
+        external_job_status=lambda status: status,
+        canonical_job_type="canonical_run",
+        queued_status="QUEUED",
+    )
+
+    assert response.run_id == "run-42"
+    assert response.status == "RUNNING"
+    assert response.reused is True
+
+
+def test_validate_market_stats_params_reports_errors():
+    payload = {
+        "spec_type": "market_stats",
+        "stats": {
+            "event": {"id": "k_consecutive", "params": {"k": 0, "direction": "side"}},
+            "condition": {"id": "htf_trend", "params": {"tf_multiplier": "x", "ema_period": 0}},
+            "target": {"id": "continuation_n", "params": {"n": "", "direction": None}},
+        },
+    }
+
+    with pytest.raises(ApiValidationException) as exc:
+        run_requests.validate_market_stats_params(payload)
+
+    errors = exc.value.errors
+    fields = {error["field"] for error in errors}
+    assert "market_stats.stats.event.params.k" in fields
+    assert "market_stats.stats.event.params.direction" in fields
+    assert "market_stats.stats.condition.params.tf_multiplier" in fields
+    assert "market_stats.stats.condition.params.ema_period" in fields
+    assert "market_stats.stats.target.params.n" in fields
+    assert "market_stats.stats.target.params.direction" in fields


### PR DESCRIPTION
### Motivation

- Reduce `api/app.py` surface area so FastAPI handlers become thin orchestration only (validation, I/O mapping, delegation). 
- Centralize canonical run-request business rules (idempotent `request_id`, enqueue orchestration, `market_stats` validation) into a unit-testable service.
- Provide explicit, reviewable evidence of the refactor via focused service tests and an updated architecture checklist.

### Description

- Introduced `api/services/run_requests.py` implementing `enqueue_run_request(...)` and `validate_market_stats_params(...)` to host canonical enqueue orchestration and `market_stats` validation logic.
- Updated `api/app.py` to delegate the canonical enqueue flow to the service via a thin wrapper `enqueue_run_request(...)` and kept a compatibility wrapper `_validate_canonical_market_stats_params` to ease rollback/rerouting.
- Exported the new service in `api/services/__init__.py` so it is available as `api.services.run_requests`.
- Added unit tests `tests/api/test_run_requests_service.py` that exercise the service directly (idempotent reuse path, new-job path, and validation error reporting) to prove logic is decoupled from HTTP handlers.
- Documented the target "thin handlers" architecture, evidence and a reviewer checklist in `docs/architecture_market_intelligence_refactor.md`.

### Testing

- Ran service-level API tests with `poetry run pytest -q tests/api` and observed `19 passed`.
- Ran contract/validation HTTP tests with `poetry run pytest -q tests/test_api_http_contract.py tests/test_api_validation_error_format.py` and observed `5 passed`.
- Ran the full test-suite with `poetry run pytest -q` (or `-x`) and hit an unrelated existing failure at `tests/test_api_worker_queue.py::test_worker_marks_canonical_dca_not_implemented_for_invalid_trailing_tp_sl`, which caused the full run to stop; the targeted service and endpoint tests for this change passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9824fd8308323bb740fa9f1568073)